### PR TITLE
Use 'cargo metadata' to determine the target directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
+ "serde_json",
  "syn",
  "toml",
  "unescape",

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -18,6 +18,7 @@ quote = "1.0.8"
 regex = "1.4.3"
 serde = "1.0.120"
 serde_derive = "1.0.120"
+serde_json = "1.0"
 syn = { version = "1.0.58", features = [ "extra-traits", "full", "fold", "parsing" ] }
 toml = "0.5.8"
 unescape = "0.1.0"


### PR DESCRIPTION
This allows 'cargo pgx' to work within workspaces, and ensures that pgx uses the same target directory as the rest of cargo. It will still obey env overrides such as `CARGO_TARGET_DIR` and _should_ obey `build.target-dir` from `cargo.config`, though I have not tested that. Since `cargo pgx` does not have the `--target-dir` option, this doesn't try to forward on to cargo metadata.