### PR TITLE
feat: add aarch64 support

### DIFF
--- a/pgx/src/bgworkers.rs
+++ b/pgx/src/bgworkers.rs
@@ -8,6 +8,7 @@ use crate::pg_sys;
 use std::convert::TryInto;
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::os::raw::c_char;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -66,7 +67,7 @@ impl BackgroundWorker {
         const LEN: usize = 96;
 
         unsafe {
-            CStr::from_ptr(std::mem::transmute::<&[i8; LEN], *const i8>(
+            CStr::from_ptr(std::mem::transmute::<&[c_char; LEN], *const c_char>(
                 &(*pg_sys::MyBgworkerEntry).bgw_name,
             ))
         }
@@ -79,7 +80,7 @@ impl BackgroundWorker {
         const LEN: usize = 128;
 
         unsafe {
-            CStr::from_ptr(std::mem::transmute::<&[i8; LEN], *const i8>(
+            CStr::from_ptr(std::mem::transmute::<&[c_char; LEN], *const c_char>(
                 &(*pg_sys::MyBgworkerEntry).bgw_extra,
             ))
         }
@@ -122,10 +123,10 @@ impl BackgroundWorker {
     /// connect to via SPI
     pub fn connect_worker_to_spi(dbname: Option<&str>, username: Option<&str>) {
         let db = dbname.and_then(|rs| CString::new(rs).ok());
-        let db: *const i8 = db.as_ref().map_or(std::ptr::null(), |i| i.as_ptr());
+        let db: *const c_char = db.as_ref().map_or(std::ptr::null(), |i| i.as_ptr());
 
         let user = username.and_then(|rs| CString::new(rs).ok());
-        let user: *const i8 = user.as_ref().map_or(std::ptr::null(), |i| i.as_ptr());
+        let user: *const c_char = user.as_ref().map_or(std::ptr::null(), |i| i.as_ptr());
 
         unsafe {
             #[cfg(feature = "pg10")]
@@ -452,25 +453,25 @@ impl<'a> From<&'a str> for RpgffiChar64 {
     }
 }
 
-struct RpgffiChar96([i8; 96]);
+struct RpgffiChar96([c_char; 96]);
 
 impl<'a> From<&'a str> for RpgffiChar96 {
     fn from(string: &str) -> Self {
         let mut r = [0; 96];
         for (dest, src) in r.iter_mut().zip(string.as_bytes()) {
-            *dest = *src as i8;
+            *dest = *src as c_char;
         }
         RpgffiChar96(r)
     }
 }
 
-struct RpgffiChar128([i8; 128]);
+struct RpgffiChar128([c_char; 128]);
 
 impl<'a> From<&'a str> for RpgffiChar128 {
     fn from(string: &str) -> Self {
         let mut r = [0; 128];
         for (dest, src) in r.iter_mut().zip(string.as_bytes()) {
-            *dest = *src as i8;
+            *dest = *src as c_char;
         }
         RpgffiChar128(r)
     }

--- a/pgx/src/enum_helper.rs
+++ b/pgx/src/enum_helper.rs
@@ -30,7 +30,7 @@ pub fn lookup_enum_by_oid(enumval: pg_sys::Oid) -> (String, pg_sys::Oid, f32) {
     let en = unsafe { pgx_GETSTRUCT(tup) } as pg_sys::Form_pg_enum;
     let en = unsafe { en.as_ref() }.unwrap();
     let result = (
-        unsafe { std::ffi::CStr::from_ptr(en.enumlabel.data.as_ptr() as *const i8) }
+        unsafe { std::ffi::CStr::from_ptr(en.enumlabel.data.as_ptr() as *const std::os::raw::c_char) }
             .to_str()
             .unwrap()
             .to_string(),

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -7,6 +7,7 @@ use crate::{
     PgTupleDesc,
 };
 use std::ops::Deref;
+use std::os::raw::c_char;
 
 pub struct PgRelation {
     boxed: PgBox<pg_sys::RelationData>,
@@ -231,55 +232,55 @@ impl PgRelation {
     pub fn is_table(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_RELATION as i8
+        rd_rel.relkind == pg_sys::RELKIND_RELATION as c_char
     }
 
     pub fn is_matview(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_MATVIEW as i8
+        rd_rel.relkind == pg_sys::RELKIND_MATVIEW as c_char
     }
 
     pub fn is_index(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_INDEX as i8
+        rd_rel.relkind == pg_sys::RELKIND_INDEX as c_char
     }
 
     pub fn is_view(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_VIEW as i8
+        rd_rel.relkind == pg_sys::RELKIND_VIEW as c_char
     }
 
     pub fn is_sequence(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_SEQUENCE as i8
+        rd_rel.relkind == pg_sys::RELKIND_SEQUENCE as c_char
     }
 
     pub fn is_composite_type(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_COMPOSITE_TYPE as i8
+        rd_rel.relkind == pg_sys::RELKIND_COMPOSITE_TYPE as c_char
     }
 
     pub fn is_foreign_table(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_FOREIGN_TABLE as i8
+        rd_rel.relkind == pg_sys::RELKIND_FOREIGN_TABLE as c_char
     }
 
     pub fn is_partitioned_table(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_PARTITIONED_TABLE as i8
+        rd_rel.relkind == pg_sys::RELKIND_PARTITIONED_TABLE as c_char
     }
 
     pub fn is_toast_value(&self) -> bool {
         let rd_rel: &pg_sys::FormData_pg_class =
             unsafe { self.boxed.rd_rel.as_ref().expect("rd_rel is NULL") };
-        rd_rel.relkind == pg_sys::RELKIND_TOASTVALUE as i8
+        rd_rel.relkind == pg_sys::RELKIND_TOASTVALUE as c_char
     }
 
     /// ensures that the returned `PgRelation` is closed by Rust when it is dropped


### PR DESCRIPTION
Adds aarch64 support to PGX by using [`std::os::raw::c_char`](https://doc.rust-lang.org/std/os/raw/type.c_char.html) instead of `i8` or `u8`s. 

In theory, this may add support for other architectures as well.