### PR TITLE
feat: `cargo-pgx init` does initdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ Next, `pgx` needs to be initialized.  You only need to do this once.
 $ cargo pgx init
 ```
 
-The `init` command downloads Postgres versions v10, v11, v12, v13 and compiles them to `~/.pgx/`.  These installations
-are needed by `pgx` not only for auto-generating Rust bindings from each version's header files, but also for `pgx`'s
-test framework.
+The `init` command downloads Postgres versions v10, v11, v12, v13, compiles them to `~/.pgx/`, and runs `initdb`.
+These installations are needed by `pgx` not only for auto-generating Rust bindings from each version's header files,
+but also for `pgx`'s test framework.
 
 See the documentation for [`cargo-pgx`](cargo-pgx/README.md) for details on how to limit the required postgres versions.
 

--- a/cargo-pgx/src/commands/start.rs
+++ b/cargo-pgx/src/commands/start.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
 // governed by the MIT license that can be found in the LICENSE file.
 
+use crate::commands::init::initdb;
 use crate::commands::status::status_postgres;
 use colored::Colorize;
 use pgx_utils::exit_with_error;
@@ -62,33 +63,6 @@ pub(crate) fn start_postgres(pg_config: &PgConfig) -> Result<(), std::io::Error>
     if !output.status.success() {
         exit_with_error!(
             "problem running pg_ctl: {}\n\n{}",
-            command_str,
-            String::from_utf8(output.stderr).unwrap()
-        )
-    }
-
-    Ok(())
-}
-
-fn initdb(bindir: &PathBuf, datadir: &PathBuf) -> Result<(), std::io::Error> {
-    println!(
-        " {} data directory at {}",
-        "Initializing".bold().green(),
-        datadir.display()
-    );
-    let mut command = std::process::Command::new(format!("{}/initdb", bindir.display()));
-    command
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .arg("-D")
-        .arg(&datadir);
-
-    let command_str = format!("{:?}", command);
-    let output = command.output()?;
-
-    if !output.status.success() {
-        exit_with_error!(
-            "problem running initdb: {}\n{}",
             command_str,
             String::from_utf8(output.stderr).unwrap()
         )


### PR DESCRIPTION
While working on extensions which include GUC options, particularly mandatory ones (such as those in `plrust`), users will want to edit the contents of their `.pgx/data-$VERSION` after an `initdb` has been run.

This PR teaches `cargo-pgx pgx init` to initialize the database, and safely ensures `cargo-pgx pgx run` still does so.

* Migrate `cargo-pgx::commands::run::initdb` to `cargo-pgx::commands::init::initdb`.
* Call `cargo-pgx::commands::init::iinitdb` in `cargo-pgx pgx init`.
* Include backwards compatibility safety, still call `initdb` in `cargo-pgx pgx run`