### PR TITLE
Fix to stop ctrl-c passing through cargo pgx run

### DIFF
--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 clap = { version = "2.33.1", features = [ "yaml" ] }
 colored = "2.0.0"
 env_proxy = "0.4.1"
-exec = "0.3.1"
 num_cpus = "1.13.0"
 pgx-utils = { path = "../pgx-utils", version = "^0.0.12"}
 proc-macro2 = { version = "1.0.19", features = [ "span-locations" ] }

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -24,3 +24,4 @@ regex = "1.3.9"
 rttp_client = { version = "0.1.0", features = ["tls-native"] }
 syn = { version = "1.0.36", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
+fork = "0.1.17"

--- a/cargo-pgx/src/commands/run.rs
+++ b/cargo-pgx/src/commands/run.rs
@@ -6,6 +6,8 @@ use crate::commands::start::start_postgres;
 use crate::commands::stop::stop_postgres;
 use colored::Colorize;
 use pgx_utils::{createdb, get_pg_config, get_psql_path, BASE_POSTGRES_PORT_NO};
+use std::process::Command;
+use std::os::unix::process::CommandExt;
 
 pub(crate) fn run_psql(major_version: u16, dbname: &str, is_release: bool) {
     let pg_config = get_pg_config(major_version);
@@ -39,7 +41,7 @@ pub(crate) fn run_psql(major_version: u16, dbname: &str, is_release: bool) {
 }
 
 fn exec_psql(major_version: u16, dbname: &str) {
-    let mut command = exec::Command::new(get_psql_path(major_version));
+    let mut command = Command::new(get_psql_path(major_version));
     command
         .arg("-h")
         .arg("localhost")

--- a/cargo-pgx/src/commands/start.rs
+++ b/cargo-pgx/src/commands/start.rs
@@ -32,9 +32,11 @@ pub(crate) fn start_postgres(major_version: u16) {
         port.to_string().bold().cyan()
     );
     let mut command = std::process::Command::new(format!("{}/pg_ctl", bindir.display()));
-    // This is unsafe to stop ctrl-c being passed through from psql when using cargo pgx run
-    // without the pre_exec call this would terminate PostgreSQL. This is a workaround until
-    // a better option can be found
+    // Unsafe block is for the pre_exec setsid call below
+    //
+    // This is to work around a bug in PG10 + PG11 which don't call setsid in pg_ctl
+    // This means that when cargo pgx run dumps a user into psql, pushing ctrl-c will abort
+    // the postgres server started by pgx
     unsafe {
         command
             .stdout(Stdio::piped())


### PR DESCRIPTION
Pre-fix this would start a Postgres shutdown - potentially a bug with
the way pg_ctl does daemonization of postgres?

This uses some unsafe code - so should be a workaround only.