### PR TITLE
chore: resolve pre-Rust 2021 warnings

### DIFF
--- a/pgx-macros/src/rewriter.rs
+++ b/pgx-macros/src/rewriter.rs
@@ -528,7 +528,7 @@ impl PgGuardRewriter {
                 } else {
                     pg_sys::PG_exception_stack = prev_exception_stack;
                     pg_sys::error_context_stack = prev_error_context_stack;
-                    panic!(pg_sys::JumpContext { });
+                    std::panic::panic_any(pg_sys::JumpContext { });
                 };
 
                 pg_sys::PG_exception_stack = prev_exception_stack;

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -72,7 +72,7 @@ pub fn run_test(
             result
         }
 
-        Err(e) => panic!(e),
+        Err(e) => panic!("{}", e),
     };
 
     if let Err(e) = result {
@@ -125,10 +125,10 @@ pub fn run_test(
                     );
                 }
             } else {
-                panic!(e)
+                panic!("{}", e)
             }
         } else {
-            panic!(format!("{}", error_as_string.bold().red()))
+            panic!("{}", error_as_string.bold().red())
         }
     } else if let Some(expected_error_message) = expected_error {
         // we expected an ERROR, but didn't get one
@@ -401,7 +401,7 @@ fn monitor_pg(mut command: Command, cmd_string: String, loglines: LogLines) -> (
                     let session_lines = loglines.entry(session_id).or_insert_with(Vec::new);
                     session_lines.push(line);
                 }
-                Err(e) => panic!(e),
+                Err(e) => panic!("{}", e),
             }
         }
 
@@ -412,7 +412,7 @@ fn monitor_pg(mut command: Command, cmd_string: String, loglines: LogLines) -> (
                     // we exited normally
                 }
             }
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     });
 

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -255,7 +255,7 @@ impl Spi {
             }
 
             // closure returned an error
-            Err(e) => panic!(e),
+            Err(e) => panic!("{:?}", e),
         }
     }
 
@@ -269,7 +269,7 @@ impl Spi {
         } else {
             let status_enum = SpiError::from_i32(-status_code);
             match status_enum {
-                Some(e) => panic!(e),
+                Some(e) => panic!("{:?}", e),
                 None => panic!("unrecognized SPI status code {}", status_code),
             }
         }


### PR DESCRIPTION
Resolve 6,756 warnings related to using `panic!()` on things other than literals.

Some of the errors raised here are not `impl Display`, it may be that we wish to do that.