### PR TITLE
included access/gin/h & access/gist.h

### DIFF
--- a/pgx-pg-sys/include/pg10.h
+++ b/pgx-pg-sys/include/pg10.h
@@ -9,6 +9,8 @@
 
 #include "access/amapi.h"
 #include "access/genam.h"
+#include "access/gin.h"
+#include "access/gist.h"
 #include "access/heapam.h"
 #include "access/htup.h"
 #include "access/htup_details.h"

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -6,6 +6,8 @@
 
 #include "access/amapi.h"
 #include "access/genam.h"
+#include "access/gin.h"
+#include "access/gist.h"
 #include "access/heapam.h"
 #include "access/htup.h"
 #include "access/htup_details.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -6,6 +6,8 @@
 
 #include "access/amapi.h"
 #include "access/genam.h"
+#include "access/gin.h"
+#include "access/gist.h"
 #include "access/heapam.h"
 #include "access/htup.h"
 #include "access/htup_details.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -6,6 +6,8 @@
 
 #include "access/amapi.h"
 #include "access/genam.h"
+#include "access/gin.h"
+#include "access/gist.h"
 #include "access/heapam.h"
 #include "access/htup.h"
 #include "access/htup_details.h"


### PR DESCRIPTION
This PR includes definitions of [gin.h](https://github.com/postgres/postgres/blob/master/src/include/access/gin.h) and [gist.h](https://github.com/postgres/postgres/blob/master/src/include/access/gist.h), both of which have necessary definitions to start work over supporting custom GiST and GIN indexes.

I've regenerated rust defs from these and they seemed to work, but I didn't include the regenerated files, as I've noticed that they were changing the paths to in source code to relative to my local machine.

Are there any other steps necessary to make this PR complete?