### PR TITLE
Remove exec crate

### DIFF
--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 clap = { version = "2.33.1", features = [ "yaml" ] }
 colored = "2.0.0"
 env_proxy = "0.4.1"
-exec = "0.3.1"
 num_cpus = "1.13.0"
 pgx-utils = { path = "../pgx-utils", version = "^0.0.12"}
 proc-macro2 = { version = "1.0.19", features = [ "span-locations" ] }

--- a/cargo-pgx/src/commands/run.rs
+++ b/cargo-pgx/src/commands/run.rs
@@ -6,6 +6,8 @@ use crate::commands::start::start_postgres;
 use crate::commands::stop::stop_postgres;
 use colored::Colorize;
 use pgx_utils::{createdb, get_pg_config, get_psql_path, BASE_POSTGRES_PORT_NO};
+use std::process::Command;
+use std::os::unix::process::CommandExt;
 
 pub(crate) fn run_psql(major_version: u16, dbname: &str, is_release: bool) {
     let pg_config = get_pg_config(major_version);
@@ -39,7 +41,7 @@ pub(crate) fn run_psql(major_version: u16, dbname: &str, is_release: bool) {
 }
 
 fn exec_psql(major_version: u16, dbname: &str) {
-    let mut command = exec::Command::new(get_psql_path(major_version));
+    let mut command = Command::new(get_psql_path(major_version));
     command
         .arg("-h")
         .arg("localhost")


### PR DESCRIPTION
exec crate is deprecated (although the guy hasn't mentioned that in the
README, see https://github.com/faradayio/exec-rs/pull/4)

We can do this with stdlib for POSIX systems now (and Windows never
worked anyway)