### PR TITLE
Changed order to stop/load lib/starting

### DIFF
--- a/cargo-pgx/src/commands/run.rs
+++ b/cargo-pgx/src/commands/run.rs
@@ -10,11 +10,13 @@ use pgx_utils::{createdb, get_pg_config, get_psql_path, BASE_POSTGRES_PORT_NO};
 pub(crate) fn run_psql(major_version: u16, dbname: &str, is_release: bool) {
     let pg_config = get_pg_config(major_version);
 
+    // stop postgres
+    stop_postgres(major_version);
+
     // install the extension
     install_extension(&pg_config, is_release, None);
 
     // restart postgres
-    stop_postgres(major_version);
     start_postgres(major_version);
 
     // create the named database


### PR DESCRIPTION
Before it was load lib/start/stop and it caused segfaults when combined
with bgworkers (or more correctly things which connected to shmem).

One side effect it that PG will be stopped while Rust builds, but I can't see the issue.

2020-08-05 07:12:05.864 UTC [25297] LOG:  received fast shutdown request
2020-08-05 07:12:05.866 UTC [25297] LOG:  aborting any active transactions
2020-08-05 07:12:08.140 UTC [25297] LOG:  background writer process (PID 25300) was terminated by signal 11: Segmentation fault
2020-08-05 07:12:08.140 UTC [25297] LOG:  terminating any other active server processes
2020-08-05 07:12:08.685 UTC [25297] LOG:  statistics collector process
(PID 25303) was terminated by signal 11: Segmentation fault
2020-08-05 07:12:08.686 UTC [25297] LOG:  abnormal database system shutdown