### PR TITLE
security: only print friendly env vars

### DIFF
--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -47,9 +47,9 @@ impl bindgen::callbacks::ParseCallbacks for IgnoredMacros {
 }
 
 fn main() -> Result<(), std::io::Error> {
-    // dump parts of the environment
-    for (k, v) in std::env::vars() {
-        if k.starts_with("CARGO") {
+    // dump the environment for debugging if asked
+    if std::env::var("PGX_BUILD_VERBOSE").unwrap_or("false".to_string()) == "true" {
+        for (k, v) in std::env::vars() {
             eprintln!("{}={}", k, v);
         }
     }

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -47,9 +47,11 @@ impl bindgen::callbacks::ParseCallbacks for IgnoredMacros {
 }
 
 fn main() -> Result<(), std::io::Error> {
-    // dump our environment
+    // dump parts of the environment
     for (k, v) in std::env::vars() {
-        eprintln!("{}={}", k, v);
+        if k.starts_with("CARGO") {
+            eprintln!("{}={}", k, v);
+        }
     }
 
     let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());


### PR DESCRIPTION
People often store secrets in the environment, and likely would
prefer to avoid exposing them in CI logs and the like.

This PR is just meant as a proposal. I opened a PR rather than an
issue because the diff is so tiny, and I would have included it in the
issue description anyway. I could see the pgx project taking the stance
that people should implement some sort of secret santization for any
logs, so this is solving the issue in the wrong place. Personally, I think
a little defense in depth is worthwhile.