### PR TITLE
feat: add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Cargo.lock
 *.so
 *.a
 cmake*/
+.direnv

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -1,0 +1,47 @@
+{ lib, rustPlatform, fetchFromGitHub, postgresql_10, postgresql_11, postgresql_12, postgresql_13, pkg-config, openssl, rustfmt, llvmPackages, }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-pgx";
+  version = "0.1.20";
+
+  src = ../.;
+
+  cargoSha256 = "1HA7RFw+WKWERf4W7uHhmdnEne2XDib9ijnqf3lxKcQ=";
+  cargoBuildFlags = [ "--package" "cargo-pgx" ];
+  cargoCheckFlags = [ "--package" "cargo-pgx" ];
+  cargoTestFlags = [ "--package" "cargo-pgx" ];
+
+  /*
+    TODO: pgx currently has to modify the postgres directory during development,
+    so we can't get tricky and use the existing PostgreSQL packages.
+
+    PGX_HOME = "./pgx";
+    postBuild = ''
+    cargo run --package cargo-pgx --bin cargo-pgx -- pgx init \
+    --pg10 ${postgresql_10}/bin/pg_config \
+    --pg11 ${postgresql_11}/bin/pg_config \
+    --pg12 ${postgresql_12}/bin/pg_config \
+    --pg13 ${postgresql_13}/bin/pg_config
+    '';
+    preFixup = ''
+    mv $(pwd)/pgx $out/pgx
+    ${makeWrapper} $out/bin/cargo-pgx $out/bin/cargo-pgx-wrapped --set PGX_HOME $out/pgx
+    '';
+  */
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    openssl
+  ];
+
+  LIBCLANG_PATH="${llvmPackages.libclang}/lib";
+
+  meta = with lib; {
+    description = "Build PostgreSQL extensions with Rust.";
+    homepage = "https://github.com/zombodb/pgx";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ hoverbear ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1619045745,
+        "narHash": "sha256-wekCSTvL5YCCpMdbsEq8lkoTYjriKPLNtSnL7MyZryA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eef51210071dcf7f605aef8c246f7c2fee6216c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  description = "Postgres extensions in Rust.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in
+    {
+      defaultPackage = forAllSystems (system: (import nixpkgs {
+        inherit system;
+        overlays = [ self.overlay ];
+      }).cargo-pgx);
+
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlay ];
+          };
+        in
+        {
+          inherit (pkgs) cargo-pgx;
+        });
+
+      overlay = final: prev: {
+        cargo-pgx = final.callPackage ./cargo-pgx { };
+      };
+
+      devShell = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlay ];
+          };
+        in
+        pkgs.mkShell {
+          inputsFrom = with pkgs; [
+            postgresql_10
+            postgresql_11
+            postgresql_12
+            postgresql_13
+          ];
+          buildInputs = with pkgs; [
+            rustfmt
+            nixpkgs-fmt
+            cargo-pgx
+          ];
+          LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
+        });
+
+      checks = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlay ];
+          };
+        in
+        {
+          format = pkgs.runCommand "check-format"
+            {
+              buildInputs = with pkgs; [ rustfmt cargo ];
+            } ''
+            ${pkgs.rustfmt}/bin/cargo-fmt fmt --manifest-path ${./.}/Cargo.toml -- --check
+            ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check ${./.}
+            touch $out # it worked!
+          '';
+        });
+    };
+}


### PR DESCRIPTION
Introduce a Nix flake, a [recently introduced concept](https://www.tweag.io/blog/2020-05-25-flakes/) in the Nix community.

This will allow our users and developers to optionally use Nix to work with `pgx`. This commit is a minimal step, and does not include documentation or usage guidelines, as it is not officially supported for users yet.

> Flakes are experimental and require [manual effort](https://nixos.wiki/wiki/Flakes#Installing_flakes) to enable after installing Nix.

* Introduce a `cargo-pgx` derivation for Nix users.

  Users can run `cargo-pgx` ad-hoc:

  ```bash
  nix run .#cargo-pgx -- pgx init
  ```

  Or they can develop `cargo-pgx` itself:

  ```bash
  nix develop .#cargo-pgx
  ```
* Add a flake file that imports the `cargo-pgx` derivation.
* Set `cargo-pgx` as the default run/build target:

  ```bash
  nix run .
  nix build .
  ```
* Define a development shell for building `pgx` based extensions.

  ```bash
  nix develop .
  ```

* Define checks for formatting (using `rustfmt` and `nixpkgs-fmt`):

  ```bash
  nix flake check
  ```

* Adds a `.envrc` compatible with
   [`nix-direnv`](https://github.com/nix-community/nix-direnv).

