### PR TITLE
Allow overriding function names and returning schema-qualified type

### DIFF
--- a/cargo-pgx/src/commands/schema.rs
+++ b/cargo-pgx/src/commands/schema.rs
@@ -390,7 +390,7 @@ fn walk_items(
                     type_name
                 ));
                 operator_sql.push(format!(
-                    "CREATE OPERATOR CLASS {type_name}_hash_ops DEFAULT FOR TYPE {type_name} USING hash FAMILY {type_name}_hash_ops AS 
+                    "CREATE OPERATOR CLASS {type_name}_hash_ops DEFAULT FOR TYPE {type_name} USING hash FAMILY {type_name}_hash_ops AS
                         OPERATOR    1   =  ({type_name}, {type_name}),
                         FUNCTION    1   {type_name}_hash({type_name});",
                     type_name = type_name
@@ -406,7 +406,7 @@ fn walk_items(
                     type_name
                 ));
                 operator_sql.push(format!(
-                    "CREATE OPERATOR CLASS {type_name}_btree_ops DEFAULT FOR TYPE {type_name} USING btree FAMILY {type_name}_btree_ops AS 
+                    "CREATE OPERATOR CLASS {type_name}_btree_ops DEFAULT FOR TYPE {type_name} USING btree FAMILY {type_name}_btree_ops AS
                       OPERATOR 1 < ,
                       OPERATOR 2 <= ,
                       OPERATOR 3 = ,
@@ -653,17 +653,14 @@ fn make_create_function_statement(
     funcargs: &Vec<FunctionArgs>,
 ) -> (Option<String>, Option<String>, Option<Vec<String>>) {
     let exported_func_name = format!("{}_wrapper", func.sig.ident.to_string());
-    let mut statement = String::new();
+
     let has_option_arg = func_args_have_option(func, rs_file);
     let attributes = collect_attributes(rs_file, &func.sig.ident, &func.attrs);
-    let sql_func_name =
+    let mut sql_func_name =
         extract_funcname_attribute(&attributes).unwrap_or_else(|| quote_ident(&func.sig.ident));
     let mut sql_argument_type_names = Vec::new();
 
-    statement.push_str(&format!(
-        "CREATE OR REPLACE FUNCTION {}",
-        qualify_name(schema, &sql_func_name)
-    ));
+    let mut statement = String::new();
 
     if let Some(sql_func_arg) = sql_func_arg {
         statement.push_str(sql_func_arg.as_str());
@@ -752,6 +749,7 @@ fn make_create_function_statement(
         ),
     }
 
+    let mut custom_schema = None;
     // modifiers
     if let Some(extern_args) = extern_args {
         for extern_arg in extern_args {
@@ -766,9 +764,19 @@ fn make_create_function_statement(
                 ExternArgs::ParallelRestricted => statement.push_str(" PARALLEL RESTRICTED"),
                 ExternArgs::Error(_) => { /* noop */ }
                 ExternArgs::NoGuard => {}
+                ExternArgs::Schema(s) => custom_schema = Some(s),
+                ExternArgs::Name(n) => sql_func_name = n,
             }
         }
     }
+
+    statement = format!(
+        "CREATE OR REPLACE FUNCTION {}{}",
+        qualify_name(
+            custom_schema.as_ref().map(|s| &**s).unwrap_or(schema),
+            &sql_func_name
+        ),
+    statement);
 
     let mut search_path = String::new();
     for arg in funcargs {

--- a/cargo-pgx/src/commands/schema.rs
+++ b/cargo-pgx/src/commands/schema.rs
@@ -1212,7 +1212,14 @@ fn translate_type_string(
                 Some(idx) => unknown[0..idx].trim(),
                 None => unknown,
             };
-            Some((unknown.trim().to_string(), false, default_value, variadic))
+            let parts: Vec<_> = unknown.split("::").collect();
+            if parts.len() == 1 {
+                return Some((unknown.trim().to_string(), false, default_value, variadic))
+            }
+
+            let (schema, name) = (parts[parts.len()-2], parts[parts.len()-1]);
+            let qualified_name = format!("{}.{}", schema.trim(), name.trim());
+            return Some((qualified_name.to_string(), false, default_value, variadic))
         }
     }
 }

--- a/pgx-tests/sql/load-order.txt
+++ b/pgx-tests/sql/load-order.txt
@@ -23,3 +23,4 @@ tests_pg_try_tests.generated.sql
 tests_xact_callback_tests.generated.sql
 tests_xid64_tests.generated.sql
 tests_postgres_type_tests.generated.sql
+tests_name_tests.generated.sql

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod inet_tests;
 mod json_tests;
 mod log_tests;
 mod memcxt_tests;
+mod name_tests;
 mod numeric_tests;
 mod pg_extern_args_tests;
 mod pg_try_tests;

--- a/pgx-tests/src/tests/name_tests.rs
+++ b/pgx-tests/src/tests/name_tests.rs
@@ -1,0 +1,17 @@
+use pgx::*;
+
+#[pg_extern(name="renamed_func")]
+fn func_to_rename() {}
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+
+    use pgx::*;
+
+    #[pg_test]
+    fn renamed_func() {
+        Spi::run("SELECT renamed_func();");
+    }
+}

--- a/pgx-tests/src/tests/schema_tests.rs
+++ b/pgx-tests/src/tests/schema_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
 // governed by the MIT license that can be found in the LICENSE file.
+use pgx::*;
 
 
 mod test_schema {
@@ -8,6 +9,9 @@ mod test_schema {
     #[pg_extern]
     fn func_in_diff_schema() {}
 }
+
+#[pg_extern(schema="test_schema")]
+fn func_in_diff_schema2() {}
 
 #[cfg(any(test, feature = "pg_test"))]
 mod tests {
@@ -19,5 +23,10 @@ mod tests {
     #[pg_test]
     fn test_in_different_schema() {
         Spi::run("SELECT test_schema.func_in_diff_schema();");
+    }
+
+    #[pg_test]
+    fn test_in_different_schema2() {
+        Spi::run("SELECT test_schema.func_in_diff_schema2();");
     }
 }

--- a/pgx-tests/src/tests/schema_tests.rs
+++ b/pgx-tests/src/tests/schema_tests.rs
@@ -5,13 +5,22 @@ use pgx::*;
 
 mod test_schema {
     use pgx::*;
+    use serde::{Deserialize, Serialize};
 
     #[pg_extern]
     fn func_in_diff_schema() {}
+
+    #[derive(Debug, PostgresType, Serialize, Deserialize)]
+    pub struct TestType(pub u64);
 }
 
 #[pg_extern(schema="test_schema")]
 fn func_in_diff_schema2() {}
+
+#[pg_extern]
+fn type_in_diff_schema() -> test_schema::TestType {
+    test_schema::TestType(1)
+}
 
 #[cfg(any(test, feature = "pg_test"))]
 mod tests {
@@ -28,5 +37,10 @@ mod tests {
     #[pg_test]
     fn test_in_different_schema2() {
         Spi::run("SELECT test_schema.func_in_diff_schema2();");
+    }
+
+    #[pg_test]
+    fn test_type_in_different_schema() {
+        Spi::run("SELECT type_in_diff_schema();");
     }
 }

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -194,6 +194,8 @@ pub enum ExternArgs {
     ParallelUnsafe,
     ParallelRestricted,
     Error(String),
+    Schema(String),
+    Name(String),
 }
 
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
@@ -240,6 +242,26 @@ pub fn parse_extern_attributes(attr: TokenStream) -> HashSet<ExternArgs> {
                         // trim leading/trailing quotes around the literal
                         let message = message[1..message.len() - 1].to_string();
                         args.insert(ExternArgs::Error(message.to_string()))
+                    }
+                    "schema" => {
+                        let _punc = itr.next().unwrap();
+                        let literal = itr.next().unwrap();
+                        let schema = literal.to_string();
+                        let schema = unescape::unescape(&schema).expect("failed to unescape");
+
+                        // trim leading/trailing quotes around the literal
+                        let schema = schema[1..schema.len() - 1].to_string();
+                        args.insert(ExternArgs::Schema(schema.to_string()))
+                    }
+                    "name" => {
+                        let _punc = itr.next().unwrap();
+                        let literal = itr.next().unwrap();
+                        let name = literal.to_string();
+                        let name = unescape::unescape(&name).expect("failed to unescape");
+
+                        // trim leading/trailing quotes around the literal
+                        let name = name[1..name.len() - 1].to_string();
+                        args.insert(ExternArgs::Name(name.to_string()))
                     }
                     _ => false,
                 };


### PR DESCRIPTION
This PR contains two commits.

The first one adds the ability to override the SQL name of a function defined using `pg_extern`. Though Postgres allows multiple functions to have the same name, we currently cannot define such function families using pgx because the externally-generated symbol created for the rust function must be globally unique. This commit adds a field to the `#[pg_extern]` macro, `#[pg_extern(name = "foo")]` allowing users to define a different SQL name for a function than the rust name. This enables the creation of multiple functions that have the same SQL name, and different rust names, e.g. if you have pgx functions like

```rust
#[pg_extern(name = "plus2")]
pub fn plus2_int(i: i32) -> i32 { i + 2 }

#[pg_extern(name = "plus2")]
pub fn plus2_bigint(i: i64) -> i32 { i + 2 }
```

both of them will be callable like

```SQL
SELECT plus2(foo)
```

For symmetry, the commit adds a similar override for schema, so `#[pg_extern(schema="foo", name="bar")]` will create a function `foo.bar()`.

The second commit allows functions to return schema-qualified SQL types by using module-qualified rust types. e.g. the function like
```rust
#[pg_extern]
pub fn foo() -> myschema::mytype;
```
will generate SQL like
```SQL
CREATE OR REPLACE FUNCTION foo() RETURNS myschema.mytype ...
```

(the PR contains both commits because the second one depends on the first, I remove the second one and open a new PR later if needed)
