### PR TITLE
chore: fix pgx-test load-order

### DIFF
--- a/pgx-tests/sql/load-order.txt
+++ b/pgx-tests/sql/load-order.txt
@@ -25,5 +25,3 @@ tests_pg_try_tests.generated.sql
 tests_spi_tests.generated.sql
 tests_xact_callback_tests.generated.sql
 tests_xid64_tests.generated.sql
-tests_postgres_type_tests.generated.sql
-tests_name_tests.generated.sql


### PR DESCRIPTION
Fix failing tests occurring due to a bad merge.