### PR TITLE
Release v0.1.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cargo-pgx"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "clap",
  "colored",
@@ -988,7 +988,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pgx"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-parent"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cargo-pgx",
  "pgx",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "colored",
  "lazy_static",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "colored",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,15 +624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "heapless"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,7 +631,7 @@ checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
 dependencies = [
  "as-slice",
  "generic-array 0.14.4",
- "hash32 0.1.1",
+ "hash32",
  "stable_deref_trait",
 ]
 
@@ -972,7 +963,7 @@ dependencies = [
  "atomic-traits",
  "bitflags",
  "enum-primitive-derive",
- "hash32 0.2.1",
+ "hash32",
  "heapless",
  "num-traits",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -23,18 +23,6 @@ checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "as-slice"
@@ -50,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -106,9 +94,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
+checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -132,17 +120,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "block-buffer"
@@ -228,9 +205,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
+checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
 dependencies = [
  "glob",
  "libc",
@@ -266,15 +243,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "402da840495de3f976eaefc3485b7f5eb5b0bf9761f9a47be27fe975b3b8c2ec"
 
 [[package]]
 name = "core-foundation"
@@ -309,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -330,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -343,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -373,18 +344,18 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
@@ -491,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -506,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -516,15 +487,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -533,15 +504,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -551,21 +522,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -653,6 +624,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "heapless"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +640,7 @@ checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
 dependencies = [
  "as-slice",
  "generic-array 0.14.4",
- "hash32",
+ "hash32 0.1.1",
  "stable_deref_trait",
 ]
 
@@ -697,9 +677,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -735,9 +715,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.89"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libloading"
@@ -751,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -786,15 +766,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg",
 ]
@@ -827,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
@@ -840,11 +820,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2 0.3.19",
  "winapi 0.3.9",
 ]
 
@@ -918,9 +897,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.33"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -938,9 +917,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.61"
+version = "0.9.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+checksum = "fa52160d45fa2e7608d504b7c3a3355afed615e6d8b627a74458634ba21b69bd"
 dependencies = [
  "autocfg",
  "cc",
@@ -969,7 +948,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -993,7 +972,7 @@ dependencies = [
  "atomic-traits",
  "bitflags",
  "enum-primitive-derive",
- "hash32",
+ "hash32 0.2.1",
  "heapless",
  "num-traits",
  "once_cell",
@@ -1309,35 +1288,28 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "85dd92e586f7355c633911e11f77f3d12f04b1b1bd76a198bd34ae3af8341ef2"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
+ "getrandom 0.2.2",
+ "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "1efb2352a0f4d4b128f734b5c44c79ff80117351138733f12f982fe3e2b13343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1346,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "00efb87459ba4f6fb2169d20f68565555688e1250ee6825cdf6254f8b48fafb2"
 
 [[package]]
 name = "remove_dir_all"
@@ -1375,18 +1347,6 @@ dependencies = [
  "rand 0.7.3",
  "socks",
  "url",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1434,9 +1394,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1447,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1544,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "shutdown_hooks"
@@ -1556,32 +1516,21 @@ checksum = "6057adedbec913419c92996f395ba69931acbd50b7d56955394cd3f7bedbfa45"
 
 [[package]]
 name = "siphasher"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+checksum = "cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
-name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "socket2"
@@ -1613,9 +1562,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standback"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2beb4d1860a61f571530b3f855a1b538d0200f7871c63331ecd6f17b1f014f8"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check",
 ]
@@ -1693,9 +1642,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9505f307c872bab8eb46f77ae357c8eba1fdacead58ee5a850116b1d7f82883"
+checksum = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1711,7 +1660,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.5",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -1794,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1809,9 +1758,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1839,16 +1788,16 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2 0.4.0",
+ "socket2",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1890,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -1914,9 +1863,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
@@ -1941,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec_map"
@@ -1971,9 +1920,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1981,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1996,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2006,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2019,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-parent"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -23,8 +23,8 @@ pgx-utils = { path = "../pgx-utils", version = "0.1.21"}
 proc-macro2 = { version = "1.0.26", features = [ "span-locations" ] }
 quote = "1.0.9"
 rayon = "1.5.0"
-regex = "1.4.5"
+regex = "1.5.2"
 rttp_client = { version = "0.1.0", features = ["tls-native"] }
-syn = { version = "1.0.69", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.71", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 fork = "0.1.18"

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -19,7 +19,7 @@ clap = { version = "2.33.3", features = [ "yaml" ] }
 colored = "2.0.0"
 env_proxy = "0.4.1"
 num_cpus = "1.13.0"
-pgx-utils = { path = "../pgx-utils", version = "0.1.20"}
+pgx-utils = { path = "../pgx-utils", version = "0.1.21"}
 proc-macro2 = { version = "1.0.26", features = [ "span-locations" ] }
 quote = "1.0.9"
 rayon = "1.5.0"

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -2,12 +2,12 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-pgx";
-  version = "0.1.20";
+  version = "0.1.21";
 
   src = ../.;
 
   #cargoSha256 = lib.fakeSha256;
-  cargoSha256 = "l/IJ8IjXPoPVnIJojA4i9wLtSqfWHT5OqpdvyK11OAg=";
+  cargoSha256 = "hKpqdvPEyBnfcjA98wQWgJyEZEf3eaaEi99nB/e7+ck=";
   cargoBuildFlags = [ "--package" "cargo-pgx" ];
   cargoCheckFlags = [ "--package" "cargo-pgx" ];
   cargoTestFlags = [ "--package" "cargo-pgx" ];
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  LIBCLANG_PATH="${llvmPackages.libclang}/lib";
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   meta = with lib; {
     description = "Build PostgreSQL extensions with Rust.";

--- a/cargo-pgx/src/commands/connect.rs
+++ b/cargo-pgx/src/commands/connect.rs
@@ -15,7 +15,7 @@ pub(crate) fn connect_psql(pg_config: &PgConfig, dbname: &str) -> Result<(), std
     if !createdb(pg_config, dbname, false, true)? {
         println!(
             "{} existing database {}",
-            "    Re-using".bold().cyan(),
+            "     Re-using".bold().cyan(),
             dbname
         );
     }

--- a/cargo-pgx/src/commands/init.rs
+++ b/cargo-pgx/src/commands/init.rs
@@ -86,7 +86,7 @@ pub(crate) fn init_pgx(pgx: &Pgx) -> std::result::Result<(), std::io::Error> {
 fn download_postgres(pg_config: &PgConfig, pgxdir: &PathBuf) -> Result<PgConfig, std::io::Error> {
     println!(
         "{} Postgres v{}.{} from {}",
-        " Downloading".bold().green(),
+        "  Downloading".bold().green(),
         pg_config.major_version()?,
         pg_config.minor_version()?,
         pg_config.url().expect("no url"),
@@ -127,14 +127,14 @@ fn untar(bytes: &[u8], pgxdir: &PathBuf, pg_config: &PgConfig) -> Result<PathBuf
     ));
     if pgdir.exists() {
         // delete everything at this path if it already exists
-        println!("{} {}", "    Removing".bold().green(), pgdir.display());
+        println!("{} {}", "     Removing".bold().green(), pgdir.display());
         std::fs::remove_dir_all(&pgdir)?;
     }
     std::fs::create_dir_all(&pgdir)?;
 
     println!(
         "{} Postgres v{}.{} to {}",
-        "   Untarring".bold().green(),
+        "    Untarring".bold().green(),
         pg_config.major_version()?,
         pg_config.minor_version()?,
         pgdir.display()
@@ -168,7 +168,7 @@ fn untar(bytes: &[u8], pgxdir: &PathBuf, pg_config: &PgConfig) -> Result<PathBuf
 fn configure_postgres(pg_config: &PgConfig, pgdir: &PathBuf) -> Result<(), std::io::Error> {
     println!(
         "{} Postgres v{}.{}",
-        " Configuring".bold().green(),
+        "  Configuring".bold().green(),
         pg_config.major_version()?,
         pg_config.minor_version()?
     );
@@ -213,7 +213,7 @@ fn make_postgres(pg_config: &PgConfig, pgdir: &PathBuf) -> Result<(), std::io::E
     let num_cpus = 1.max(num_cpus::get() / 3);
     println!(
         "{} Postgres v{}.{}",
-        "   Compiling".bold().green(),
+        "    Compiling".bold().green(),
         pg_config.major_version()?,
         pg_config.minor_version()?
     );
@@ -253,7 +253,7 @@ fn make_postgres(pg_config: &PgConfig, pgdir: &PathBuf) -> Result<(), std::io::E
 fn make_install_postgres(version: &PgConfig, pgdir: &PathBuf) -> Result<PgConfig, std::io::Error> {
     println!(
         "{} Postgres v{}.{} to {}",
-        "  Installing".bold().green(),
+        "   Installing".bold().green(),
         version.major_version()?,
         version.minor_version()?,
         get_pg_installdir(pgdir).display()
@@ -295,7 +295,7 @@ fn make_install_postgres(version: &PgConfig, pgdir: &PathBuf) -> Result<PgConfig
 fn validate_pg_config(pg_config: &PgConfig) -> Result<(), std::io::Error> {
     println!(
         "{} {}",
-        "  Validating".bold().green(),
+        "   Validating".bold().green(),
         pg_config.path().expect("no path for pg_config").display()
     );
 

--- a/cargo-pgx/src/commands/install.rs
+++ b/cargo-pgx/src/commands/install.rs
@@ -59,7 +59,7 @@ pub(crate) fn install_extension(
 
     copy_sql_files(&extdir, &extname, &base_directory);
 
-    println!("{} installing {}", "    Finished".bold().green(), extname);
+    println!("{} installing {}", "     Finished".bold().green(), extname);
     Ok(())
 }
 
@@ -76,7 +76,7 @@ fn copy_file(src: PathBuf, dest: PathBuf, msg: &str) {
 
     println!(
         "{} {} to `{}`",
-        "     Copying".bold().green(),
+        "      Copying".bold().green(),
         msg,
         format_display_path(&dest)
     );
@@ -140,7 +140,7 @@ pub(crate) fn write_full_schema_file(dir: &PathBuf, extdir: Option<&PathBuf>) {
     let mut sql = std::fs::File::create(&target_filename).unwrap();
     println!(
         "{} extension schema to `{}`",
-        "     Writing".bold().green(),
+        "      Writing".bold().green(),
         format_display_path(&target_filename)
     );
 

--- a/cargo-pgx/src/commands/run.rs
+++ b/cargo-pgx/src/commands/run.rs
@@ -29,7 +29,7 @@ pub(crate) fn run_psql(
     if !createdb(pg_config, dbname, false, true)? {
         println!(
             "{} existing database {}",
-            "    Re-using".bold().cyan(),
+            "     Re-using".bold().cyan(),
             dbname
         );
     }

--- a/cargo-pgx/src/commands/start.rs
+++ b/cargo-pgx/src/commands/start.rs
@@ -25,7 +25,7 @@ pub(crate) fn start_postgres(pg_config: &PgConfig) -> Result<(), std::io::Error>
 
     println!(
         "{} Postgres v{} on port {}",
-        "    Starting".bold().green(),
+        "     Starting".bold().green(),
         pg_config.major_version()?,
         port.to_string().bold().cyan()
     );

--- a/cargo-pgx/src/commands/stop.rs
+++ b/cargo-pgx/src/commands/stop.rs
@@ -19,7 +19,7 @@ pub(crate) fn stop_postgres(pg_config: &PgConfig) -> Result<(), std::io::Error> 
 
     println!(
         "{} Postgres v{}",
-        "    Stopping".bold().green(),
+        "     Stopping".bold().green(),
         pg_config.major_version()?
     );
 

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -15,11 +15,11 @@ pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.1.20"
-pgx-macros = "0.1.20"
+pgx = "0.1.21"
+pgx-macros = "0.1.21"
 
 [dev-dependencies]
-pgx-tests = "0.1.20"
+pgx-tests = "0.1.21"
 
 [profile.dev]
 panic = "unwind"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619045745,
-        "narHash": "sha256-wekCSTvL5YCCpMdbsEq8lkoTYjriKPLNtSnL7MyZryA=",
+        "lastModified": 1619894881,
+        "narHash": "sha256-9Dq/c+ewZxGkjpapY/zJ0GTmKvPjK6mnyziZyNjPsRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eef51210071dcf7f605aef8c246f7c2fee6216c2",
+        "rev": "4226837368068600e6afd11b5cbc6d586c7b5fa9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
             nixpkgs-fmt
             cargo-pgx
           ];
-          LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
         });
 
       checks = forAllSystems (system:

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -14,7 +14,7 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "0.1.20"}
+pgx-utils = { path = "../pgx-utils", version = "0.1.21"}
 proc-macro2 = "1.0.26"
 quote = "1.0.9"
 syn = { version = "1.0.69", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -17,5 +17,5 @@ proc-macro = true
 pgx-utils = { path = "../pgx-utils", version = "0.1.21"}
 proc-macro2 = "1.0.26"
 quote = "1.0.9"
-syn = { version = "1.0.69", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.71", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -23,17 +23,17 @@ no-default-features = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-memoffset = "0.6.1"
+memoffset = "0.6.3"
 once_cell = "1.7.2"
 pgx-macros = { path = "../pgx-macros/", version = "0.1.21"}
 
 [build-dependencies]
-bindgen = "0.57.0"
+bindgen = "0.58.1"
 build-deps = "0.1.4"
 colored = "2.0.0"
 num_cpus = "1.13.0"
 pgx-utils = { path = "../pgx-utils/", version = "0.1.21"}
-proc-macro2 = "1.0.24"
+proc-macro2 = "1.0.26"
 quote = "1.0.9"
 rayon = "1.5.0"
-syn = { version = "1.0.64", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.71", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -25,14 +25,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 memoffset = "0.6.1"
 once_cell = "1.7.2"
-pgx-macros = { path = "../pgx-macros/", version = "0.1.20"}
+pgx-macros = { path = "../pgx-macros/", version = "0.1.21"}
 
 [build-dependencies]
 bindgen = "0.57.0"
 build-deps = "0.1.4"
 colored = "2.0.0"
 num_cpus = "1.13.0"
-pgx-utils = { path = "../pgx-utils/", version = "0.1.20"}
+pgx-utils = { path = "../pgx-utils/", version = "0.1.21"}
 proc-macro2 = "1.0.24"
 quote = "1.0.9"
 rayon = "1.5.0"

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -464,12 +464,12 @@ fn run_bindgen(
         .header(include_h.display().to_string())
         .clang_arg(&format!("-I{}", includedir_server.display()))
         .parse_callbacks(Box::new(IgnoredMacros::default()))
-        .blacklist_function("varsize_any") // pgx converts the VARSIZE_ANY macro, so we don't want to also have this function, which is in heaptuple.c
-        .blacklist_function("query_tree_walker")
-        .blacklist_function("expression_tree_walker")
-        .blacklist_function("sigsetjmp")
-        .blacklist_function("siglongjmp")
-        .blacklist_function("pg_re_throw")
+        .blocklist_function("varsize_any") // pgx converts the VARSIZE_ANY macro, so we don't want to also have this function, which is in heaptuple.c
+        .blocklist_function("query_tree_walker")
+        .blocklist_function("expression_tree_walker")
+        .blocklist_function("sigsetjmp")
+        .blocklist_function("siglongjmp")
+        .blocklist_function("pg_re_throw")
         .size_t_is_usize(true)
         .rustfmt_bindings(false)
         .derive_debug(true)

--- a/pgx-pg-sys/src/pg10.rs
+++ b/pgx-pg-sys/src/pg10.rs
@@ -187,23 +187,24 @@ pub const DEF_PGPORT_STR: &'static [u8; 6usize] = b"28810\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
 pub const FLOAT4PASSBYVAL: u32 = 1;
 pub const FLOAT8PASSBYVAL: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_CBRT: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
 pub const HAVE_CRYPT: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_CRYPT_H: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_SNPRINTF: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DECL_VSNPRINTF: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -213,11 +214,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -227,7 +228,6 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTPTR_T: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
 pub const HAVE_ISINF: u32 = 1;
@@ -238,7 +238,6 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
 pub const HAVE_LONG_LONG_INT: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMMOVE: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
@@ -246,8 +245,9 @@ pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
 pub const HAVE_READLINE_HISTORY_H: u32 = 1;
@@ -257,6 +257,7 @@ pub const HAVE_RINT: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SNPRINTF: u32 = 1;
@@ -268,30 +269,26 @@ pub const HAVE_STRERROR: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRONG_RANDOM: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TM_ZONE: u32 = 1;
@@ -299,7 +296,6 @@ pub const HAVE_TOWLOWER: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
 pub const HAVE_TZNAME: u32 = 1;
 pub const HAVE_UINTPTR_T: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNIX_SOCKETS: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
@@ -311,7 +307,6 @@ pub const HAVE_UTIME_H: u32 = 1;
 pub const HAVE_VSNPRINTF: u32 = 1;
 pub const HAVE_WCHAR_H: u32 = 1;
 pub const HAVE_WCSTOMBS: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP32: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP64: u32 = 1;
@@ -322,7 +317,6 @@ pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const HAVE__VA_ARGS: u32 = 1;
 pub const INT64_MODIFIER: &'static [u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &'static [u8; 26usize] = b"pgsql-bugs@postgresql.org\0";
@@ -335,22 +329,21 @@ pub const PG_KRB_SRVNAM: &'static [u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &'static [u8; 3usize] = b"10\0";
 pub const PG_VERSION: &'static [u8; 6usize] = b"10.16\0";
 pub const PG_VERSION_NUM: u32 = 100016;
-pub const PG_VERSION_STR : & 'static [u8 ; 115usize] = b"PostgreSQL 10.16 on x86_64-apple-darwin20.3.0, compiled by Apple clang version 12.0.0 (clang-1200.0.32.29), 64-bit\0" ;
+pub const PG_VERSION_STR: &'static [u8; 78usize] =
+    b"PostgreSQL 10.16 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_LONG: u32 = 8;
 pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -365,510 +358,211 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &'static [u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &'static [u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
-pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
-pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 32;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &'static [u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _I386_SIGNAL_H_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const FP_PREC_24B: u32 = 0;
-pub const FP_PREC_53B: u32 = 2;
-pub const FP_PREC_64B: u32 = 3;
-pub const FP_RND_NEAR: u32 = 0;
-pub const FP_RND_DOWN: u32 = 1;
-pub const FP_RND_UP: u32 = 2;
-pub const FP_CHOP: u32 = 3;
-pub const FP_STATE_BYTES: u32 = 512;
-pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
-pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
-pub const __LASTBRANCH_MAX: u32 = 32;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_CURRENT: u32 = 5;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
+pub const P_tmpdir: &'static [u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -879,7 +573,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -903,88 +597,147 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const TRUE: u32 = 1;
 pub const FALSE: u32 = 0;
@@ -1012,375 +765,355 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &'static [u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &'static [u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &'static [u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &'static [u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_MASTER_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _CTYPE_H: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MAX: u32 = 45;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MAX: u32 = 45;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1392,275 +1125,56 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &'static [u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &'static [u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &'static [u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &'static [u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &'static [u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &'static [u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &'static [u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const _PATH_PWD: &'static [u8; 5usize] = b"/etc\0";
-pub const _PATH_PASSWD: &'static [u8; 12usize] = b"/etc/passwd\0";
-pub const _PASSWD: &'static [u8; 7usize] = b"passwd\0";
-pub const _PATH_MASTERPASSWD: &'static [u8; 19usize] = b"/etc/master.passwd\0";
-pub const _PATH_MASTERPASSWD_LOCK: &'static [u8; 10usize] = b"/etc/ptmp\0";
-pub const _MASTERPASSWD: &'static [u8; 14usize] = b"master.passwd\0";
-pub const _PATH_MP_DB: &'static [u8; 12usize] = b"/etc/pwd.db\0";
-pub const _MP_DB: &'static [u8; 7usize] = b"pwd.db\0";
-pub const _PATH_SMP_DB: &'static [u8; 13usize] = b"/etc/spwd.db\0";
-pub const _SMP_DB: &'static [u8; 8usize] = b"spwd.db\0";
-pub const _PATH_PWD_MKDB: &'static [u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
-pub const _PW_KEYBYNAME: u8 = 49u8;
-pub const _PW_KEYBYNUM: u8 = 50u8;
-pub const _PW_KEYBYUID: u8 = 51u8;
-pub const _PASSWORD_EFMT1: u8 = 95u8;
-pub const _PASSWORD_LEN: u32 = 128;
-pub const _PASSWORD_NOUID: u32 = 1;
-pub const _PASSWORD_NOGID: u32 = 2;
-pub const _PASSWORD_NOCHG: u32 = 4;
-pub const _PASSWORD_NOEXP: u32 = 8;
-pub const _PASSWORD_WARNDAYS: u32 = 14;
-pub const _PASSWORD_CHGNOW: i32 = -1;
+pub const _PWD_H: u32 = 1;
+pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
 pub const PG_BACKEND_VERSIONSTR: &'static [u8; 29usize] = b"postgres (PostgreSQL) 10.16\n\0";
 pub const EXE: &'static [u8; 1usize] = b"\0";
 pub const DEVNULL: &'static [u8; 10usize] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
-pub const _JBLEN: u32 = 37;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1769,121 +1283,84 @@ pub const SK_SEARCHARRAY: u32 = 32;
 pub const SK_SEARCHNULL: u32 = 64;
 pub const SK_SEARCHNOTNULL: u32 = 128;
 pub const SK_ORDER_BY: u32 = 256;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 8192;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const DSM_IMPL_NONE: u32 = 0;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
@@ -1909,153 +1386,139 @@ pub const ShareRowExclusiveLock: u32 = 6;
 pub const ExclusiveLock: u32 = 7;
 pub const AccessExclusiveLock: u32 = 8;
 pub const BITS_PER_BITMAPWORD: u32 = 32;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const MAX_TIMESTAMP_PRECISION: u32 = 6;
 pub const MAX_INTERVAL_PRECISION: u32 = 6;
 pub const TS_PREC_INV: f64 = 1000000.0;
@@ -2099,8 +1562,24 @@ pub const HEAP_INSERT_SKIP_FSM: u32 = 2;
 pub const HEAP_INSERT_FROZEN: u32 = 4;
 pub const HEAP_INSERT_SPECULATIVE: u32 = 8;
 pub const HEAP_INSERT_NO_LOGICAL: u32 = 16;
-pub const CLOCKS_PER_SEC: u32 = 1000000;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const PARAM_FLAG_CONST: u32 = 1;
 pub const HASH_PARTITION: u32 = 1;
 pub const HASH_SEGMENT: u32 = 2;
@@ -2176,7 +1655,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const FORKNAMECHARS: u32 = 4;
 pub const InvalidBackendId: i32 = -1;
@@ -2204,25 +1682,9 @@ pub const XLR_MAX_BLOCK_ID: u32 = 32;
 pub const XLR_BLOCK_ID_DATA_SHORT: u32 = 255;
 pub const XLR_BLOCK_ID_DATA_LONG: u32 = 254;
 pub const XLR_BLOCK_ID_ORIGIN: u32 = 253;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const SYNC_METHOD_FSYNC: u32 = 0;
@@ -2370,6 +1832,85 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2388,13 +1929,7 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -3067,7 +2602,6 @@ pub const PROCARRAY_FLAGS_DEFAULT: u32 = 16;
 pub const PROCARRAY_FLAGS_VACUUM: u32 = 18;
 pub const PROCARRAY_FLAGS_ANALYZE: u32 = 20;
 pub const PROCARRAY_FLAGS_VACUUM_ANALYZE: u32 = 22;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &'static [u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3093,11 +2627,18 @@ pub const GUC_UNIT_MIN: u32 = 196608;
 pub const GUC_UNIT_TIME: u32 = 983040;
 pub const GUC_UNIT: u32 = 1044480;
 pub const STACK_DEPTH_SLOP: u32 = 524288;
-pub const FP_SUPERNORMAL: u32 = 6;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -3111,12 +2652,6 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
 pub const MAX_TIME_PRECISION: u32 = 6;
 pub const NUMERIC_MAX_PRECISION: u32 = 1000;
 pub const NUMERIC_MAX_DISPLAY_SCALE: u32 = 1000;
@@ -3182,429 +2717,195 @@ pub const TYPECACHE_RANGE_INFO: u32 = 2048;
 pub const TYPECACHE_DOMAIN_INFO: u32 = 4096;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
-    _bindgen_union_align: [u64; 16usize],
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+    _bindgen_union_align: u32,
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
+}
+impl Default for _G_fpos_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __fpos_t = _G_fpos_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
+}
+impl Default for _G_fpos64_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
-}
-impl Default for __darwin_pthread_handler_rec {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_attr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[pg_guard]
-extern "C" {
-    pub fn renameat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn renamex_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn renameatx_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 #[pg_guard]
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdout: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stderr: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgets(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut FILE,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __mode: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut FILE,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fseek(
-        arg1: *mut FILE,
-        arg2: ::std::os::raw::c_long,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn perror(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3615,39 +2916,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn rewind(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setvbuf(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sscanf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    pub fn renameat(
+        __oldfd: ::std::os::raw::c_int,
+        __old: *const ::std::os::raw::c_char,
+        __newfd: ::std::os::raw::c_int,
+        __new: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3656,135 +2929,207 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vfprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vprintf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn popen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __svfscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flockfile(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn funlockfile(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn tempnam(
         __dir: *const ::std::os::raw::c_char,
-        __prefix: *const ::std::os::raw::c_char,
+        __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-pub type off_t = __darwin_off_t;
 #[pg_guard]
 extern "C" {
-    pub fn fseeko(
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
         __stream: *mut FILE,
-        __offset: off_t,
-        __whence: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
+        -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmemopen(
+        __s: *mut ::std::os::raw::c_void,
+        __len: usize,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn open_memstream(
+        __bufloc: *mut *mut ::std::os::raw::c_char,
+        __sizeloc: *mut usize,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setvbuf(
+        __stream: *mut FILE,
+        __buf: *mut ::std::os::raw::c_char,
+        __modes: ::std::os::raw::c_int,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> off_t;
+    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setlinebuf(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fprintf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vfprintf(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vprintf(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vsprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn snprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vsnprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vdprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sscanf(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_fscanf"]
+    pub fn fscanf1(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_scanf"]
+    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_sscanf"]
+    pub fn sscanf1(
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
         ...
     ) -> ::std::os::raw::c_int;
@@ -3792,2037 +3137,299 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn vfscanf(
-        __stream: *mut FILE,
+        __s: *mut FILE,
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vscanf(
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsnprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vsscanf(
-        __str: *const ::std::os::raw::c_char,
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    #[link_name = "\u{1}__isoc99_vfscanf"]
+    pub fn vfscanf1(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vdprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
+    #[link_name = "\u{1}__isoc99_vscanf"]
+    pub fn vscanf1(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_vsscanf"]
+    pub fn vsscanf1(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgets(
+        __s: *mut ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __getdelim(
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn getdelim(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __delimiter: ::std::os::raw::c_int,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn getline(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmemopen(
-        __buf: *mut ::std::os::raw::c_void,
+    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __s: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread_unlocked(
+        __ptr: *mut ::std::os::raw::c_void,
         __size: usize,
-        __mode: *const ::std::os::raw::c_char,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite_unlocked(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: usize,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseek(
+        __stream: *mut FILE,
+        __off: ::std::os::raw::c_long,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rewind(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseeko(
+        __stream: *mut FILE,
+        __off: __off_t,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftello(__stream: *mut FILE) -> __off_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr_unlocked(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn perror(__s: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn popen(
+        __command: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn open_memstream(
-        __bufp: *mut *mut ::std::os::raw::c_char,
-        __sizep: *mut usize,
-    ) -> *mut FILE;
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
+    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+    pub fn flockfile(__stream: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn asprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn funlockfile(__stream: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmtcheck(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-#[pg_guard]
-extern "C" {
-    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuffer(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vasprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn zopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn funopen(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg3: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg4: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: fpos_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> fpos_t,
-        >,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-        >,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __snprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __vsprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __vsnprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        arg6: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_i386_thread_state {
-    pub __eax: ::std::os::raw::c_uint,
-    pub __ebx: ::std::os::raw::c_uint,
-    pub __ecx: ::std::os::raw::c_uint,
-    pub __edx: ::std::os::raw::c_uint,
-    pub __edi: ::std::os::raw::c_uint,
-    pub __esi: ::std::os::raw::c_uint,
-    pub __ebp: ::std::os::raw::c_uint,
-    pub __esp: ::std::os::raw::c_uint,
-    pub __ss: ::std::os::raw::c_uint,
-    pub __eflags: ::std::os::raw::c_uint,
-    pub __eip: ::std::os::raw::c_uint,
-    pub __cs: ::std::os::raw::c_uint,
-    pub __ds: ::std::os::raw::c_uint,
-    pub __es: ::std::os::raw::c_uint,
-    pub __fs: ::std::os::raw::c_uint,
-    pub __gs: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_fp_control {
-    pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-}
-impl __darwin_fp_control {
-    #[inline]
-    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
-    }
-    #[inline]
-    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 2u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
-    }
-    #[inline]
-    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(10usize, 2u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __invalid: ::std::os::raw::c_ushort,
-        __denorm: ::std::os::raw::c_ushort,
-        __zdiv: ::std::os::raw::c_ushort,
-        __ovrfl: ::std::os::raw::c_ushort,
-        __undfl: ::std::os::raw::c_ushort,
-        __precis: ::std::os::raw::c_ushort,
-        __pc: ::std::os::raw::c_ushort,
-        __rc: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
-            __invalid as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
-            __denorm as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
-            __zdiv as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
-            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
-            __ovrfl as u64
-        });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
-            __undfl as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
-            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
-            __precis as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 2u8, {
-            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
-            __pc as u64
-        });
-        __bindgen_bitfield_unit.set(10usize, 2u8, {
-            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
-            __rc as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-pub type __darwin_fp_control_t = __darwin_fp_control;
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_fp_status {
-    pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-}
-impl __darwin_fp_status {
-    #[inline]
-    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(6usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(9usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(10usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
-    }
-    #[inline]
-    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(11usize, 3u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(14usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(15usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __invalid: ::std::os::raw::c_ushort,
-        __denorm: ::std::os::raw::c_ushort,
-        __zdiv: ::std::os::raw::c_ushort,
-        __ovrfl: ::std::os::raw::c_ushort,
-        __undfl: ::std::os::raw::c_ushort,
-        __precis: ::std::os::raw::c_ushort,
-        __stkflt: ::std::os::raw::c_ushort,
-        __errsumm: ::std::os::raw::c_ushort,
-        __c0: ::std::os::raw::c_ushort,
-        __c1: ::std::os::raw::c_ushort,
-        __c2: ::std::os::raw::c_ushort,
-        __tos: ::std::os::raw::c_ushort,
-        __c3: ::std::os::raw::c_ushort,
-        __busy: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
-            __invalid as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
-            __denorm as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
-            __zdiv as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
-            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
-            __ovrfl as u64
-        });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
-            __undfl as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
-            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
-            __precis as u64
-        });
-        __bindgen_bitfield_unit.set(6usize, 1u8, {
-            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
-            __stkflt as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
-            __errsumm as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 1u8, {
-            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
-            __c0 as u64
-        });
-        __bindgen_bitfield_unit.set(9usize, 1u8, {
-            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
-            __c1 as u64
-        });
-        __bindgen_bitfield_unit.set(10usize, 1u8, {
-            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
-            __c2 as u64
-        });
-        __bindgen_bitfield_unit.set(11usize, 3u8, {
-            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
-            __tos as u64
-        });
-        __bindgen_bitfield_unit.set(14usize, 1u8, {
-            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
-            __c3 as u64
-        });
-        __bindgen_bitfield_unit.set(15usize, 1u8, {
-            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
-            __busy as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-pub type __darwin_fp_status_t = __darwin_fp_status;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mmst_reg {
-    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
-    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_xmm_reg {
-    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_ymm_reg {
-    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_zmm_reg {
-    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
-}
-impl Default for __darwin_zmm_reg {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_opmask_reg {
-    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_float_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-}
-impl Default for __darwin_i386_float_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_avx_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-}
-impl Default for __darwin_i386_avx_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_avx512_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_k0: __darwin_opmask_reg,
-    pub __fpu_k1: __darwin_opmask_reg,
-    pub __fpu_k2: __darwin_opmask_reg,
-    pub __fpu_k3: __darwin_opmask_reg,
-    pub __fpu_k4: __darwin_opmask_reg,
-    pub __fpu_k5: __darwin_opmask_reg,
-    pub __fpu_k6: __darwin_opmask_reg,
-    pub __fpu_k7: __darwin_opmask_reg,
-    pub __fpu_zmmh0: __darwin_ymm_reg,
-    pub __fpu_zmmh1: __darwin_ymm_reg,
-    pub __fpu_zmmh2: __darwin_ymm_reg,
-    pub __fpu_zmmh3: __darwin_ymm_reg,
-    pub __fpu_zmmh4: __darwin_ymm_reg,
-    pub __fpu_zmmh5: __darwin_ymm_reg,
-    pub __fpu_zmmh6: __darwin_ymm_reg,
-    pub __fpu_zmmh7: __darwin_ymm_reg,
-}
-impl Default for __darwin_i386_avx512_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_i386_exception_state {
-    pub __trapno: __uint16_t,
-    pub __cpu: __uint16_t,
-    pub __err: __uint32_t,
-    pub __faultvaddr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_debug_state32 {
-    pub __dr0: ::std::os::raw::c_uint,
-    pub __dr1: ::std::os::raw::c_uint,
-    pub __dr2: ::std::os::raw::c_uint,
-    pub __dr3: ::std::os::raw::c_uint,
-    pub __dr4: ::std::os::raw::c_uint,
-    pub __dr5: ::std::os::raw::c_uint,
-    pub __dr6: ::std::os::raw::c_uint,
-    pub __dr7: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __x86_instruction_state {
-    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
-    pub __insn_offset: ::std::os::raw::c_int,
-    pub __out_of_synch: ::std::os::raw::c_int,
-    pub __insn_bytes: [__uint8_t; 2380usize],
-    pub __insn_cacheline: [__uint8_t; 64usize],
-}
-impl Default for __x86_instruction_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __last_branch_record {
-    pub __from_ip: __uint64_t,
-    pub __to_ip: __uint64_t,
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __bindgen_padding_0: u32,
-}
-impl __last_branch_record {
-    #[inline]
-    pub fn __mispredict(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___mispredict(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __tsx_abort(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __in_tsx(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___in_tsx(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __cycle_count(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set___cycle_count(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __reserved(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
-    }
-    #[inline]
-    pub fn set___reserved(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(19usize, 13u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __mispredict: __uint32_t,
-        __tsx_abort: __uint32_t,
-        __in_tsx: __uint32_t,
-        __cycle_count: __uint32_t,
-        __reserved: __uint32_t,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
-            __mispredict as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
-            __tsx_abort as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
-            __in_tsx as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 16u8, {
-            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
-            __cycle_count as u64
-        });
-        __bindgen_bitfield_unit.set(19usize, 13u8, {
-            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
-            __reserved as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __last_branch_state {
-    pub __lbr_count: ::std::os::raw::c_int,
-    pub _bitfield_align_1: [u32; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __lbrs: [__last_branch_record; 32usize],
-}
-impl __last_branch_state {
-    #[inline]
-    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __reserved(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
-    }
-    #[inline]
-    pub fn set___reserved(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 30u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __lbr_supported_tsx: __uint32_t,
-        __lbr_supported_cycle_count: __uint32_t,
-        __reserved: __uint32_t,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
-            __lbr_supported_tsx as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __lbr_supported_cycle_count: u32 =
-                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
-            __lbr_supported_cycle_count as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 30u8, {
-            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
-            __reserved as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __x86_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_thread_state64 {
-    pub __rax: __uint64_t,
-    pub __rbx: __uint64_t,
-    pub __rcx: __uint64_t,
-    pub __rdx: __uint64_t,
-    pub __rdi: __uint64_t,
-    pub __rsi: __uint64_t,
-    pub __rbp: __uint64_t,
-    pub __rsp: __uint64_t,
-    pub __r8: __uint64_t,
-    pub __r9: __uint64_t,
-    pub __r10: __uint64_t,
-    pub __r11: __uint64_t,
-    pub __r12: __uint64_t,
-    pub __r13: __uint64_t,
-    pub __r14: __uint64_t,
-    pub __r15: __uint64_t,
-    pub __rip: __uint64_t,
-    pub __rflags: __uint64_t,
-    pub __cs: __uint64_t,
-    pub __fs: __uint64_t,
-    pub __gs: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_thread_full_state64 {
-    pub __ss64: __darwin_x86_thread_state64,
-    pub __ds: __uint64_t,
-    pub __es: __uint64_t,
-    pub __ss: __uint64_t,
-    pub __gsbase: __uint64_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_float_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-}
-impl Default for __darwin_x86_float_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_avx_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_ymmh8: __darwin_xmm_reg,
-    pub __fpu_ymmh9: __darwin_xmm_reg,
-    pub __fpu_ymmh10: __darwin_xmm_reg,
-    pub __fpu_ymmh11: __darwin_xmm_reg,
-    pub __fpu_ymmh12: __darwin_xmm_reg,
-    pub __fpu_ymmh13: __darwin_xmm_reg,
-    pub __fpu_ymmh14: __darwin_xmm_reg,
-    pub __fpu_ymmh15: __darwin_xmm_reg,
-}
-impl Default for __darwin_x86_avx_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_avx512_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_ymmh8: __darwin_xmm_reg,
-    pub __fpu_ymmh9: __darwin_xmm_reg,
-    pub __fpu_ymmh10: __darwin_xmm_reg,
-    pub __fpu_ymmh11: __darwin_xmm_reg,
-    pub __fpu_ymmh12: __darwin_xmm_reg,
-    pub __fpu_ymmh13: __darwin_xmm_reg,
-    pub __fpu_ymmh14: __darwin_xmm_reg,
-    pub __fpu_ymmh15: __darwin_xmm_reg,
-    pub __fpu_k0: __darwin_opmask_reg,
-    pub __fpu_k1: __darwin_opmask_reg,
-    pub __fpu_k2: __darwin_opmask_reg,
-    pub __fpu_k3: __darwin_opmask_reg,
-    pub __fpu_k4: __darwin_opmask_reg,
-    pub __fpu_k5: __darwin_opmask_reg,
-    pub __fpu_k6: __darwin_opmask_reg,
-    pub __fpu_k7: __darwin_opmask_reg,
-    pub __fpu_zmmh0: __darwin_ymm_reg,
-    pub __fpu_zmmh1: __darwin_ymm_reg,
-    pub __fpu_zmmh2: __darwin_ymm_reg,
-    pub __fpu_zmmh3: __darwin_ymm_reg,
-    pub __fpu_zmmh4: __darwin_ymm_reg,
-    pub __fpu_zmmh5: __darwin_ymm_reg,
-    pub __fpu_zmmh6: __darwin_ymm_reg,
-    pub __fpu_zmmh7: __darwin_ymm_reg,
-    pub __fpu_zmmh8: __darwin_ymm_reg,
-    pub __fpu_zmmh9: __darwin_ymm_reg,
-    pub __fpu_zmmh10: __darwin_ymm_reg,
-    pub __fpu_zmmh11: __darwin_ymm_reg,
-    pub __fpu_zmmh12: __darwin_ymm_reg,
-    pub __fpu_zmmh13: __darwin_ymm_reg,
-    pub __fpu_zmmh14: __darwin_ymm_reg,
-    pub __fpu_zmmh15: __darwin_ymm_reg,
-    pub __fpu_zmm16: __darwin_zmm_reg,
-    pub __fpu_zmm17: __darwin_zmm_reg,
-    pub __fpu_zmm18: __darwin_zmm_reg,
-    pub __fpu_zmm19: __darwin_zmm_reg,
-    pub __fpu_zmm20: __darwin_zmm_reg,
-    pub __fpu_zmm21: __darwin_zmm_reg,
-    pub __fpu_zmm22: __darwin_zmm_reg,
-    pub __fpu_zmm23: __darwin_zmm_reg,
-    pub __fpu_zmm24: __darwin_zmm_reg,
-    pub __fpu_zmm25: __darwin_zmm_reg,
-    pub __fpu_zmm26: __darwin_zmm_reg,
-    pub __fpu_zmm27: __darwin_zmm_reg,
-    pub __fpu_zmm28: __darwin_zmm_reg,
-    pub __fpu_zmm29: __darwin_zmm_reg,
-    pub __fpu_zmm30: __darwin_zmm_reg,
-    pub __fpu_zmm31: __darwin_zmm_reg,
-}
-impl Default for __darwin_x86_avx512_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_exception_state64 {
-    pub __trapno: __uint16_t,
-    pub __cpu: __uint16_t,
-    pub __err: __uint32_t,
-    pub __faultvaddr: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_debug_state64 {
-    pub __dr0: __uint64_t,
-    pub __dr1: __uint64_t,
-    pub __dr2: __uint64_t,
-    pub __dr3: __uint64_t,
-    pub __dr4: __uint64_t,
-    pub __dr5: __uint64_t,
-    pub __dr6: __uint64_t,
-    pub __dr7: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_float_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_avx_state,
-}
-impl Default for __darwin_mcontext_avx32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_avx512_state,
-}
-impl Default for __darwin_mcontext_avx512_32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_float_state64,
-}
-impl Default for __darwin_mcontext64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_float_state64,
-}
-impl Default for __darwin_mcontext64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_avx_state64,
-}
-impl Default for __darwin_mcontext_avx64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_avx_state64,
-}
-impl Default for __darwin_mcontext_avx64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_avx512_state64,
-}
-impl Default for __darwin_mcontext_avx512_64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_avx512_state64,
-}
-impl Default for __darwin_mcontext_avx512_64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-    _bindgen_union_align: u64,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    _bindgen_union_align: u64,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-pub type rusage_info_current = rusage_info_v5;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setpriority(
-        arg1: ::std::os::raw::c_int,
-        arg2: id_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-    _bindgen_union_align: u32,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn waitpid(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn waitid(
-        arg1: idtype_t,
-        arg2: id_t,
-        arg3: *mut siginfo_t,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait3(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut rusage,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait4(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut rusage,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -5843,7 +3450,595 @@ pub struct lldiv_t {
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+    pub fn __ctype_get_mb_cur_max() -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtod(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtof(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtold(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtol(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoul(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtouq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoll(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoull(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[pg_guard]
+extern "C" {
+    pub fn select(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *mut timeval,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pselect(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *const timespec,
+        __sigmask: *const __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __bindgen_anon_1: __pthread_cond_s__bindgen_ty_1,
+    pub __bindgen_anon_2: __pthread_cond_s__bindgen_ty_2,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __pthread_cond_s__bindgen_ty_1 {
+    pub __wseq: ::std::os::raw::c_ulonglong,
+    pub __wseq32: __pthread_cond_s__bindgen_ty_1__bindgen_ty_1,
+    _bindgen_union_align: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_cond_s__bindgen_ty_1__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __pthread_cond_s__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __pthread_cond_s__bindgen_ty_2 {
+    pub __g1_start: ::std::os::raw::c_ulonglong,
+    pub __g1_start32: __pthread_cond_s__bindgen_ty_2__bindgen_ty_1,
+    _bindgen_union_align: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_cond_s__bindgen_ty_2__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __pthread_cond_s__bindgen_ty_2 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 7usize],
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 5usize],
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+    _bindgen_union_align: [u64; 6usize],
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 7usize],
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: u64,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 4usize],
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn random() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom(__seed: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn initstate(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom_r(
+        __seed: ::std::os::raw::c_uint,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn initstate_r(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate_r(
+        __statebuf: *mut ::std::os::raw::c_char,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand(__seed: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48(__seedval: ::std::os::raw::c_long);
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48_r(
+        __seedval: ::std::os::raw::c_long,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48_r(
+        __seed16v: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48_r(
+        __param: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -5852,13 +4047,9 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn calloc(
-        __count: ::std::os::raw::c_ulong,
+        __nmemb: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -5869,11 +4060,23 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+    pub fn reallocarray(
+        __ptr: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
+}
+#[pg_guard]
+extern "C" {
+    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5885,74 +4088,247 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
     pub fn abort();
 }
 #[pg_guard]
 extern "C" {
-    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+    pub fn at_quick_exit(
+        __func: ::std::option::Option<unsafe extern "C" fn()>,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+    pub fn on_exit(
+        __func: ::std::option::Option<
+            unsafe extern "C" fn(
+                __status: ::std::os::raw::c_int,
+                __arg: *mut ::std::os::raw::c_void,
+            ),
+        >,
+        __arg: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn exit(__status: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+    pub fn quick_exit(__status: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+    pub fn _Exit(__status: ::std::os::raw::c_int);
 }
+#[pg_guard]
+extern "C" {
+    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setenv(
+        __name: *const ::std::os::raw::c_char,
+        __value: *const ::std::os::raw::c_char,
+        __replace: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearenv() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemps(
+        __template: *mut ::std::os::raw::c_char,
+        __suffixlen: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn realpath(
+        __name: *const ::std::os::raw::c_char,
+        __resolved: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[pg_guard]
 extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn exit(arg1: ::std::os::raw::c_int);
+    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
+    pub fn lldiv(
+        __numer: ::std::os::raw::c_longlong,
+        __denom: ::std::os::raw::c_longlong,
+    ) -> lldiv_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qecvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qfcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qgcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qecvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qfcvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -5960,594 +4336,70 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
-}
-#[pg_guard]
-extern "C" {
     pub fn mbtowc(
-        arg1: *mut wchar_t,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: usize,
+        __pwc: *mut wchar_t,
+        __s: *const ::std::os::raw::c_char,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
+    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
+    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn srand(arg1: ::std::os::raw::c_uint);
+    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtod(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtof(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtol(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtold(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoll(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoul(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoull(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _Exit(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn getsubopt(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+        __optionp: *mut *mut ::std::os::raw::c_char,
+        __tokens: *const *mut ::std::os::raw::c_char,
+        __valuep: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn initstate(
-        arg1: ::std::os::raw::c_uint,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ptsname_r(
-        fildes: ::std::os::raw::c_int,
-        buffer: *mut ::std::os::raw::c_char,
-        buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-    pub fn realpath(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __overwrite: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setkey(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48(arg1: ::std::os::raw::c_long);
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom(arg1: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[pg_guard]
-extern "C" {
-    pub fn arc4random() -> u32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_stir();
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bsearch_b(
-        __key: *const ::std::os::raw::c_void,
-        __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+    pub fn memcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cgetcap(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetclose() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetfirst(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetmatch(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetnext(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetnum(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetstr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetustr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_daemon$1050"]
-    pub fn daemon(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn devname_r(
-        arg1: dev_t,
-        arg2: mode_t,
-        buf: *mut ::std::os::raw::c_char,
-        len: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getbsize(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_long,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprogname() -> *const ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn heapsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn heapsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mergesort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mergesort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn qsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn qsort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn radixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sradixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sranddev();
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandomdev();
-}
-#[pg_guard]
-extern "C" {
-    pub fn reallocf(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
+    pub fn memmove(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtonum(
-        __numstr: *const ::std::os::raw::c_char,
-        __minval: ::std::os::raw::c_longlong,
-        __maxval: ::std::os::raw::c_longlong,
-        __errstrp: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_longlong;
+    pub fn memccpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtoq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtouq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
+    pub fn memset(
+        __s: *mut ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -6562,40 +4414,40 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn memcpy(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmove(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset(
-        __b: *mut ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
+    pub fn strcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strncat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -6607,43 +4459,6 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcspn(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
     pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
@@ -6652,17 +4467,68 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncpy(
-        __dst: *mut ::std::os::raw::c_char,
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm(
+        __dest: *mut ::std::os::raw::c_char,
         __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[pg_guard]
+extern "C" {
+    pub fn strcoll_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __l: locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm_l(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+        __l: locale_t,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strndup(
+        __string: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strpbrk(
+    pub fn strchr(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -6674,170 +4540,164 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strspn(
+    pub fn strcspn(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __reject: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
     pub fn strstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
+        __haystack: *const ::std::os::raw::c_char,
+        __needle: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strtok(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strxfrm(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn __strtok_r(
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strtok_r(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
-        __lasts: *mut *mut ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__xpg_strerror_r"]
     pub fn strerror_r(
         __errnum: ::std::os::raw::c_int,
-        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buf: *mut ::std::os::raw::c_char,
         __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn strerror_l(
+        __errnum: ::std::os::raw::c_int,
+        __l: locale_t,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memccpy(
-        __dst: *mut ::std::os::raw::c_void,
+    pub fn bcmp(
+        __s1: *const ::std::os::raw::c_void,
+        __s2: *const ::std::os::raw::c_void,
+        __n: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcopy(
         __src: *const ::std::os::raw::c_void,
+        __dest: *mut ::std::os::raw::c_void,
+        __n: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
+}
+#[pg_guard]
+extern "C" {
+    pub fn index(
+        __s: *const ::std::os::raw::c_char,
         __c: ::std::os::raw::c_int,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn stpcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpncpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
+    pub fn rindex(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strndup(
+    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcasecmp(
         __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strncasecmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn strcasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[pg_guard]
-extern "C" {
-    pub fn memset_s(
-        __s: *mut ::std::os::raw::c_void,
-        __smax: rsize_t,
-        __c: ::std::os::raw::c_int,
-        __n: rsize_t,
-    ) -> errno_t;
+    pub fn strncasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __n: usize,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmem(
-        __big: *const ::std::os::raw::c_void,
-        __big_len: usize,
-        __little: *const ::std::os::raw::c_void,
-        __little_len: usize,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern4(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern4: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern8(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern8: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern16(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern16: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcasestr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strnstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-        __len: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
 }
 #[pg_guard]
 extern "C" {
@@ -6848,158 +4708,67 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn swab(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: isize,
-    );
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timingsafe_bcmp(
-        __b1: *const ::std::os::raw::c_void,
-        __b2: *const ::std::os::raw::c_void,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strsignal_r(
-        __sig: ::std::os::raw::c_int,
-        __strsignalbuf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcmp(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcopy(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-}
-#[pg_guard]
-extern "C" {
-    pub fn index(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn __stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rindex(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+    pub fn stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
-#[pg_guard]
-extern "C" {
-    pub fn strncasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-pub type max_align_t = u128;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[pg_guard]
 extern "C" {
-    pub fn __darwin_check_fd_set_overflow(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[pg_guard]
-extern "C" {
-    pub fn __error() -> *mut ::std::os::raw::c_int;
+    pub fn __errno_location() -> *mut ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7023,8 +4792,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -7036,14 +4805,34 @@ impl Default for lconv {
 }
 #[pg_guard]
 extern "C" {
+    pub fn setlocale(
+        __category: ::std::os::raw::c_int,
+        __locale: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
     pub fn localeconv() -> *mut lconv;
 }
 #[pg_guard]
 extern "C" {
-    pub fn setlocale(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn newlocale(
+        __category_mask: ::std::os::raw::c_int,
+        __locale: *const ::std::os::raw::c_char,
+        __base: locale_t,
+    ) -> locale_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn duplocale(__dataset: locale_t) -> locale_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freelocale(__dataset: locale_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uselocale(__dataset: locale_t) -> locale_t;
 }
 pub type BoolPtr = *mut bool;
 pub type Pointer = *mut ::std::os::raw::c_char;
@@ -7148,115 +4937,167 @@ impl Default for PGAlignedXLogBlock {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const _ISupper: ::std::os::raw::c_uint = 256;
+pub const _ISlower: ::std::os::raw::c_uint = 512;
+pub const _ISalpha: ::std::os::raw::c_uint = 1024;
+pub const _ISdigit: ::std::os::raw::c_uint = 2048;
+pub const _ISxdigit: ::std::os::raw::c_uint = 4096;
+pub const _ISspace: ::std::os::raw::c_uint = 8192;
+pub const _ISprint: ::std::os::raw::c_uint = 16384;
+pub const _ISgraph: ::std::os::raw::c_uint = 32768;
+pub const _ISblank: ::std::os::raw::c_uint = 1;
+pub const _IScntrl: ::std::os::raw::c_uint = 2;
+pub const _ISpunct: ::std::os::raw::c_uint = 4;
+pub const _ISalnum: ::std::os::raw::c_uint = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
+    pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
+    pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
+    pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __maskrune(
-        arg1: __darwin_ct_rune_t,
-        arg2: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
+    pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-pub type socklen_t = __darwin_socklen_t;
-pub type sa_family_t = __uint8_t;
+#[pg_guard]
+extern "C" {
+    pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -7268,71 +5109,67 @@ impl Default for iovec {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
-}
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const MSG_OOB: ::std::os::raw::c_uint = 1;
+pub const MSG_PEEK: ::std::os::raw::c_uint = 2;
+pub const MSG_DONTROUTE: ::std::os::raw::c_uint = 4;
+pub const MSG_CTRUNC: ::std::os::raw::c_uint = 8;
+pub const MSG_PROXY: ::std::os::raw::c_uint = 16;
+pub const MSG_TRUNC: ::std::os::raw::c_uint = 32;
+pub const MSG_DONTWAIT: ::std::os::raw::c_uint = 64;
+pub const MSG_EOR: ::std::os::raw::c_uint = 128;
+pub const MSG_WAITALL: ::std::os::raw::c_uint = 256;
+pub const MSG_FIN: ::std::os::raw::c_uint = 512;
+pub const MSG_SYN: ::std::os::raw::c_uint = 1024;
+pub const MSG_CONFIRM: ::std::os::raw::c_uint = 2048;
+pub const MSG_RST: ::std::os::raw::c_uint = 4096;
+pub const MSG_ERRQUEUE: ::std::os::raw::c_uint = 8192;
+pub const MSG_NOSIGNAL: ::std::os::raw::c_uint = 16384;
+pub const MSG_MORE: ::std::os::raw::c_uint = 32768;
+pub const MSG_WAITFORONE: ::std::os::raw::c_uint = 65536;
+pub const MSG_BATCH: ::std::os::raw::c_uint = 262144;
+pub const MSG_ZEROCOPY: ::std::os::raw::c_uint = 67108864;
+pub const MSG_FASTOPEN: ::std::os::raw::c_uint = 536870912;
+pub const MSG_CMSG_CLOEXEC: ::std::os::raw::c_uint = 1073741824;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -7341,225 +5178,239 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+}
+pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn accept(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bind(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sockaddr,
-        arg3: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn connect(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sockaddr,
-        arg3: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpeername(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockname(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockopt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_void,
-        arg5: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn listen(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recv(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recvfrom(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-        arg5: *mut sockaddr,
-        arg6: *mut socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recvmsg(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut msghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn send(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendmsg(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const msghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendto(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-        arg5: *const sockaddr,
-        arg6: socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setsockopt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_void,
-        arg5: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn shutdown(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
+pub const SHUT_RD: ::std::os::raw::c_uint = 0;
+pub const SHUT_WR: ::std::os::raw::c_uint = 1;
+pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn socket(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
+        __domain: ::std::os::raw::c_int,
+        __type: ::std::os::raw::c_int,
+        __protocol: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn socketpair(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
+        __domain: ::std::os::raw::c_int,
+        __type: ::std::os::raw::c_int,
+        __protocol: ::std::os::raw::c_int,
+        __fds: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sendfile(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: off_t,
-        arg4: *mut off_t,
-        arg5: *mut sf_hdtr,
-        arg6: ::std::os::raw::c_int,
+    pub fn bind(
+        __fd: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-}
-#[pg_guard]
-extern "C" {
-    pub fn connectx(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sa_endpoints_t,
-        arg3: sae_associd_t,
-        arg4: ::std::os::raw::c_uint,
-        arg5: *const iovec,
-        arg6: ::std::os::raw::c_uint,
-        arg7: *mut usize,
-        arg8: *mut sae_connid_t,
+    pub fn getsockname(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __len: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn disconnectx(
-        arg1: ::std::os::raw::c_int,
-        arg2: sae_associd_t,
-        arg3: sae_connid_t,
+    pub fn connect(
+        __fd: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
+#[pg_guard]
+extern "C" {
+    pub fn getpeername(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __len: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn send(
+        __fd: ::std::os::raw::c_int,
+        __buf: *const ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recv(
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendto(
+        __fd: ::std::os::raw::c_int,
+        __buf: *const ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __addr_len: socklen_t,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recvfrom(
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __addr_len: *mut socklen_t,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendmsg(
+        __fd: ::std::os::raw::c_int,
+        __message: *const msghdr,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recvmsg(
+        __fd: ::std::os::raw::c_int,
+        __message: *mut msghdr,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsockopt(
+        __fd: ::std::os::raw::c_int,
+        __level: ::std::os::raw::c_int,
+        __optname: ::std::os::raw::c_int,
+        __optval: *mut ::std::os::raw::c_void,
+        __optlen: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setsockopt(
+        __fd: ::std::os::raw::c_int,
+        __level: ::std::os::raw::c_int,
+        __optname: ::std::os::raw::c_int,
+        __optval: *const ::std::os::raw::c_void,
+        __optlen: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn accept(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __addr_len: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn shutdown(
+        __fd: ::std::os::raw::c_int,
+        __how: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isfdtype(
+        __fd: ::std::os::raw::c_int,
+        __fdtype: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -7574,12 +5425,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -7587,113 +5432,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn setipv4sourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: in_addr,
-        arg3: in_addr,
-        arg4: u32,
-        arg5: u32,
-        arg6: *mut in_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipv4sourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: in_addr,
-        arg3: in_addr,
-        arg4: *mut u32,
-        arg5: *mut u32,
-        arg6: *mut in_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setsourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: u32,
-        arg3: *mut sockaddr,
-        arg4: socklen_t,
-        arg5: u32,
-        arg6: u32,
-        arg7: *mut sockaddr_storage,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: u32,
-        arg3: *mut sockaddr,
-        arg4: socklen_t,
-        arg5: *mut u32,
-        arg6: *mut u32,
-        arg7: *mut sockaddr_storage,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: ::std::os::raw::c_uint = 0;
+pub const IPPROTO_ICMP: ::std::os::raw::c_uint = 1;
+pub const IPPROTO_IGMP: ::std::os::raw::c_uint = 2;
+pub const IPPROTO_IPIP: ::std::os::raw::c_uint = 4;
+pub const IPPROTO_TCP: ::std::os::raw::c_uint = 6;
+pub const IPPROTO_EGP: ::std::os::raw::c_uint = 8;
+pub const IPPROTO_PUP: ::std::os::raw::c_uint = 12;
+pub const IPPROTO_UDP: ::std::os::raw::c_uint = 17;
+pub const IPPROTO_IDP: ::std::os::raw::c_uint = 22;
+pub const IPPROTO_TP: ::std::os::raw::c_uint = 29;
+pub const IPPROTO_DCCP: ::std::os::raw::c_uint = 33;
+pub const IPPROTO_IPV6: ::std::os::raw::c_uint = 41;
+pub const IPPROTO_RSVP: ::std::os::raw::c_uint = 46;
+pub const IPPROTO_GRE: ::std::os::raw::c_uint = 47;
+pub const IPPROTO_ESP: ::std::os::raw::c_uint = 50;
+pub const IPPROTO_AH: ::std::os::raw::c_uint = 51;
+pub const IPPROTO_MTP: ::std::os::raw::c_uint = 92;
+pub const IPPROTO_BEETPH: ::std::os::raw::c_uint = 94;
+pub const IPPROTO_ENCAP: ::std::os::raw::c_uint = 98;
+pub const IPPROTO_PIM: ::std::os::raw::c_uint = 103;
+pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
+pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
+pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
+pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
+pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
+pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
+pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
+pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
+pub const IPPROTO_FRAGMENT: ::std::os::raw::c_uint = 44;
+pub const IPPROTO_ICMPV6: ::std::os::raw::c_uint = 58;
+pub const IPPROTO_NONE: ::std::os::raw::c_uint = 59;
+pub const IPPROTO_DSTOPTS: ::std::os::raw::c_uint = 60;
+pub const IPPROTO_MH: ::std::os::raw::c_uint = 135;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: ::std::os::raw::c_uint = 7;
+pub const IPPORT_DISCARD: ::std::os::raw::c_uint = 9;
+pub const IPPORT_SYSTAT: ::std::os::raw::c_uint = 11;
+pub const IPPORT_DAYTIME: ::std::os::raw::c_uint = 13;
+pub const IPPORT_NETSTAT: ::std::os::raw::c_uint = 15;
+pub const IPPORT_FTP: ::std::os::raw::c_uint = 21;
+pub const IPPORT_TELNET: ::std::os::raw::c_uint = 23;
+pub const IPPORT_SMTP: ::std::os::raw::c_uint = 25;
+pub const IPPORT_TIMESERVER: ::std::os::raw::c_uint = 37;
+pub const IPPORT_NAMESERVER: ::std::os::raw::c_uint = 42;
+pub const IPPORT_WHOIS: ::std::os::raw::c_uint = 43;
+pub const IPPORT_MTP: ::std::os::raw::c_uint = 57;
+pub const IPPORT_TFTP: ::std::os::raw::c_uint = 69;
+pub const IPPORT_RJE: ::std::os::raw::c_uint = 77;
+pub const IPPORT_FINGER: ::std::os::raw::c_uint = 79;
+pub const IPPORT_TTYLINK: ::std::os::raw::c_uint = 87;
+pub const IPPORT_SUPDUP: ::std::os::raw::c_uint = 95;
+pub const IPPORT_EXECSERVER: ::std::os::raw::c_uint = 512;
+pub const IPPORT_LOGINSERVER: ::std::os::raw::c_uint = 513;
+pub const IPPORT_CMDSERVER: ::std::os::raw::c_uint = 514;
+pub const IPPORT_EFSSERVER: ::std::os::raw::c_uint = 520;
+pub const IPPORT_BIFFUDP: ::std::os::raw::c_uint = 512;
+pub const IPPORT_WHOSERVER: ::std::os::raw::c_uint = 513;
+pub const IPPORT_ROUTESERVER: ::std::os::raw::c_uint = 520;
+pub const IPPORT_RESERVED: ::std::os::raw::c_uint = 1024;
+pub const IPPORT_USERRESERVED: ::std::os::raw::c_uint = 5000;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
     _bindgen_union_align: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
@@ -7706,22 +5525,6 @@ impl Default for in6_addr {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type in6_addr_t = in6_addr;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
-    pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
-}
-impl Default for sockaddr_in6 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
 #[pg_guard]
 extern "C" {
     pub static in6addr_any: in6_addr;
@@ -7730,21 +5533,40 @@ extern "C" {
 extern "C" {
     pub static in6addr_loopback: in6_addr;
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: u32,
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
+impl Default for sockaddr_in6 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -7759,303 +5581,79 @@ impl Default for ipv6_mreq {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ntohl(__netlong: u32) -> u32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *mut *mut cmsghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn ntohs(__netshort: u16) -> u16;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_append(
-        arg1: *mut cmsghdr,
-        arg2: *const __uint8_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn htonl(__hostlong: u32) -> u32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_alloc(
-        arg1: *mut cmsghdr,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> *mut __uint8_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_option_next(
-        arg1: *const cmsghdr,
-        arg2: *mut *mut __uint8_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_option_find(
-        arg1: *const cmsghdr,
-        arg2: *mut *mut __uint8_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut cmsghdr;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_add(
-        arg1: *mut cmsghdr,
-        arg2: *const in6_addr,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_lasthop(
-        arg1: *mut cmsghdr,
-        arg2: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_getaddr(arg1: *mut cmsghdr, arg2: ::std::os::raw::c_int) -> *mut in6_addr;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_getflags(
-        arg1: *const cmsghdr,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_append(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: __uint8_t,
-        arg5: socklen_t,
-        arg6: __uint8_t,
-        arg7: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_finish(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_set_val(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_next(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut __uint8_t,
-        arg5: *mut socklen_t,
-        arg6: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_find(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: __uint8_t,
-        arg5: *mut socklen_t,
-        arg6: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_get_val(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> socklen_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_add(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *const in6_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_reverse(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_getaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut in6_addr;
+    pub fn htons(__hostshort: u16) -> u16;
 }
 #[pg_guard]
 extern "C" {
     pub fn bindresvport(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr_in,
+        __sockfd: ::std::os::raw::c_int,
+        __sock_in: *mut sockaddr_in,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bindresvport_sa(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
+    pub fn bindresvport6(
+        __sockfd: ::std::os::raw::c_int,
+        __sock_in: *mut sockaddr_in6,
     ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct hostent {
-    pub h_name: *mut ::std::os::raw::c_char,
-    pub h_aliases: *mut *mut ::std::os::raw::c_char,
-    pub h_addrtype: ::std::os::raw::c_int,
-    pub h_length: ::std::os::raw::c_int,
-    pub h_addr_list: *mut *mut ::std::os::raw::c_char,
-}
-impl Default for hostent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct servent {
-    pub s_name: *mut ::std::os::raw::c_char,
-    pub s_aliases: *mut *mut ::std::os::raw::c_char,
-    pub s_port: ::std::os::raw::c_int,
-    pub s_proto: *mut ::std::os::raw::c_char,
-}
-impl Default for servent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct protoent {
-    pub p_name: *mut ::std::os::raw::c_char,
-    pub p_aliases: *mut *mut ::std::os::raw::c_char,
-    pub p_proto: ::std::os::raw::c_int,
-}
-impl Default for protoent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -8071,167 +5669,7 @@ impl Default for rpcent {
 }
 #[pg_guard]
 extern "C" {
-    pub fn endhostent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endprotoent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endservent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn freeaddrinfo(arg1: *mut addrinfo);
-}
-#[pg_guard]
-extern "C" {
-    pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getaddrinfo(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const addrinfo,
-        arg4: *mut *mut addrinfo,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent() -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnameinfo(
-        arg1: *const sockaddr,
-        arg2: socklen_t,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: socklen_t,
-        arg5: *mut ::std::os::raw::c_char,
-        arg6: socklen_t,
-        arg7: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent() -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent() -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent() -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sethostent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setprotoent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setservent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn freehostent(arg1: *mut hostent);
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipnodebyaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipnodebyname(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent() -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrpcent(stayopen: ::std::os::raw::c_int);
+    pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
@@ -8239,28 +5677,348 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn herror(arg1: *const ::std::os::raw::c_char);
+    pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn innetgr(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-        arg4: *const ::std::os::raw::c_char,
+    pub fn getrpcent() -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getnetgrent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+    pub fn getrpcbynumber_r(
+        __number: ::std::os::raw::c_int,
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcent_r(
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn herror(__str: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hostent {
+    pub h_name: *mut ::std::os::raw::c_char,
+    pub h_aliases: *mut *mut ::std::os::raw::c_char,
+    pub h_addrtype: ::std::os::raw::c_int,
+    pub h_length: ::std::os::raw::c_int,
+    pub h_addr_list: *mut *mut ::std::os::raw::c_char,
+}
+impl Default for hostent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sethostent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endhostent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent() -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyaddr(
+        __addr: *const ::std::os::raw::c_void,
+        __len: __socklen_t,
+        __type: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2(
+        __name: *const ::std::os::raw::c_char,
+        __af: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent_r(
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyaddr_r(
+        __addr: *const ::std::os::raw::c_void,
+        __len: __socklen_t,
+        __type: ::std::os::raw::c_int,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2_r(
+        __name: *const ::std::os::raw::c_char,
+        __af: ::std::os::raw::c_int,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent() -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent_r(
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr_r(
+        __net: u32,
+        __type: ::std::os::raw::c_int,
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct servent {
+    pub s_name: *mut ::std::os::raw::c_char,
+    pub s_aliases: *mut *mut ::std::os::raw::c_char,
+    pub s_port: ::std::os::raw::c_int,
+    pub s_proto: *mut ::std::os::raw::c_char,
+}
+impl Default for servent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setservent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endservent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent() -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname(
+        __name: *const ::std::os::raw::c_char,
+        __proto: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport(
+        __port: ::std::os::raw::c_int,
+        __proto: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent_r(
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __proto: *const ::std::os::raw::c_char,
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport_r(
+        __port: ::std::os::raw::c_int,
+        __proto: *const ::std::os::raw::c_char,
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct protoent {
+    pub p_name: *mut ::std::os::raw::c_char,
+    pub p_aliases: *mut *mut ::std::os::raw::c_char,
+    pub p_proto: ::std::os::raw::c_int,
+}
+impl Default for protoent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endprotoent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent() -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent_r(
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber_r(
+        __proto: ::std::os::raw::c_int,
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -8268,58 +6026,187 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+    pub fn getnetgrent(
+        __hostp: *mut *mut ::std::os::raw::c_char,
+        __userp: *mut *mut ::std::os::raw::c_char,
+        __domainp: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn innetgr(
+        __netgroup: *const ::std::os::raw::c_char,
+        __host: *const ::std::os::raw::c_char,
+        __user: *const ::std::os::raw::c_char,
+        __domain: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetgrent_r(
+        __hostp: *mut *mut ::std::os::raw::c_char,
+        __userp: *mut *mut ::std::os::raw::c_char,
+        __domainp: *mut *mut ::std::os::raw::c_char,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rcmd(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_ushort,
+        __locuser: *const ::std::os::raw::c_char,
+        __remuser: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rcmd_af(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_ushort,
+        __locuser: *const ::std::os::raw::c_char,
+        __remuser: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rexec(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_int,
+        __name: *const ::std::os::raw::c_char,
+        __pass: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rexec_af(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_int,
+        __name: *const ::std::os::raw::c_char,
+        __pass: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ruserok(
+        __rhost: *const ::std::os::raw::c_char,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ruserok_af(
+        __rhost: *const ::std::os::raw::c_char,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iruserok(
+        __raddr: u32,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iruserok_af(
+        __raddr: *const ::std::os::raw::c_void,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rresvport_af(
+        __alport: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct passwd {
-    pub pw_name: *mut ::std::os::raw::c_char,
-    pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: uid_t,
-    pub pw_gid: gid_t,
-    pub pw_change: __darwin_time_t,
-    pub pw_class: *mut ::std::os::raw::c_char,
-    pub pw_gecos: *mut ::std::os::raw::c_char,
-    pub pw_dir: *mut ::std::os::raw::c_char,
-    pub pw_shell: *mut ::std::os::raw::c_char,
-    pub pw_expire: __darwin_time_t,
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
 }
-impl Default for passwd {
+impl Default for addrinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwuid(arg1: uid_t) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuid_r(
-        arg1: uid_t,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
+    pub fn getaddrinfo(
+        __name: *const ::std::os::raw::c_char,
+        __service: *const ::std::os::raw::c_char,
+        __req: *const addrinfo,
+        __pai: *mut *mut addrinfo,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwnam_r(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
-    ) -> ::std::os::raw::c_int;
+    pub fn freeaddrinfo(__ai: *mut addrinfo);
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwent() -> *mut passwd;
+    pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnameinfo(
+        __sa: *const sockaddr,
+        __salen: socklen_t,
+        __host: *mut ::std::os::raw::c_char,
+        __hostlen: socklen_t,
+        __serv: *mut ::std::os::raw::c_char,
+        __servlen: socklen_t,
+        __flags: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct passwd {
+    pub pw_name: *mut ::std::os::raw::c_char,
+    pub pw_passwd: *mut ::std::os::raw::c_char,
+    pub pw_uid: __uid_t,
+    pub pw_gid: __gid_t,
+    pub pw_gecos: *mut ::std::os::raw::c_char,
+    pub pw_dir: *mut ::std::os::raw::c_char,
+    pub pw_shell: *mut ::std::os::raw::c_char,
+}
+impl Default for passwd {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
@@ -8329,86 +6216,63 @@ extern "C" {
 extern "C" {
     pub fn endpwent();
 }
-pub type uuid_t = __darwin_uuid_t;
-pub type uuid_string_t = __darwin_uuid_string_t;
 #[pg_guard]
 extern "C" {
-    pub static UUID_NULL: uuid_t;
+    pub fn getpwent() -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
+    pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_compare(
-        uu1: *mut ::std::os::raw::c_uchar,
-        uu2: *mut ::std::os::raw::c_uchar,
+    pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwent_r(
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_early_random(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_parse(
-        in_: *mut ::std::os::raw::c_char,
-        uu: *mut ::std::os::raw::c_uchar,
+    pub fn getpwuid_r(
+        __uid: __uid_t,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+    pub fn getpwnam_r(
+        __name: *const ::std::os::raw::c_char,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_unparse_lower(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_unparse_upper(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn user_from_uid(arg1: uid_t, arg2: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuuid_r(
-        arg1: *mut ::std::os::raw::c_uchar,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
+    pub fn fgetpwent_r(
+        __stream: *mut FILE,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -8675,6 +6539,34 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpeereid(
+        sock: ::std::os::raw::c_int,
+        uid: *mut uid_t,
+        gid: *mut gid_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
     pub fn pqStrerror(
         errnum: ::std::os::raw::c_int,
         strerrbuf: *mut ::std::os::raw::c_char,
@@ -8801,28 +6693,39 @@ extern "C" {
         include_command_not_found: bool,
     ) -> bool;
 }
-pub type jmp_buf = [::std::os::raw::c_int; 37usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 38usize];
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
+}
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
-    pub fn setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
+    pub fn __sigsetjmp(
+        __env: *mut __jmp_buf_tag,
+        __savemask: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn _setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
+    pub fn longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmperror();
+    pub fn _longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
 }
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
     pub fn errstart(
@@ -11852,239 +9755,83 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
+#[pg_guard]
+extern "C" {
+    pub fn fcntl(
+        __fd: ::std::os::raw::c_int,
+        __cmd: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fbootstraptransfer {
-    pub fbt_offset: off_t,
-    pub fbt_length: usize,
-    pub fbt_buffer: *mut ::std::os::raw::c_void,
-}
-impl Default for fbootstraptransfer {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fbootstraptransfer_t = fbootstraptransfer;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn open(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __oflag: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn openat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
+        __fd: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __oflag: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn creat(arg1: *const ::std::os::raw::c_char, arg2: mode_t) -> ::std::os::raw::c_int;
+    pub fn creat(__file: *const ::std::os::raw::c_char, __mode: mode_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fcntl(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        ...
+    pub fn lockf(
+        __fd: ::std::os::raw::c_int,
+        __cmd: ::std::os::raw::c_int,
+        __len: off_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn openx_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: filesec_t,
+    pub fn posix_fadvise(
+        __fd: ::std::os::raw::c_int,
+        __offset: off_t,
+        __len: off_t,
+        __advise: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn open_dprotected_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flock(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_init() -> filesec_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_free(arg1: filesec_t);
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_get_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_query_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_set_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *const ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_unset_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
+    pub fn posix_fallocate(
+        __fd: ::std::os::raw::c_int,
+        __offset: off_t,
+        __len: off_t,
     ) -> ::std::os::raw::c_int;
 }
 pub type XLogRecPtr = uint64;
@@ -13919,32 +11666,18 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-#[pg_guard]
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[pg_guard]
 extern "C" {
@@ -13952,48 +11685,88 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+    pub fn time(__timer: *mut time_t) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+    pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime(arg1: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime(arg1: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktime(arg1: *mut tm) -> time_t;
+    pub fn mktime(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn strftime(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: *const ::std::os::raw::c_char,
-        arg4: *const tm,
+        __s: *mut ::std::os::raw::c_char,
+        __maxsize: usize,
+        __format: *const ::std::os::raw::c_char,
+        __tp: *const tm,
     ) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strptime(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut tm,
+    pub fn strftime_l(
+        __s: *mut ::std::os::raw::c_char,
+        __maxsize: usize,
+        __format: *const ::std::os::raw::c_char,
+        __tp: *const tm,
+        __loc: locale_t,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime(__timer: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime(__timer: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime_r(
+        __tp: *const tm,
+        __buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn time(arg1: *mut time_t) -> time_t;
+    pub fn ctime_r(
+        __timer: *const time_t,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[pg_guard]
 extern "C" {
@@ -14001,59 +11774,31 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn asctime_r(
-        arg1: *const tm,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub static mut daylight: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctime_r(
-        arg1: *const time_t,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub static mut timezone: ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+    pub fn timegm(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+    pub fn timelocal(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix2time(arg1: time_t) -> time_t;
+    pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tzsetwall();
+    pub fn nanosleep(
+        __requested_time: *const timespec,
+        __remaining: *mut timespec,
+    ) -> ::std::os::raw::c_int;
 }
-#[pg_guard]
-extern "C" {
-    pub fn time2posix(arg1: time_t) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timelocal(arg1: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timegm(arg1: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanosleep(__rqtp: *const timespec, __rmtp: *mut timespec) -> ::std::os::raw::c_int;
-}
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn clock_getres(__clock_id: clockid_t, __res: *mut timespec) -> ::std::os::raw::c_int;
@@ -14064,15 +11809,56 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-}
-#[pg_guard]
-extern "C" {
     pub fn clock_settime(__clock_id: clockid_t, __tp: *const timespec) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timespec_get(ts: *mut timespec, base: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn clock_nanosleep(
+        __clock_id: clockid_t,
+        __flags: ::std::os::raw::c_int,
+        __req: *const timespec,
+        __rem: *mut timespec,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clock_getcpuclockid(__pid: pid_t, __clock_id: *mut clockid_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_create(
+        __clock_id: clockid_t,
+        __evp: *mut sigevent,
+        __timerid: *mut timer_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_settime(
+        __timerid: timer_t,
+        __flags: ::std::os::raw::c_int,
+        __value: *const itimerspec,
+        __ovalue: *mut itimerspec,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_gettime(__timerid: timer_t, __value: *mut itimerspec) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timespec_get(
+        __ts: *mut timespec,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 pub type instr_time = timespec;
 #[repr(C)]
@@ -20388,104 +18174,82 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const DT_UNKNOWN: ::std::os::raw::c_uint = 0;
+pub const DT_FIFO: ::std::os::raw::c_uint = 1;
+pub const DT_CHR: ::std::os::raw::c_uint = 2;
+pub const DT_DIR: ::std::os::raw::c_uint = 4;
+pub const DT_BLK: ::std::os::raw::c_uint = 6;
+pub const DT_REG: ::std::os::raw::c_uint = 8;
+pub const DT_LNK: ::std::os::raw::c_uint = 10;
+pub const DT_SOCK: ::std::os::raw::c_uint = 12;
+pub const DT_WHT: ::std::os::raw::c_uint = 14;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+pub type DIR = __dirstream;
+#[pg_guard]
+extern "C" {
+    pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+    pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_opendir$INODE64"]
-    pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+    pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_readdir$INODE64"]
-    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+    pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_readdir_r$INODE64"]
     pub fn readdir_r(
-        arg1: *mut DIR,
-        arg2: *mut dirent,
-        arg3: *mut *mut dirent,
+        __dirp: *mut DIR,
+        __entry: *mut dirent,
+        __result: *mut *mut dirent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_rewinddir$INODE64"]
-    pub fn rewinddir(arg1: *mut DIR);
+    pub fn rewinddir(__dirp: *mut DIR);
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_seekdir$INODE64"]
-    pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+    pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_telldir$INODE64"]
-    pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+    pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_fdopendir$INODE64"]
-    pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+    pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_alphasort$INODE64"]
-    pub fn alphasort(arg1: *mut *const dirent, arg2: *mut *const dirent) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_scandir$INODE64"]
     pub fn scandir(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut *mut dirent,
-        arg3: ::std::option::Option<
+        __dir: *const ::std::os::raw::c_char,
+        __namelist: *mut *mut *mut dirent,
+        __selector: ::std::option::Option<
             unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
         >,
-        arg4: ::std::option::Option<
+        __cmp: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut *const dirent,
                 arg2: *mut *const dirent,
@@ -20495,29 +18259,16 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_scandir_b$INODE64"]
-    pub fn scandir_b(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut *mut dirent,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
+    pub fn alphasort(__e1: *mut *const dirent, __e2: *mut *const dirent) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
     pub fn getdirentries(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}___opendir2$INODE64"]
-    pub fn __opendir2(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int)
-        -> *mut DIR;
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+        __basep: *mut __off_t,
+    ) -> __ssize_t;
 }
 pub type FileName = *mut ::std::os::raw::c_char;
 pub type File = ::std::os::raw::c_int;
@@ -23838,160 +21589,651 @@ extern "C" {
         nulls: *mut *mut bool,
     ) -> ::std::os::raw::c_int;
 }
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
+    _bindgen_union_align: u64,
+}
+impl Default for sigval {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+    _bindgen_union_align: [u64; 14usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+    _bindgen_union_align: [u64; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub const SI_ASYNCNL: ::std::os::raw::c_int = -60;
+pub const SI_DETHREAD: ::std::os::raw::c_int = -7;
+pub const SI_TKILL: ::std::os::raw::c_int = -6;
+pub const SI_SIGIO: ::std::os::raw::c_int = -5;
+pub const SI_ASYNCIO: ::std::os::raw::c_int = -4;
+pub const SI_MESGQ: ::std::os::raw::c_int = -3;
+pub const SI_TIMER: ::std::os::raw::c_int = -2;
+pub const SI_QUEUE: ::std::os::raw::c_int = -1;
+pub const SI_USER: ::std::os::raw::c_int = 0;
+pub const SI_KERNEL: ::std::os::raw::c_int = 128;
+pub type _bindgen_ty_9 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: ::std::os::raw::c_uint = 1;
+pub const ILL_ILLOPN: ::std::os::raw::c_uint = 2;
+pub const ILL_ILLADR: ::std::os::raw::c_uint = 3;
+pub const ILL_ILLTRP: ::std::os::raw::c_uint = 4;
+pub const ILL_PRVOPC: ::std::os::raw::c_uint = 5;
+pub const ILL_PRVREG: ::std::os::raw::c_uint = 6;
+pub const ILL_COPROC: ::std::os::raw::c_uint = 7;
+pub const ILL_BADSTK: ::std::os::raw::c_uint = 8;
+pub const ILL_BADIADDR: ::std::os::raw::c_uint = 9;
+pub type _bindgen_ty_10 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: ::std::os::raw::c_uint = 1;
+pub const FPE_INTOVF: ::std::os::raw::c_uint = 2;
+pub const FPE_FLTDIV: ::std::os::raw::c_uint = 3;
+pub const FPE_FLTOVF: ::std::os::raw::c_uint = 4;
+pub const FPE_FLTUND: ::std::os::raw::c_uint = 5;
+pub const FPE_FLTRES: ::std::os::raw::c_uint = 6;
+pub const FPE_FLTINV: ::std::os::raw::c_uint = 7;
+pub const FPE_FLTSUB: ::std::os::raw::c_uint = 8;
+pub const FPE_FLTUNK: ::std::os::raw::c_uint = 14;
+pub const FPE_CONDTRAP: ::std::os::raw::c_uint = 15;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: ::std::os::raw::c_uint = 1;
+pub const SEGV_ACCERR: ::std::os::raw::c_uint = 2;
+pub const SEGV_BNDERR: ::std::os::raw::c_uint = 3;
+pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
+pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
+pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
+pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
+pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
+pub const BUS_OBJERR: ::std::os::raw::c_uint = 3;
+pub const BUS_MCEERR_AR: ::std::os::raw::c_uint = 4;
+pub const BUS_MCEERR_AO: ::std::os::raw::c_uint = 5;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: ::std::os::raw::c_uint = 1;
+pub const CLD_KILLED: ::std::os::raw::c_uint = 2;
+pub const CLD_DUMPED: ::std::os::raw::c_uint = 3;
+pub const CLD_TRAPPED: ::std::os::raw::c_uint = 4;
+pub const CLD_STOPPED: ::std::os::raw::c_uint = 5;
+pub const CLD_CONTINUED: ::std::os::raw::c_uint = 6;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+pub const POLL_IN: ::std::os::raw::c_uint = 1;
+pub const POLL_OUT: ::std::os::raw::c_uint = 2;
+pub const POLL_MSG: ::std::os::raw::c_uint = 3;
+pub const POLL_ERR: ::std::os::raw::c_uint = 4;
+pub const POLL_PRI: ::std::os::raw::c_uint = 5;
+pub const POLL_HUP: ::std::os::raw::c_uint = 6;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+    _bindgen_union_align: [u64; 6usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: ::std::os::raw::c_uint = 0;
+pub const SIGEV_NONE: ::std::os::raw::c_uint = 1;
+pub const SIGEV_THREAD: ::std::os::raw::c_uint = 2;
+pub const SIGEV_THREAD_ID: ::std::os::raw::c_uint = 4;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[pg_guard]
 extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+    pub fn __sysv_signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t)
+        -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+    pub fn signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bsd_signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
+    pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ssignal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_kill(arg1: pthread_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_sigmask(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigset_t,
-        arg3: *mut sigset_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaction(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigaction,
-        arg3: *mut sigaction,
-    ) -> ::std::os::raw::c_int;
+    pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaddset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
+    pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigdelset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn siggetmask() -> ::std::os::raw::c_int;
+}
+pub type sig_t = __sighandler_t;
+#[pg_guard]
+extern "C" {
+    pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn siginterrupt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigismember(arg1: *const sigset_t, arg2: ::std::os::raw::c_int)
+    pub fn sigaddset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigdelset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigismember(
+        __set: *const sigset_t,
+        __signo: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+    _bindgen_union_align: u64,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
     pub fn sigprocmask(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigset_t,
-        arg3: *mut sigset_t,
+        __how: ::std::os::raw::c_int,
+        __set: *const sigset_t,
+        __oset: *mut sigset_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigset(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
+    pub fn sigaction(
+        __sig: ::std::os::raw::c_int,
+        __act: *const sigaction,
+        __oact: *mut sigaction,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn sigwait(
-        arg1: *const sigset_t,
-        arg2: *mut ::std::os::raw::c_int,
+        __set: *const sigset_t,
+        __sig: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
+    pub fn sigwaitinfo(__set: *const sigset_t, __info: *mut siginfo_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigvec(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sigvec,
-        arg3: *mut sigvec,
+    pub fn sigtimedwait(
+        __set: *const sigset_t,
+        __info: *mut siginfo_t,
+        __timeout: *const timespec,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigqueue(
+        __pid: __pid_t,
+        __sig: ::std::os::raw::c_int,
+        __val: sigval,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+    _bindgen_union_align: u64,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigreturn(__scp: *mut sigcontext) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn siginterrupt(
+        __sig: ::std::os::raw::c_int,
+        __interrupt: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub const SS_ONSTACK: ::std::os::raw::c_uint = 1;
+pub const SS_DISABLE: ::std::os::raw::c_uint = 2;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+#[pg_guard]
+extern "C" {
+    pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigstack(__ss: *mut sigstack, __oss: *mut sigstack) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pthread_sigmask(
+        __how: ::std::os::raw::c_int,
+        __newmask: *const __sigset_t,
+        __oldmask: *mut __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pthread_kill(
+        __threadid: pthread_t,
+        __signo: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
 }
 pub type pg_time_t = int64;
 #[repr(C)]
@@ -24595,9 +22837,8 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -49449,779 +47690,331 @@ pub type float_t = f32;
 pub type double_t = f64;
 #[pg_guard]
 extern "C" {
-    pub fn __math_errhandling() -> ::std::os::raw::c_int;
+    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
+    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosf(arg1: f32) -> f32;
+    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acos(arg1: f64) -> f64;
+    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosl(arg1: u128) -> u128;
+    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinf(arg1: f32) -> f32;
+    pub fn acos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asin(arg1: f64) -> f64;
+    pub fn __acos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinl(arg1: u128) -> u128;
+    pub fn asin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanf(arg1: f32) -> f32;
+    pub fn __asin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan(arg1: f64) -> f64;
+    pub fn atan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanl(arg1: u128) -> u128;
+    pub fn __atan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+    pub fn atan2(__y: f64, __x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2(arg1: f64, arg2: f64) -> f64;
+    pub fn __atan2(__y: f64, __x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
+    pub fn cos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosf(arg1: f32) -> f32;
+    pub fn __cos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cos(arg1: f64) -> f64;
+    pub fn sin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosl(arg1: u128) -> u128;
+    pub fn __sin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinf(arg1: f32) -> f32;
+    pub fn tan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sin(arg1: f64) -> f64;
+    pub fn __tan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinl(arg1: u128) -> u128;
+    pub fn cosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanf(arg1: f32) -> f32;
+    pub fn __cosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tan(arg1: f64) -> f64;
+    pub fn sinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanl(arg1: u128) -> u128;
+    pub fn __sinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acoshf(arg1: f32) -> f32;
+    pub fn tanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosh(arg1: f64) -> f64;
+    pub fn __tanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acoshl(arg1: u128) -> u128;
+    pub fn acosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinhf(arg1: f32) -> f32;
+    pub fn __acosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinh(arg1: f64) -> f64;
+    pub fn asinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinhl(arg1: u128) -> u128;
+    pub fn __asinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanhf(arg1: f32) -> f32;
+    pub fn atanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanh(arg1: f64) -> f64;
+    pub fn __atanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanhl(arg1: u128) -> u128;
+    pub fn exp(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn coshf(arg1: f32) -> f32;
+    pub fn __exp(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosh(arg1: f64) -> f64;
+    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn coshl(arg1: u128) -> u128;
+    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinhf(arg1: f32) -> f32;
+    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinh(arg1: f64) -> f64;
+    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinhl(arg1: u128) -> u128;
+    pub fn log(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanhf(arg1: f32) -> f32;
+    pub fn __log(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanh(arg1: f64) -> f64;
+    pub fn log10(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanhl(arg1: u128) -> u128;
+    pub fn __log10(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expf(arg1: f32) -> f32;
+    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp(arg1: f64) -> f64;
+    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expl(arg1: u128) -> u128;
+    pub fn expm1(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2f(arg1: f32) -> f32;
+    pub fn __expm1(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2(arg1: f64) -> f64;
+    pub fn log1p(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2l(arg1: u128) -> u128;
+    pub fn __log1p(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1f(arg1: f32) -> f32;
+    pub fn logb(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1(arg1: f64) -> f64;
+    pub fn __logb(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1l(arg1: u128) -> u128;
+    pub fn exp2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logf(arg1: f32) -> f32;
+    pub fn __exp2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log(arg1: f64) -> f64;
+    pub fn log2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logl(arg1: u128) -> u128;
+    pub fn __log2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10f(arg1: f32) -> f32;
+    pub fn pow(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10(arg1: f64) -> f64;
+    pub fn __pow(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10l(arg1: u128) -> u128;
+    pub fn sqrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2f(arg1: f32) -> f32;
+    pub fn __sqrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2(arg1: f64) -> f64;
+    pub fn hypot(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2l(arg1: u128) -> u128;
+    pub fn __hypot(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1pf(arg1: f32) -> f32;
+    pub fn cbrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1p(arg1: f64) -> f64;
+    pub fn __cbrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1pl(arg1: u128) -> u128;
+    pub fn ceil(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logbf(arg1: f32) -> f32;
+    pub fn __ceil(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logb(arg1: f64) -> f64;
+    pub fn fabs(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logbl(arg1: u128) -> u128;
+    pub fn __fabs(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+    pub fn floor(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn __floor(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
+    pub fn fmod(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn __fmod(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
+    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+    pub fn drem(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn __drem(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
+    pub fn significand(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __significand(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn copysign(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
+    pub fn __copysign(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabs(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrt(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypot(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pow(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrt(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erff(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erf(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammal(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammal(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceilf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceil(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceill(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floor(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyint(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rint(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn round(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn trunc(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmod(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainder(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysign(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdim(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmax(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmin(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __inff() -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __inf() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __infl() -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nan() -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp10f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp10(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cospif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cospi(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinpif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinpi(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanpif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanpi(arg1: f64) -> f64;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincosf_stret(arg1: f32) -> __float2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincos_stret(arg1: f64) -> __double2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincospif_stret(arg1: f32) -> __float2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincospi_stret(arg1: f64) -> __double2;
+    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -50229,7 +48022,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __j0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn j1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -50237,7 +48038,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn y0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -50245,31 +48054,47 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __y1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalb(arg1: f64, arg2: f64) -> f64;
+    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut signgam: ::std::os::raw::c_int;
+    pub fn erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn __erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn drem(arg1: f64, arg2: f64) -> f64;
+    pub fn __erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn lgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -50277,22 +48102,1354 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn significand(arg1: f64) -> f64;
+    pub fn __gamma(arg1: f64) -> f64;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
+#[pg_guard]
+extern "C" {
+    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
 }
-impl Default for exception {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+#[pg_guard]
+extern "C" {
+    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
 }
+#[pg_guard]
+extern "C" {
+    pub fn rint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafter(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafter(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttoward(__x: f64, __y: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainder(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainder(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn round(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __round(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn trunc(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __trunc(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdim(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdim(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmax(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmax(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmin(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmin(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalb(__x: f64, __n: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalb(__x: f64, __n: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atan2f(__y: f32, __x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atan2f(__y: f32, __x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn coshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __coshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acoshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acoshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log10f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log10f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expm1f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expm1f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log1pf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log1pf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logbf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logbf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn exp2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn powf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __powf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sqrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sqrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn hypotf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __hypotf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cbrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cbrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ceilf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ceilf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fabsf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fabsf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn floorf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __floorf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmodf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmodf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dremf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __dremf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significandf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __significandf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn copysignf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __copysignf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erff(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erff(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __gammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainderf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainderf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __roundf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn truncf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __truncf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdimf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdimf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fminf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbf(__x: f32, __n: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbf(__x: f32, __n: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atan2l(__y: u128, __x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atan2l(__y: u128, __x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn coshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __coshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acoshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acoshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log10l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log10l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expm1l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expm1l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log1pl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log1pl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logbl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logbl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn exp2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn powl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __powl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sqrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sqrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn hypotl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __hypotl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cbrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cbrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ceill(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ceill(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fabsl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fabsl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn floorl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __floorl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmodl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmodl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dreml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __dreml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significandl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __significandl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn copysignl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __copysignl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfcl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfcl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __gammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainderl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __roundl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn truncl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __truncl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdiml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fminl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbl(__x: u128, __n: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbl(__x: u128, __n: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut signgam: ::std::os::raw::c_int;
+}
+pub const FP_NAN: ::std::os::raw::c_uint = 0;
+pub const FP_INFINITE: ::std::os::raw::c_uint = 1;
+pub const FP_ZERO: ::std::os::raw::c_uint = 2;
+pub const FP_SUBNORMAL: ::std::os::raw::c_uint = 3;
+pub const FP_NORMAL: ::std::os::raw::c_uint = 4;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
 pub type DateADT = int32;
 pub type TimeADT = int64;
 #[repr(C)]
@@ -51973,6 +51130,11 @@ impl Default for __va_list_tag {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/pgx-pg-sys/src/pg10.rs
+++ b/pgx-pg-sys/src/pg10.rs
@@ -187,24 +187,23 @@ pub const DEF_PGPORT_STR: &'static [u8; 6usize] = b"28810\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
 pub const FLOAT4PASSBYVAL: u32 = 1;
 pub const FLOAT8PASSBYVAL: u32 = 1;
-pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_CBRT: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
 pub const HAVE_CRYPT: u32 = 1;
-pub const HAVE_CRYPT_H: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 1;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 0;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
 pub const HAVE_DECL_SNPRINTF: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 0;
-pub const HAVE_DECL_STRLCPY: u32 = 0;
+pub const HAVE_DECL_STRLCAT: u32 = 1;
+pub const HAVE_DECL_STRLCPY: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DECL_VSNPRINTF: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
+pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -214,11 +213,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
-pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
+pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -228,6 +227,7 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTPTR_T: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
+pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
 pub const HAVE_ISINF: u32 = 1;
@@ -238,6 +238,7 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
 pub const HAVE_LONG_LONG_INT: u32 = 1;
+pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMMOVE: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
@@ -245,9 +246,8 @@ pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
-pub const HAVE_POSIX_FADVISE: u32 = 1;
-pub const HAVE_POSIX_FALLOCATE: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
+pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
 pub const HAVE_READLINE_HISTORY_H: u32 = 1;
@@ -257,7 +257,6 @@ pub const HAVE_RINT: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
-pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SNPRINTF: u32 = 1;
@@ -269,26 +268,30 @@ pub const HAVE_STRERROR: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
+pub const HAVE_STRLCAT: u32 = 1;
+pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRONG_RANDOM: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
+pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
+pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
-pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
-pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
+pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
+pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TM_ZONE: u32 = 1;
@@ -296,6 +299,7 @@ pub const HAVE_TOWLOWER: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
 pub const HAVE_TZNAME: u32 = 1;
 pub const HAVE_UINTPTR_T: u32 = 1;
+pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNIX_SOCKETS: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
@@ -307,6 +311,7 @@ pub const HAVE_UTIME_H: u32 = 1;
 pub const HAVE_VSNPRINTF: u32 = 1;
 pub const HAVE_WCHAR_H: u32 = 1;
 pub const HAVE_WCSTOMBS: u32 = 1;
+pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP32: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP64: u32 = 1;
@@ -317,6 +322,7 @@ pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const HAVE__VA_ARGS: u32 = 1;
 pub const INT64_MODIFIER: &'static [u8; 2usize] = b"l\0";
+pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &'static [u8; 26usize] = b"pgsql-bugs@postgresql.org\0";
@@ -329,21 +335,22 @@ pub const PG_KRB_SRVNAM: &'static [u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &'static [u8; 3usize] = b"10\0";
 pub const PG_VERSION: &'static [u8; 6usize] = b"10.16\0";
 pub const PG_VERSION_NUM: u32 = 100016;
-pub const PG_VERSION_STR: &'static [u8; 78usize] =
-    b"PostgreSQL 10.16 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.0, 64-bit\0";
+pub const PG_VERSION_STR : & 'static [u8 ; 114usize] = b"PostgreSQL 10.16 on x86_64-apple-darwin20.3.0, compiled by Apple clang version 12.0.5 (clang-1205.0.22.9), 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_LONG: u32 = 8;
 pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const STRERROR_R_INT: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
+pub const USE_SYSV_SEMAPHORES: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
+pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -358,211 +365,510 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &'static [u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &'static [u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const _STDIO_H: u32 = 1;
-pub const _FEATURES_H: u32 = 1;
-pub const _DEFAULT_SOURCE: u32 = 1;
-pub const __GLIBC_USE_ISOC2X: u32 = 0;
-pub const __USE_ISOC11: u32 = 1;
-pub const __USE_ISOC99: u32 = 1;
-pub const __USE_ISOC95: u32 = 1;
-pub const __USE_POSIX_IMPLICITLY: u32 = 1;
-pub const _POSIX_SOURCE: u32 = 1;
-pub const _POSIX_C_SOURCE: u32 = 200809;
-pub const __USE_POSIX: u32 = 1;
-pub const __USE_POSIX2: u32 = 1;
-pub const __USE_POSIX199309: u32 = 1;
-pub const __USE_POSIX199506: u32 = 1;
-pub const __USE_XOPEN2K: u32 = 1;
-pub const __USE_XOPEN2K8: u32 = 1;
-pub const _ATFILE_SOURCE: u32 = 1;
-pub const __USE_MISC: u32 = 1;
-pub const __USE_ATFILE: u32 = 1;
-pub const __USE_FORTIFY_LEVEL: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const _STDC_PREDEF_H: u32 = 1;
-pub const __STDC_IEC_559__: u32 = 1;
-pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
-pub const __STDC_ISO_10646__: u32 = 201706;
-pub const __GNU_LIBRARY__: u32 = 6;
-pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 32;
-pub const _SYS_CDEFS_H: u32 = 1;
-pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
-pub const __HAVE_GENERIC_SELECTION: u32 = 1;
-pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const _BITS_TYPES_H: u32 = 1;
-pub const __TIMESIZE: u32 = 64;
-pub const _BITS_TYPESIZES_H: u32 = 1;
-pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
-pub const __INO_T_MATCHES_INO64_T: u32 = 1;
-pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
-pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
-pub const __FD_SETSIZE: u32 = 1024;
-pub const _BITS_TIME64_H: u32 = 1;
-pub const _____fpos_t_defined: u32 = 1;
-pub const ____mbstate_t_defined: u32 = 1;
-pub const _____fpos64_t_defined: u32 = 1;
-pub const ____FILE_defined: u32 = 1;
-pub const __FILE_defined: u32 = 1;
-pub const __struct_FILE_defined: u32 = 1;
-pub const _IO_EOF_SEEN: u32 = 16;
-pub const _IO_ERR_SEEN: u32 = 32;
-pub const _IO_USER_LOCK: u32 = 32768;
+pub const __darwin__: u32 = 1;
+pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
+pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
+pub const __DARWIN_UNIX03: u32 = 1;
+pub const __DARWIN_64_BIT_INO_T: u32 = 1;
+pub const __DARWIN_VERS_1050: u32 = 1;
+pub const __DARWIN_NON_CANCELABLE: u32 = 0;
+pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
+pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
+pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
+pub const __DARWIN_C_ANSI: u32 = 4096;
+pub const __DARWIN_C_FULL: u32 = 900000;
+pub const __DARWIN_C_LEVEL: u32 = 900000;
+pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
+pub const __DARWIN_NO_LONG_LONG: u32 = 0;
+pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
+pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
+pub const __API_TO_BE_DEPRECATED: u32 = 100000;
+pub const __MAC_10_0: u32 = 1000;
+pub const __MAC_10_1: u32 = 1010;
+pub const __MAC_10_2: u32 = 1020;
+pub const __MAC_10_3: u32 = 1030;
+pub const __MAC_10_4: u32 = 1040;
+pub const __MAC_10_5: u32 = 1050;
+pub const __MAC_10_6: u32 = 1060;
+pub const __MAC_10_7: u32 = 1070;
+pub const __MAC_10_8: u32 = 1080;
+pub const __MAC_10_9: u32 = 1090;
+pub const __MAC_10_10: u32 = 101000;
+pub const __MAC_10_10_2: u32 = 101002;
+pub const __MAC_10_10_3: u32 = 101003;
+pub const __MAC_10_11: u32 = 101100;
+pub const __MAC_10_11_2: u32 = 101102;
+pub const __MAC_10_11_3: u32 = 101103;
+pub const __MAC_10_11_4: u32 = 101104;
+pub const __MAC_10_12: u32 = 101200;
+pub const __MAC_10_12_1: u32 = 101201;
+pub const __MAC_10_12_2: u32 = 101202;
+pub const __MAC_10_12_4: u32 = 101204;
+pub const __MAC_10_13: u32 = 101300;
+pub const __MAC_10_13_1: u32 = 101301;
+pub const __MAC_10_13_2: u32 = 101302;
+pub const __MAC_10_13_4: u32 = 101304;
+pub const __MAC_10_14: u32 = 101400;
+pub const __MAC_10_14_1: u32 = 101401;
+pub const __MAC_10_14_4: u32 = 101404;
+pub const __MAC_10_14_6: u32 = 101406;
+pub const __MAC_10_15: u32 = 101500;
+pub const __MAC_10_15_1: u32 = 101501;
+pub const __MAC_10_15_4: u32 = 101504;
+pub const __MAC_10_16: u32 = 101600;
+pub const __MAC_11_0: u32 = 110000;
+pub const __MAC_11_1: u32 = 110100;
+pub const __IPHONE_2_0: u32 = 20000;
+pub const __IPHONE_2_1: u32 = 20100;
+pub const __IPHONE_2_2: u32 = 20200;
+pub const __IPHONE_3_0: u32 = 30000;
+pub const __IPHONE_3_1: u32 = 30100;
+pub const __IPHONE_3_2: u32 = 30200;
+pub const __IPHONE_4_0: u32 = 40000;
+pub const __IPHONE_4_1: u32 = 40100;
+pub const __IPHONE_4_2: u32 = 40200;
+pub const __IPHONE_4_3: u32 = 40300;
+pub const __IPHONE_5_0: u32 = 50000;
+pub const __IPHONE_5_1: u32 = 50100;
+pub const __IPHONE_6_0: u32 = 60000;
+pub const __IPHONE_6_1: u32 = 60100;
+pub const __IPHONE_7_0: u32 = 70000;
+pub const __IPHONE_7_1: u32 = 70100;
+pub const __IPHONE_8_0: u32 = 80000;
+pub const __IPHONE_8_1: u32 = 80100;
+pub const __IPHONE_8_2: u32 = 80200;
+pub const __IPHONE_8_3: u32 = 80300;
+pub const __IPHONE_8_4: u32 = 80400;
+pub const __IPHONE_9_0: u32 = 90000;
+pub const __IPHONE_9_1: u32 = 90100;
+pub const __IPHONE_9_2: u32 = 90200;
+pub const __IPHONE_9_3: u32 = 90300;
+pub const __IPHONE_10_0: u32 = 100000;
+pub const __IPHONE_10_1: u32 = 100100;
+pub const __IPHONE_10_2: u32 = 100200;
+pub const __IPHONE_10_3: u32 = 100300;
+pub const __IPHONE_11_0: u32 = 110000;
+pub const __IPHONE_11_1: u32 = 110100;
+pub const __IPHONE_11_2: u32 = 110200;
+pub const __IPHONE_11_3: u32 = 110300;
+pub const __IPHONE_11_4: u32 = 110400;
+pub const __IPHONE_12_0: u32 = 120000;
+pub const __IPHONE_12_1: u32 = 120100;
+pub const __IPHONE_12_2: u32 = 120200;
+pub const __IPHONE_12_3: u32 = 120300;
+pub const __IPHONE_12_4: u32 = 120400;
+pub const __IPHONE_13_0: u32 = 130000;
+pub const __IPHONE_13_1: u32 = 130100;
+pub const __IPHONE_13_2: u32 = 130200;
+pub const __IPHONE_13_3: u32 = 130300;
+pub const __IPHONE_13_4: u32 = 130400;
+pub const __IPHONE_13_5: u32 = 130500;
+pub const __IPHONE_13_6: u32 = 130600;
+pub const __IPHONE_13_7: u32 = 130700;
+pub const __IPHONE_14_0: u32 = 140000;
+pub const __IPHONE_14_1: u32 = 140100;
+pub const __IPHONE_14_2: u32 = 140200;
+pub const __IPHONE_14_3: u32 = 140300;
+pub const __TVOS_9_0: u32 = 90000;
+pub const __TVOS_9_1: u32 = 90100;
+pub const __TVOS_9_2: u32 = 90200;
+pub const __TVOS_10_0: u32 = 100000;
+pub const __TVOS_10_0_1: u32 = 100001;
+pub const __TVOS_10_1: u32 = 100100;
+pub const __TVOS_10_2: u32 = 100200;
+pub const __TVOS_11_0: u32 = 110000;
+pub const __TVOS_11_1: u32 = 110100;
+pub const __TVOS_11_2: u32 = 110200;
+pub const __TVOS_11_3: u32 = 110300;
+pub const __TVOS_11_4: u32 = 110400;
+pub const __TVOS_12_0: u32 = 120000;
+pub const __TVOS_12_1: u32 = 120100;
+pub const __TVOS_12_2: u32 = 120200;
+pub const __TVOS_12_3: u32 = 120300;
+pub const __TVOS_12_4: u32 = 120400;
+pub const __TVOS_13_0: u32 = 130000;
+pub const __TVOS_13_2: u32 = 130200;
+pub const __TVOS_13_3: u32 = 130300;
+pub const __TVOS_13_4: u32 = 130400;
+pub const __TVOS_14_0: u32 = 140000;
+pub const __TVOS_14_1: u32 = 140100;
+pub const __TVOS_14_2: u32 = 140200;
+pub const __TVOS_14_3: u32 = 140300;
+pub const __WATCHOS_1_0: u32 = 10000;
+pub const __WATCHOS_2_0: u32 = 20000;
+pub const __WATCHOS_2_1: u32 = 20100;
+pub const __WATCHOS_2_2: u32 = 20200;
+pub const __WATCHOS_3_0: u32 = 30000;
+pub const __WATCHOS_3_1: u32 = 30100;
+pub const __WATCHOS_3_1_1: u32 = 30101;
+pub const __WATCHOS_3_2: u32 = 30200;
+pub const __WATCHOS_4_0: u32 = 40000;
+pub const __WATCHOS_4_1: u32 = 40100;
+pub const __WATCHOS_4_2: u32 = 40200;
+pub const __WATCHOS_4_3: u32 = 40300;
+pub const __WATCHOS_5_0: u32 = 50000;
+pub const __WATCHOS_5_1: u32 = 50100;
+pub const __WATCHOS_5_2: u32 = 50200;
+pub const __WATCHOS_5_3: u32 = 50300;
+pub const __WATCHOS_6_0: u32 = 60000;
+pub const __WATCHOS_6_1: u32 = 60100;
+pub const __WATCHOS_6_2: u32 = 60200;
+pub const __WATCHOS_7_0: u32 = 70000;
+pub const __WATCHOS_7_1: u32 = 70100;
+pub const __WATCHOS_7_2: u32 = 70200;
+pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
+pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
+pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
+pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
+pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
+pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
+pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
+pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
+pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
+pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
+pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
+pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
+pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
+pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
+pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
+pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
+pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
+pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
+pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
+pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
+pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
+pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
+pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
+pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
+pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
+pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
+pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
+pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
+pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
+pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
+pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
+pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
+pub const MAC_OS_VERSION_11_0: u32 = 110000;
+pub const __DRIVERKIT_19_0: u32 = 190000;
+pub const __DRIVERKIT_20_0: u32 = 200000;
+pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
+pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
+pub const __PTHREAD_SIZE__: u32 = 8176;
+pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
+pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
+pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_COND_SIZE__: u32 = 40;
+pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
+pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
+pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
+pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
+pub const _FORTIFY_SOURCE: u32 = 2;
+pub const RENAME_SECLUDE: u32 = 1;
+pub const RENAME_SWAP: u32 = 2;
+pub const RENAME_EXCL: u32 = 4;
+pub const __SLBF: u32 = 1;
+pub const __SNBF: u32 = 2;
+pub const __SRD: u32 = 4;
+pub const __SWR: u32 = 8;
+pub const __SRW: u32 = 16;
+pub const __SEOF: u32 = 32;
+pub const __SERR: u32 = 64;
+pub const __SMBF: u32 = 128;
+pub const __SAPP: u32 = 256;
+pub const __SSTR: u32 = 512;
+pub const __SOPT: u32 = 1024;
+pub const __SNPT: u32 = 2048;
+pub const __SOFF: u32 = 4096;
+pub const __SMOD: u32 = 8192;
+pub const __SALC: u32 = 16384;
+pub const __SIGN: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 8192;
+pub const BUFSIZ: u32 = 1024;
 pub const EOF: i32 = -1;
+pub const FOPEN_MAX: u32 = 20;
+pub const FILENAME_MAX: u32 = 1024;
+pub const P_tmpdir: &'static [u8; 10usize] = b"/var/tmp/\0";
+pub const L_tmpnam: u32 = 1024;
+pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const P_tmpdir: &'static [u8; 5usize] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
-pub const L_tmpnam: u32 = 20;
-pub const TMP_MAX: u32 = 238328;
-pub const FILENAME_MAX: u32 = 4096;
-pub const L_ctermid: u32 = 9;
-pub const FOPEN_MAX: u32 = 16;
-pub const __HAVE_FLOAT128: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
-pub const __HAVE_FLOAT64X: u32 = 1;
-pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
-pub const __HAVE_FLOAT16: u32 = 0;
-pub const __HAVE_FLOAT32: u32 = 1;
-pub const __HAVE_FLOAT64: u32 = 1;
-pub const __HAVE_FLOAT32X: u32 = 1;
-pub const __HAVE_FLOAT128X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
-pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
+pub const L_ctermid: u32 = 1024;
+pub const _USE_FORTIFY_LEVEL: u32 = 2;
+pub const __DARWIN_NSIG: u32 = 32;
+pub const NSIG: u32 = 32;
+pub const _I386_SIGNAL_H_: u32 = 1;
+pub const SIGHUP: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGQUIT: u32 = 3;
+pub const SIGILL: u32 = 4;
+pub const SIGTRAP: u32 = 5;
+pub const SIGABRT: u32 = 6;
+pub const SIGIOT: u32 = 6;
+pub const SIGEMT: u32 = 7;
+pub const SIGFPE: u32 = 8;
+pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSEGV: u32 = 11;
+pub const SIGSYS: u32 = 12;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGTERM: u32 = 15;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGIO: u32 = 23;
+pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGWINCH: u32 = 28;
+pub const SIGINFO: u32 = 29;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
+pub const FP_PREC_24B: u32 = 0;
+pub const FP_PREC_53B: u32 = 2;
+pub const FP_PREC_64B: u32 = 3;
+pub const FP_RND_NEAR: u32 = 0;
+pub const FP_RND_DOWN: u32 = 1;
+pub const FP_RND_UP: u32 = 2;
+pub const FP_CHOP: u32 = 3;
+pub const FP_STATE_BYTES: u32 = 512;
+pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
+pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
+pub const __LASTBRANCH_MAX: u32 = 32;
+pub const SIGEV_NONE: u32 = 0;
+pub const SIGEV_SIGNAL: u32 = 1;
+pub const SIGEV_THREAD: u32 = 3;
+pub const ILL_NOOP: u32 = 0;
+pub const ILL_ILLOPC: u32 = 1;
+pub const ILL_ILLTRP: u32 = 2;
+pub const ILL_PRVOPC: u32 = 3;
+pub const ILL_ILLOPN: u32 = 4;
+pub const ILL_ILLADR: u32 = 5;
+pub const ILL_PRVREG: u32 = 6;
+pub const ILL_COPROC: u32 = 7;
+pub const ILL_BADSTK: u32 = 8;
+pub const FPE_NOOP: u32 = 0;
+pub const FPE_FLTDIV: u32 = 1;
+pub const FPE_FLTOVF: u32 = 2;
+pub const FPE_FLTUND: u32 = 3;
+pub const FPE_FLTRES: u32 = 4;
+pub const FPE_FLTINV: u32 = 5;
+pub const FPE_FLTSUB: u32 = 6;
+pub const FPE_INTDIV: u32 = 7;
+pub const FPE_INTOVF: u32 = 8;
+pub const SEGV_NOOP: u32 = 0;
+pub const SEGV_MAPERR: u32 = 1;
+pub const SEGV_ACCERR: u32 = 2;
+pub const BUS_NOOP: u32 = 0;
+pub const BUS_ADRALN: u32 = 1;
+pub const BUS_ADRERR: u32 = 2;
+pub const BUS_OBJERR: u32 = 3;
+pub const TRAP_BRKPT: u32 = 1;
+pub const TRAP_TRACE: u32 = 2;
+pub const CLD_NOOP: u32 = 0;
+pub const CLD_EXITED: u32 = 1;
+pub const CLD_KILLED: u32 = 2;
+pub const CLD_DUMPED: u32 = 3;
+pub const CLD_TRAPPED: u32 = 4;
+pub const CLD_STOPPED: u32 = 5;
+pub const CLD_CONTINUED: u32 = 6;
+pub const POLL_IN: u32 = 1;
+pub const POLL_OUT: u32 = 2;
+pub const POLL_MSG: u32 = 3;
+pub const POLL_ERR: u32 = 4;
+pub const POLL_PRI: u32 = 5;
+pub const POLL_HUP: u32 = 6;
+pub const SA_ONSTACK: u32 = 1;
+pub const SA_RESTART: u32 = 2;
+pub const SA_RESETHAND: u32 = 4;
+pub const SA_NOCLDSTOP: u32 = 8;
+pub const SA_NODEFER: u32 = 16;
+pub const SA_NOCLDWAIT: u32 = 32;
+pub const SA_SIGINFO: u32 = 64;
+pub const SA_USERTRAMP: u32 = 256;
+pub const SA_64REGSET: u32 = 512;
+pub const SA_USERSPACE_MASK: u32 = 127;
+pub const SIG_BLOCK: u32 = 1;
+pub const SIG_UNBLOCK: u32 = 2;
+pub const SIG_SETMASK: u32 = 3;
+pub const SI_USER: u32 = 65537;
+pub const SI_QUEUE: u32 = 65538;
+pub const SI_TIMER: u32 = 65539;
+pub const SI_ASYNCIO: u32 = 65540;
+pub const SI_MESGQ: u32 = 65541;
+pub const SS_ONSTACK: u32 = 1;
+pub const SS_DISABLE: u32 = 4;
+pub const MINSIGSTKSZ: u32 = 32768;
+pub const SIGSTKSZ: u32 = 131072;
+pub const SV_ONSTACK: u32 = 1;
+pub const SV_INTERRUPT: u32 = 2;
+pub const SV_RESETHAND: u32 = 4;
+pub const SV_NODEFER: u32 = 16;
+pub const SV_NOCLDSTOP: u32 = 8;
+pub const SV_SIGINFO: u32 = 64;
+pub const __WORDSIZE: u32 = 64;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const INT64_MAX: u64 = 9223372036854775807;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT64_MIN: i64 = -9223372036854775808;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const UINT64_MAX: i32 = -1;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const UINT_LEAST64_MAX: i32 = -1;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i32 = -32768;
+pub const INT_FAST32_MIN: i32 = -2147483648;
+pub const INT_FAST64_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u32 = 32767;
+pub const INT_FAST32_MAX: u32 = 2147483647;
+pub const INT_FAST64_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: u32 = 65535;
+pub const UINT_FAST32_MAX: u32 = 4294967295;
+pub const UINT_FAST64_MAX: i32 = -1;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const UINTPTR_MAX: i32 = -1;
+pub const SIZE_MAX: i32 = -1;
+pub const RSIZE_MAX: i32 = -1;
+pub const WINT_MIN: i32 = -2147483648;
+pub const WINT_MAX: u32 = 2147483647;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const PRIO_PROCESS: u32 = 0;
+pub const PRIO_PGRP: u32 = 1;
+pub const PRIO_USER: u32 = 2;
+pub const PRIO_DARWIN_THREAD: u32 = 3;
+pub const PRIO_DARWIN_PROCESS: u32 = 4;
+pub const PRIO_MIN: i32 = -20;
+pub const PRIO_MAX: u32 = 20;
+pub const PRIO_DARWIN_BG: u32 = 4096;
+pub const PRIO_DARWIN_NONUI: u32 = 4097;
+pub const RUSAGE_SELF: u32 = 0;
+pub const RUSAGE_CHILDREN: i32 = -1;
+pub const RUSAGE_INFO_V0: u32 = 0;
+pub const RUSAGE_INFO_V1: u32 = 1;
+pub const RUSAGE_INFO_V2: u32 = 2;
+pub const RUSAGE_INFO_V3: u32 = 3;
+pub const RUSAGE_INFO_V4: u32 = 4;
+pub const RUSAGE_INFO_V5: u32 = 5;
+pub const RUSAGE_INFO_CURRENT: u32 = 5;
+pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
+pub const RLIMIT_CPU: u32 = 0;
+pub const RLIMIT_FSIZE: u32 = 1;
+pub const RLIMIT_DATA: u32 = 2;
+pub const RLIMIT_STACK: u32 = 3;
+pub const RLIMIT_CORE: u32 = 4;
+pub const RLIMIT_AS: u32 = 5;
+pub const RLIMIT_RSS: u32 = 5;
+pub const RLIMIT_MEMLOCK: u32 = 6;
+pub const RLIMIT_NPROC: u32 = 7;
+pub const RLIMIT_NOFILE: u32 = 8;
+pub const RLIM_NLIMITS: u32 = 9;
+pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
+pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
+pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
+pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
+pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
+pub const WAKEMON_ENABLE: u32 = 1;
+pub const WAKEMON_DISABLE: u32 = 2;
+pub const WAKEMON_GET_PARAMS: u32 = 4;
+pub const WAKEMON_SET_DEFAULTS: u32 = 8;
+pub const WAKEMON_MAKE_FATAL: u32 = 16;
+pub const CPUMON_MAKE_FATAL: u32 = 4096;
+pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
+pub const IOPOL_TYPE_DISK: u32 = 0;
+pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
+pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
+pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
+pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
+pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
+pub const IOPOL_SCOPE_PROCESS: u32 = 0;
+pub const IOPOL_SCOPE_THREAD: u32 = 1;
+pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
+pub const IOPOL_DEFAULT: u32 = 0;
+pub const IOPOL_IMPORTANT: u32 = 1;
+pub const IOPOL_PASSIVE: u32 = 2;
+pub const IOPOL_THROTTLE: u32 = 3;
+pub const IOPOL_UTILITY: u32 = 4;
+pub const IOPOL_STANDARD: u32 = 5;
+pub const IOPOL_APPLICATION: u32 = 5;
+pub const IOPOL_NORMAL: u32 = 1;
+pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
+pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
+pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
+pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
+pub const WCOREFLAG: u32 = 128;
+pub const _WSTOPPED: u32 = 127;
 pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
-pub const __ldiv_t_defined: u32 = 1;
-pub const __lldiv_t_defined: u32 = 1;
-pub const RAND_MAX: u32 = 2147483647;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const _SYS_TYPES_H: u32 = 1;
-pub const __clock_t_defined: u32 = 1;
-pub const __clockid_t_defined: u32 = 1;
-pub const __time_t_defined: u32 = 1;
-pub const __timer_t_defined: u32 = 1;
-pub const _BITS_STDINT_INTN_H: u32 = 1;
-pub const __BIT_TYPES_DEFINED__: u32 = 1;
-pub const _ENDIAN_H: u32 = 1;
-pub const _BITS_ENDIAN_H: u32 = 1;
-pub const __LITTLE_ENDIAN: u32 = 1234;
-pub const __BIG_ENDIAN: u32 = 4321;
-pub const __PDP_ENDIAN: u32 = 3412;
-pub const _BITS_ENDIANNESS_H: u32 = 1;
-pub const __BYTE_ORDER: u32 = 1234;
-pub const __FLOAT_WORD_ORDER: u32 = 1234;
+pub const WSTOPPED: u32 = 8;
+pub const WCONTINUED: u32 = 16;
+pub const WNOWAIT: u32 = 32;
+pub const WAIT_ANY: i32 = -1;
+pub const WAIT_MYPGRP: u32 = 0;
+pub const _QUAD_HIGHWORD: u32 = 1;
+pub const _QUAD_LOWWORD: u32 = 0;
+pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
+pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
+pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
+pub const __DARWIN_BYTE_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const _BITS_BYTESWAP_H: u32 = 1;
-pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
-pub const _SYS_SELECT_H: u32 = 1;
-pub const __sigset_t_defined: u32 = 1;
-pub const __timeval_defined: u32 = 1;
-pub const _STRUCT_TIMESPEC: u32 = 1;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const RAND_MAX: u32 = 2147483647;
+pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const __DARWIN_FD_SETSIZE: u32 = 1024;
+pub const __DARWIN_NBBY: u32 = 8;
+pub const NBBY: u32 = 8;
 pub const FD_SETSIZE: u32 = 1024;
-pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
-pub const _THREAD_SHARED_TYPES_H: u32 = 1;
-pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
-pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
-pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
-pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
-pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
-pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
-pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
-pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
-pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
-pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
-pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
-pub const __have_pthread_attr_t: u32 = 1;
-pub const _ALLOCA_H: u32 = 1;
-pub const _STRING_H: u32 = 1;
-pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
-pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
-pub const _STRINGS_H: u32 = 1;
-pub const _STDINT_H: u32 = 1;
-pub const _BITS_WCHAR_H: u32 = 1;
-pub const _BITS_STDINT_UINTN_H: u32 = 1;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i64 = -9223372036854775808;
-pub const INT_FAST32_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u64 = 9223372036854775807;
-pub const INT_FAST32_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: i32 = -1;
-pub const UINT_FAST32_MAX: i32 = -1;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const UINTPTR_MAX: i32 = -1;
-pub const PTRDIFF_MIN: i64 = -9223372036854775808;
-pub const PTRDIFF_MAX: u64 = 9223372036854775807;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const SIZE_MAX: i32 = -1;
-pub const WINT_MIN: u32 = 0;
-pub const WINT_MAX: u32 = 4294967295;
-pub const _ERRNO_H: u32 = 1;
-pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -573,7 +879,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EAGAIN: u32 = 11;
+pub const EDEADLK: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -597,147 +903,88 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EDEADLK: u32 = 35;
-pub const ENAMETOOLONG: u32 = 36;
-pub const ENOLCK: u32 = 37;
-pub const ENOSYS: u32 = 38;
-pub const ENOTEMPTY: u32 = 39;
-pub const ELOOP: u32 = 40;
-pub const EWOULDBLOCK: u32 = 11;
-pub const ENOMSG: u32 = 42;
-pub const EIDRM: u32 = 43;
-pub const ECHRNG: u32 = 44;
-pub const EL2NSYNC: u32 = 45;
-pub const EL3HLT: u32 = 46;
-pub const EL3RST: u32 = 47;
-pub const ELNRNG: u32 = 48;
-pub const EUNATCH: u32 = 49;
-pub const ENOCSI: u32 = 50;
-pub const EL2HLT: u32 = 51;
-pub const EBADE: u32 = 52;
-pub const EBADR: u32 = 53;
-pub const EXFULL: u32 = 54;
-pub const ENOANO: u32 = 55;
-pub const EBADRQC: u32 = 56;
-pub const EBADSLT: u32 = 57;
-pub const EDEADLOCK: u32 = 35;
-pub const EBFONT: u32 = 59;
-pub const ENOSTR: u32 = 60;
-pub const ENODATA: u32 = 61;
-pub const ETIME: u32 = 62;
-pub const ENOSR: u32 = 63;
-pub const ENONET: u32 = 64;
-pub const ENOPKG: u32 = 65;
-pub const EREMOTE: u32 = 66;
-pub const ENOLINK: u32 = 67;
-pub const EADV: u32 = 68;
-pub const ESRMNT: u32 = 69;
-pub const ECOMM: u32 = 70;
-pub const EPROTO: u32 = 71;
-pub const EMULTIHOP: u32 = 72;
-pub const EDOTDOT: u32 = 73;
-pub const EBADMSG: u32 = 74;
-pub const EOVERFLOW: u32 = 75;
-pub const ENOTUNIQ: u32 = 76;
-pub const EBADFD: u32 = 77;
-pub const EREMCHG: u32 = 78;
-pub const ELIBACC: u32 = 79;
-pub const ELIBBAD: u32 = 80;
-pub const ELIBSCN: u32 = 81;
-pub const ELIBMAX: u32 = 82;
-pub const ELIBEXEC: u32 = 83;
-pub const EILSEQ: u32 = 84;
-pub const ERESTART: u32 = 85;
-pub const ESTRPIPE: u32 = 86;
-pub const EUSERS: u32 = 87;
-pub const ENOTSOCK: u32 = 88;
-pub const EDESTADDRREQ: u32 = 89;
-pub const EMSGSIZE: u32 = 90;
-pub const EPROTOTYPE: u32 = 91;
-pub const ENOPROTOOPT: u32 = 92;
-pub const EPROTONOSUPPORT: u32 = 93;
-pub const ESOCKTNOSUPPORT: u32 = 94;
-pub const EOPNOTSUPP: u32 = 95;
-pub const EPFNOSUPPORT: u32 = 96;
-pub const EAFNOSUPPORT: u32 = 97;
-pub const EADDRINUSE: u32 = 98;
-pub const EADDRNOTAVAIL: u32 = 99;
-pub const ENETDOWN: u32 = 100;
-pub const ENETUNREACH: u32 = 101;
-pub const ENETRESET: u32 = 102;
-pub const ECONNABORTED: u32 = 103;
-pub const ECONNRESET: u32 = 104;
-pub const ENOBUFS: u32 = 105;
-pub const EISCONN: u32 = 106;
-pub const ENOTCONN: u32 = 107;
-pub const ESHUTDOWN: u32 = 108;
-pub const ETOOMANYREFS: u32 = 109;
-pub const ETIMEDOUT: u32 = 110;
-pub const ECONNREFUSED: u32 = 111;
-pub const EHOSTDOWN: u32 = 112;
-pub const EHOSTUNREACH: u32 = 113;
-pub const EALREADY: u32 = 114;
-pub const EINPROGRESS: u32 = 115;
-pub const ESTALE: u32 = 116;
-pub const EUCLEAN: u32 = 117;
-pub const ENOTNAM: u32 = 118;
-pub const ENAVAIL: u32 = 119;
-pub const EISNAM: u32 = 120;
-pub const EREMOTEIO: u32 = 121;
-pub const EDQUOT: u32 = 122;
-pub const ENOMEDIUM: u32 = 123;
-pub const EMEDIUMTYPE: u32 = 124;
-pub const ECANCELED: u32 = 125;
-pub const ENOKEY: u32 = 126;
-pub const EKEYEXPIRED: u32 = 127;
-pub const EKEYREVOKED: u32 = 128;
-pub const EKEYREJECTED: u32 = 129;
-pub const EOWNERDEAD: u32 = 130;
-pub const ENOTRECOVERABLE: u32 = 131;
-pub const ERFKILL: u32 = 132;
-pub const EHWPOISON: u32 = 133;
-pub const ENOTSUP: u32 = 95;
-pub const _LOCALE_H: u32 = 1;
-pub const _BITS_LOCALE_H: u32 = 1;
-pub const __LC_CTYPE: u32 = 0;
-pub const __LC_NUMERIC: u32 = 1;
-pub const __LC_TIME: u32 = 2;
-pub const __LC_COLLATE: u32 = 3;
-pub const __LC_MONETARY: u32 = 4;
-pub const __LC_MESSAGES: u32 = 5;
-pub const __LC_ALL: u32 = 6;
-pub const __LC_PAPER: u32 = 7;
-pub const __LC_NAME: u32 = 8;
-pub const __LC_ADDRESS: u32 = 9;
-pub const __LC_TELEPHONE: u32 = 10;
-pub const __LC_MEASUREMENT: u32 = 11;
-pub const __LC_IDENTIFICATION: u32 = 12;
-pub const LC_CTYPE: u32 = 0;
-pub const LC_NUMERIC: u32 = 1;
-pub const LC_TIME: u32 = 2;
-pub const LC_COLLATE: u32 = 3;
-pub const LC_MONETARY: u32 = 4;
-pub const LC_MESSAGES: u32 = 5;
-pub const LC_ALL: u32 = 6;
-pub const LC_PAPER: u32 = 7;
-pub const LC_NAME: u32 = 8;
-pub const LC_ADDRESS: u32 = 9;
-pub const LC_TELEPHONE: u32 = 10;
-pub const LC_MEASUREMENT: u32 = 11;
-pub const LC_IDENTIFICATION: u32 = 12;
-pub const LC_CTYPE_MASK: u32 = 1;
-pub const LC_NUMERIC_MASK: u32 = 2;
-pub const LC_TIME_MASK: u32 = 4;
-pub const LC_COLLATE_MASK: u32 = 8;
-pub const LC_MONETARY_MASK: u32 = 16;
-pub const LC_MESSAGES_MASK: u32 = 32;
-pub const LC_PAPER_MASK: u32 = 128;
-pub const LC_NAME_MASK: u32 = 256;
-pub const LC_ADDRESS_MASK: u32 = 512;
-pub const LC_TELEPHONE_MASK: u32 = 1024;
-pub const LC_MEASUREMENT_MASK: u32 = 2048;
-pub const LC_IDENTIFICATION_MASK: u32 = 4096;
-pub const LC_ALL_MASK: u32 = 8127;
+pub const EAGAIN: u32 = 35;
+pub const EWOULDBLOCK: u32 = 35;
+pub const EINPROGRESS: u32 = 36;
+pub const EALREADY: u32 = 37;
+pub const ENOTSOCK: u32 = 38;
+pub const EDESTADDRREQ: u32 = 39;
+pub const EMSGSIZE: u32 = 40;
+pub const EPROTOTYPE: u32 = 41;
+pub const ENOPROTOOPT: u32 = 42;
+pub const EPROTONOSUPPORT: u32 = 43;
+pub const ESOCKTNOSUPPORT: u32 = 44;
+pub const ENOTSUP: u32 = 45;
+pub const EPFNOSUPPORT: u32 = 46;
+pub const EAFNOSUPPORT: u32 = 47;
+pub const EADDRINUSE: u32 = 48;
+pub const EADDRNOTAVAIL: u32 = 49;
+pub const ENETDOWN: u32 = 50;
+pub const ENETUNREACH: u32 = 51;
+pub const ENETRESET: u32 = 52;
+pub const ECONNABORTED: u32 = 53;
+pub const ECONNRESET: u32 = 54;
+pub const ENOBUFS: u32 = 55;
+pub const EISCONN: u32 = 56;
+pub const ENOTCONN: u32 = 57;
+pub const ESHUTDOWN: u32 = 58;
+pub const ETOOMANYREFS: u32 = 59;
+pub const ETIMEDOUT: u32 = 60;
+pub const ECONNREFUSED: u32 = 61;
+pub const ELOOP: u32 = 62;
+pub const ENAMETOOLONG: u32 = 63;
+pub const EHOSTDOWN: u32 = 64;
+pub const EHOSTUNREACH: u32 = 65;
+pub const ENOTEMPTY: u32 = 66;
+pub const EPROCLIM: u32 = 67;
+pub const EUSERS: u32 = 68;
+pub const EDQUOT: u32 = 69;
+pub const ESTALE: u32 = 70;
+pub const EREMOTE: u32 = 71;
+pub const EBADRPC: u32 = 72;
+pub const ERPCMISMATCH: u32 = 73;
+pub const EPROGUNAVAIL: u32 = 74;
+pub const EPROGMISMATCH: u32 = 75;
+pub const EPROCUNAVAIL: u32 = 76;
+pub const ENOLCK: u32 = 77;
+pub const ENOSYS: u32 = 78;
+pub const EFTYPE: u32 = 79;
+pub const EAUTH: u32 = 80;
+pub const ENEEDAUTH: u32 = 81;
+pub const EPWROFF: u32 = 82;
+pub const EDEVERR: u32 = 83;
+pub const EOVERFLOW: u32 = 84;
+pub const EBADEXEC: u32 = 85;
+pub const EBADARCH: u32 = 86;
+pub const ESHLIBVERS: u32 = 87;
+pub const EBADMACHO: u32 = 88;
+pub const ECANCELED: u32 = 89;
+pub const EIDRM: u32 = 90;
+pub const ENOMSG: u32 = 91;
+pub const EILSEQ: u32 = 92;
+pub const ENOATTR: u32 = 93;
+pub const EBADMSG: u32 = 94;
+pub const EMULTIHOP: u32 = 95;
+pub const ENODATA: u32 = 96;
+pub const ENOLINK: u32 = 97;
+pub const ENOSR: u32 = 98;
+pub const ENOSTR: u32 = 99;
+pub const EPROTO: u32 = 100;
+pub const ETIME: u32 = 101;
+pub const EOPNOTSUPP: u32 = 102;
+pub const ENOPOLICY: u32 = 103;
+pub const ENOTRECOVERABLE: u32 = 104;
+pub const EOWNERDEAD: u32 = 105;
+pub const EQFULL: u32 = 106;
+pub const ELAST: u32 = 106;
+pub const LC_ALL: u32 = 0;
+pub const LC_COLLATE: u32 = 1;
+pub const LC_CTYPE: u32 = 2;
+pub const LC_MONETARY: u32 = 3;
+pub const LC_NUMERIC: u32 = 4;
+pub const LC_TIME: u32 = 5;
+pub const LC_MESSAGES: u32 = 6;
+pub const _LC_LAST: u32 = 7;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const TRUE: u32 = 1;
 pub const FALSE: u32 = 0;
@@ -765,355 +1012,375 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &'static [u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &'static [u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &'static [u8; 2usize] = b"w\0";
-pub const _CTYPE_H: u32 = 1;
-pub const _NETDB_H: u32 = 1;
-pub const _NETINET_IN_H: u32 = 1;
-pub const _SYS_SOCKET_H: u32 = 1;
-pub const __iovec_defined: u32 = 1;
+pub const _CACHED_RUNES: u32 = 256;
+pub const _CRMASK: i32 = -256;
+pub const _RUNE_MAGIC_A: &'static [u8; 9usize] = b"RuneMagA\0";
+pub const _CTYPE_A: u32 = 256;
+pub const _CTYPE_C: u32 = 512;
+pub const _CTYPE_D: u32 = 1024;
+pub const _CTYPE_G: u32 = 2048;
+pub const _CTYPE_L: u32 = 4096;
+pub const _CTYPE_P: u32 = 8192;
+pub const _CTYPE_S: u32 = 16384;
+pub const _CTYPE_U: u32 = 32768;
+pub const _CTYPE_X: u32 = 65536;
+pub const _CTYPE_B: u32 = 131072;
+pub const _CTYPE_R: u32 = 262144;
+pub const _CTYPE_I: u32 = 524288;
+pub const _CTYPE_T: u32 = 1048576;
+pub const _CTYPE_Q: u32 = 2097152;
+pub const _CTYPE_SW0: u32 = 536870912;
+pub const _CTYPE_SW1: u32 = 1073741824;
+pub const _CTYPE_SW2: u32 = 2147483648;
+pub const _CTYPE_SW3: u32 = 3221225472;
+pub const _CTYPE_SWM: u32 = 3758096384;
+pub const _CTYPE_SWS: u32 = 30;
+pub const KEV_INET_SUBCLASS: u32 = 1;
+pub const KEV_INET_NEW_ADDR: u32 = 1;
+pub const KEV_INET_CHANGED_ADDR: u32 = 2;
+pub const KEV_INET_ADDR_DELETED: u32 = 3;
+pub const KEV_INET_SIFDSTADDR: u32 = 4;
+pub const KEV_INET_SIFBRDADDR: u32 = 5;
+pub const KEV_INET_SIFNETMASK: u32 = 6;
+pub const KEV_INET_ARPCOLLISION: u32 = 7;
+pub const KEV_INET_PORTINUSE: u32 = 8;
+pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
+pub const KEV_INET_ARPRTRALIVE: u32 = 10;
+pub const KEV_DL_SUBCLASS: u32 = 2;
+pub const KEV_DL_SIFFLAGS: u32 = 1;
+pub const KEV_DL_SIFMETRICS: u32 = 2;
+pub const KEV_DL_SIFMTU: u32 = 3;
+pub const KEV_DL_SIFPHYS: u32 = 4;
+pub const KEV_DL_SIFMEDIA: u32 = 5;
+pub const KEV_DL_SIFGENERIC: u32 = 6;
+pub const KEV_DL_ADDMULTI: u32 = 7;
+pub const KEV_DL_DELMULTI: u32 = 8;
+pub const KEV_DL_IF_ATTACHED: u32 = 9;
+pub const KEV_DL_IF_DETACHING: u32 = 10;
+pub const KEV_DL_IF_DETACHED: u32 = 11;
+pub const KEV_DL_LINK_OFF: u32 = 12;
+pub const KEV_DL_LINK_ON: u32 = 13;
+pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
+pub const KEV_DL_PROTO_DETACHED: u32 = 15;
+pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
+pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
+pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
+pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
+pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
+pub const KEV_DL_NODE_PRESENCE: u32 = 21;
+pub const KEV_DL_NODE_ABSENCE: u32 = 22;
+pub const KEV_DL_MASTER_ELECTED: u32 = 23;
+pub const KEV_DL_ISSUES: u32 = 24;
+pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
+pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
+pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
+pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
+pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
+pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
+pub const KEV_INET6_SUBCLASS: u32 = 6;
+pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
+pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
+pub const KEV_INET6_ADDR_DELETED: u32 = 3;
+pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
+pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
+pub const KEV_INET6_DEFROUTER: u32 = 6;
+pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
+pub const SOCK_STREAM: u32 = 1;
+pub const SOCK_DGRAM: u32 = 2;
+pub const SOCK_RAW: u32 = 3;
+pub const SOCK_RDM: u32 = 4;
+pub const SOCK_SEQPACKET: u32 = 5;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_ACCEPTCONN: u32 = 2;
+pub const SO_REUSEADDR: u32 = 4;
+pub const SO_KEEPALIVE: u32 = 8;
+pub const SO_DONTROUTE: u32 = 16;
+pub const SO_BROADCAST: u32 = 32;
+pub const SO_USELOOPBACK: u32 = 64;
+pub const SO_LINGER: u32 = 128;
+pub const SO_OOBINLINE: u32 = 256;
+pub const SO_REUSEPORT: u32 = 512;
+pub const SO_TIMESTAMP: u32 = 1024;
+pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
+pub const SO_DONTTRUNC: u32 = 8192;
+pub const SO_WANTMORE: u32 = 16384;
+pub const SO_WANTOOBFLAG: u32 = 32768;
+pub const SO_SNDBUF: u32 = 4097;
+pub const SO_RCVBUF: u32 = 4098;
+pub const SO_SNDLOWAT: u32 = 4099;
+pub const SO_RCVLOWAT: u32 = 4100;
+pub const SO_SNDTIMEO: u32 = 4101;
+pub const SO_RCVTIMEO: u32 = 4102;
+pub const SO_ERROR: u32 = 4103;
+pub const SO_TYPE: u32 = 4104;
+pub const SO_LABEL: u32 = 4112;
+pub const SO_PEERLABEL: u32 = 4113;
+pub const SO_NREAD: u32 = 4128;
+pub const SO_NKE: u32 = 4129;
+pub const SO_NOSIGPIPE: u32 = 4130;
+pub const SO_NOADDRERR: u32 = 4131;
+pub const SO_NWRITE: u32 = 4132;
+pub const SO_REUSESHAREUID: u32 = 4133;
+pub const SO_NOTIFYCONFLICT: u32 = 4134;
+pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
+pub const SO_LINGER_SEC: u32 = 4224;
+pub const SO_RANDOMPORT: u32 = 4226;
+pub const SO_NP_EXTENSIONS: u32 = 4227;
+pub const SO_NUMRCVPKT: u32 = 4370;
+pub const SO_NET_SERVICE_TYPE: u32 = 4374;
+pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
+pub const NET_SERVICE_TYPE_BE: u32 = 0;
+pub const NET_SERVICE_TYPE_BK: u32 = 1;
+pub const NET_SERVICE_TYPE_SIG: u32 = 2;
+pub const NET_SERVICE_TYPE_VI: u32 = 3;
+pub const NET_SERVICE_TYPE_VO: u32 = 4;
+pub const NET_SERVICE_TYPE_RV: u32 = 5;
+pub const NET_SERVICE_TYPE_AV: u32 = 6;
+pub const NET_SERVICE_TYPE_OAM: u32 = 7;
+pub const NET_SERVICE_TYPE_RD: u32 = 8;
+pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
+pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
+pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
+pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
+pub const SAE_ASSOCID_ANY: u32 = 0;
+pub const SAE_CONNID_ANY: u32 = 0;
+pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
+pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
+pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
+pub const SONPX_SETOPTSHUT: u32 = 1;
+pub const SOL_SOCKET: u32 = 65535;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_UNIX: u32 = 1;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_IMPLINK: u32 = 3;
+pub const AF_PUP: u32 = 4;
+pub const AF_CHAOS: u32 = 5;
+pub const AF_NS: u32 = 6;
+pub const AF_ISO: u32 = 7;
+pub const AF_OSI: u32 = 7;
+pub const AF_ECMA: u32 = 8;
+pub const AF_DATAKIT: u32 = 9;
+pub const AF_CCITT: u32 = 10;
+pub const AF_SNA: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_DLI: u32 = 13;
+pub const AF_LAT: u32 = 14;
+pub const AF_HYLINK: u32 = 15;
+pub const AF_APPLETALK: u32 = 16;
+pub const AF_ROUTE: u32 = 17;
+pub const AF_LINK: u32 = 18;
+pub const pseudo_AF_XTP: u32 = 19;
+pub const AF_COIP: u32 = 20;
+pub const AF_CNT: u32 = 21;
+pub const pseudo_AF_RTIP: u32 = 22;
+pub const AF_IPX: u32 = 23;
+pub const AF_SIP: u32 = 24;
+pub const pseudo_AF_PIP: u32 = 25;
+pub const AF_NDRV: u32 = 27;
+pub const AF_ISDN: u32 = 28;
+pub const AF_E164: u32 = 28;
+pub const pseudo_AF_KEY: u32 = 29;
+pub const AF_INET6: u32 = 30;
+pub const AF_NATM: u32 = 31;
+pub const AF_SYSTEM: u32 = 32;
+pub const AF_NETBIOS: u32 = 33;
+pub const AF_PPP: u32 = 34;
+pub const pseudo_AF_HDRCMPLT: u32 = 35;
+pub const AF_RESERVED_36: u32 = 36;
+pub const AF_IEEE80211: u32 = 37;
+pub const AF_UTUN: u32 = 38;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_MAX: u32 = 41;
+pub const SOCK_MAXADDRLEN: u32 = 255;
+pub const _SS_MAXSIZE: u32 = 128;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
-pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_AX25: u32 = 3;
-pub const PF_IPX: u32 = 4;
-pub const PF_APPLETALK: u32 = 5;
-pub const PF_NETROM: u32 = 6;
-pub const PF_BRIDGE: u32 = 7;
-pub const PF_ATMPVC: u32 = 8;
-pub const PF_X25: u32 = 9;
-pub const PF_INET6: u32 = 10;
-pub const PF_ROSE: u32 = 11;
+pub const PF_IMPLINK: u32 = 3;
+pub const PF_PUP: u32 = 4;
+pub const PF_CHAOS: u32 = 5;
+pub const PF_NS: u32 = 6;
+pub const PF_ISO: u32 = 7;
+pub const PF_OSI: u32 = 7;
+pub const PF_ECMA: u32 = 8;
+pub const PF_DATAKIT: u32 = 9;
+pub const PF_CCITT: u32 = 10;
+pub const PF_SNA: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_NETBEUI: u32 = 13;
-pub const PF_SECURITY: u32 = 14;
-pub const PF_KEY: u32 = 15;
-pub const PF_NETLINK: u32 = 16;
-pub const PF_ROUTE: u32 = 16;
-pub const PF_PACKET: u32 = 17;
-pub const PF_ASH: u32 = 18;
-pub const PF_ECONET: u32 = 19;
-pub const PF_ATMSVC: u32 = 20;
-pub const PF_RDS: u32 = 21;
-pub const PF_SNA: u32 = 22;
-pub const PF_IRDA: u32 = 23;
-pub const PF_PPPOX: u32 = 24;
-pub const PF_WANPIPE: u32 = 25;
-pub const PF_LLC: u32 = 26;
-pub const PF_IB: u32 = 27;
-pub const PF_MPLS: u32 = 28;
-pub const PF_CAN: u32 = 29;
-pub const PF_TIPC: u32 = 30;
-pub const PF_BLUETOOTH: u32 = 31;
-pub const PF_IUCV: u32 = 32;
-pub const PF_RXRPC: u32 = 33;
-pub const PF_ISDN: u32 = 34;
-pub const PF_PHONET: u32 = 35;
-pub const PF_IEEE802154: u32 = 36;
-pub const PF_CAIF: u32 = 37;
-pub const PF_ALG: u32 = 38;
-pub const PF_NFC: u32 = 39;
+pub const PF_DLI: u32 = 13;
+pub const PF_LAT: u32 = 14;
+pub const PF_HYLINK: u32 = 15;
+pub const PF_APPLETALK: u32 = 16;
+pub const PF_ROUTE: u32 = 17;
+pub const PF_LINK: u32 = 18;
+pub const PF_XTP: u32 = 19;
+pub const PF_COIP: u32 = 20;
+pub const PF_CNT: u32 = 21;
+pub const PF_SIP: u32 = 24;
+pub const PF_IPX: u32 = 23;
+pub const PF_RTIP: u32 = 22;
+pub const PF_PIP: u32 = 25;
+pub const PF_NDRV: u32 = 27;
+pub const PF_ISDN: u32 = 28;
+pub const PF_KEY: u32 = 29;
+pub const PF_INET6: u32 = 30;
+pub const PF_NATM: u32 = 31;
+pub const PF_SYSTEM: u32 = 32;
+pub const PF_NETBIOS: u32 = 33;
+pub const PF_PPP: u32 = 34;
+pub const PF_RESERVED_36: u32 = 36;
+pub const PF_UTUN: u32 = 38;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_KCM: u32 = 41;
-pub const PF_QIPCRTR: u32 = 42;
-pub const PF_SMC: u32 = 43;
-pub const PF_XDP: u32 = 44;
-pub const PF_MAX: u32 = 45;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_UNIX: u32 = 1;
-pub const AF_FILE: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_AX25: u32 = 3;
-pub const AF_IPX: u32 = 4;
-pub const AF_APPLETALK: u32 = 5;
-pub const AF_NETROM: u32 = 6;
-pub const AF_BRIDGE: u32 = 7;
-pub const AF_ATMPVC: u32 = 8;
-pub const AF_X25: u32 = 9;
-pub const AF_INET6: u32 = 10;
-pub const AF_ROSE: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_NETBEUI: u32 = 13;
-pub const AF_SECURITY: u32 = 14;
-pub const AF_KEY: u32 = 15;
-pub const AF_NETLINK: u32 = 16;
-pub const AF_ROUTE: u32 = 16;
-pub const AF_PACKET: u32 = 17;
-pub const AF_ASH: u32 = 18;
-pub const AF_ECONET: u32 = 19;
-pub const AF_ATMSVC: u32 = 20;
-pub const AF_RDS: u32 = 21;
-pub const AF_SNA: u32 = 22;
-pub const AF_IRDA: u32 = 23;
-pub const AF_PPPOX: u32 = 24;
-pub const AF_WANPIPE: u32 = 25;
-pub const AF_LLC: u32 = 26;
-pub const AF_IB: u32 = 27;
-pub const AF_MPLS: u32 = 28;
-pub const AF_CAN: u32 = 29;
-pub const AF_TIPC: u32 = 30;
-pub const AF_BLUETOOTH: u32 = 31;
-pub const AF_IUCV: u32 = 32;
-pub const AF_RXRPC: u32 = 33;
-pub const AF_ISDN: u32 = 34;
-pub const AF_PHONET: u32 = 35;
-pub const AF_IEEE802154: u32 = 36;
-pub const AF_CAIF: u32 = 37;
-pub const AF_ALG: u32 = 38;
-pub const AF_NFC: u32 = 39;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_KCM: u32 = 41;
-pub const AF_QIPCRTR: u32 = 42;
-pub const AF_SMC: u32 = 43;
-pub const AF_XDP: u32 = 44;
-pub const AF_MAX: u32 = 45;
-pub const SOL_RAW: u32 = 255;
-pub const SOL_DECNET: u32 = 261;
-pub const SOL_X25: u32 = 262;
-pub const SOL_PACKET: u32 = 263;
-pub const SOL_ATM: u32 = 264;
-pub const SOL_AAL: u32 = 265;
-pub const SOL_IRDA: u32 = 266;
-pub const SOL_NETBEUI: u32 = 267;
-pub const SOL_LLC: u32 = 268;
-pub const SOL_DCCP: u32 = 269;
-pub const SOL_NETLINK: u32 = 270;
-pub const SOL_TIPC: u32 = 271;
-pub const SOL_RXRPC: u32 = 272;
-pub const SOL_PPPOL2TP: u32 = 273;
-pub const SOL_BLUETOOTH: u32 = 274;
-pub const SOL_PNPIPE: u32 = 275;
-pub const SOL_RDS: u32 = 276;
-pub const SOL_IUCV: u32 = 277;
-pub const SOL_CAIF: u32 = 278;
-pub const SOL_ALG: u32 = 279;
-pub const SOL_NFC: u32 = 280;
-pub const SOL_KCM: u32 = 281;
-pub const SOL_TLS: u32 = 282;
-pub const SOL_XDP: u32 = 283;
-pub const SOMAXCONN: u32 = 4096;
-pub const _BITS_SOCKADDR_H: u32 = 1;
-pub const _SS_SIZE: u32 = 128;
-pub const __BITS_PER_LONG: u32 = 64;
-pub const FIOSETOWN: u32 = 35073;
-pub const SIOCSPGRP: u32 = 35074;
-pub const FIOGETOWN: u32 = 35075;
-pub const SIOCGPGRP: u32 = 35076;
-pub const SIOCATMARK: u32 = 35077;
-pub const SIOCGSTAMP_OLD: u32 = 35078;
-pub const SIOCGSTAMPNS_OLD: u32 = 35079;
-pub const SOL_SOCKET: u32 = 1;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_REUSEADDR: u32 = 2;
-pub const SO_TYPE: u32 = 3;
-pub const SO_ERROR: u32 = 4;
-pub const SO_DONTROUTE: u32 = 5;
-pub const SO_BROADCAST: u32 = 6;
-pub const SO_SNDBUF: u32 = 7;
-pub const SO_RCVBUF: u32 = 8;
-pub const SO_SNDBUFFORCE: u32 = 32;
-pub const SO_RCVBUFFORCE: u32 = 33;
-pub const SO_KEEPALIVE: u32 = 9;
-pub const SO_OOBINLINE: u32 = 10;
-pub const SO_NO_CHECK: u32 = 11;
-pub const SO_PRIORITY: u32 = 12;
-pub const SO_LINGER: u32 = 13;
-pub const SO_BSDCOMPAT: u32 = 14;
-pub const SO_REUSEPORT: u32 = 15;
-pub const SO_PASSCRED: u32 = 16;
-pub const SO_PEERCRED: u32 = 17;
-pub const SO_RCVLOWAT: u32 = 18;
-pub const SO_SNDLOWAT: u32 = 19;
-pub const SO_RCVTIMEO_OLD: u32 = 20;
-pub const SO_SNDTIMEO_OLD: u32 = 21;
-pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
-pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
-pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
-pub const SO_BINDTODEVICE: u32 = 25;
-pub const SO_ATTACH_FILTER: u32 = 26;
-pub const SO_DETACH_FILTER: u32 = 27;
-pub const SO_GET_FILTER: u32 = 26;
-pub const SO_PEERNAME: u32 = 28;
-pub const SO_ACCEPTCONN: u32 = 30;
-pub const SO_PEERSEC: u32 = 31;
-pub const SO_PASSSEC: u32 = 34;
-pub const SO_MARK: u32 = 36;
-pub const SO_PROTOCOL: u32 = 38;
-pub const SO_DOMAIN: u32 = 39;
-pub const SO_RXQ_OVFL: u32 = 40;
-pub const SO_WIFI_STATUS: u32 = 41;
-pub const SCM_WIFI_STATUS: u32 = 41;
-pub const SO_PEEK_OFF: u32 = 42;
-pub const SO_NOFCS: u32 = 43;
-pub const SO_LOCK_FILTER: u32 = 44;
-pub const SO_SELECT_ERR_QUEUE: u32 = 45;
-pub const SO_BUSY_POLL: u32 = 46;
-pub const SO_MAX_PACING_RATE: u32 = 47;
-pub const SO_BPF_EXTENSIONS: u32 = 48;
-pub const SO_INCOMING_CPU: u32 = 49;
-pub const SO_ATTACH_BPF: u32 = 50;
-pub const SO_DETACH_BPF: u32 = 27;
-pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
-pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
-pub const SO_CNX_ADVICE: u32 = 53;
-pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
-pub const SO_MEMINFO: u32 = 55;
-pub const SO_INCOMING_NAPI_ID: u32 = 56;
-pub const SO_COOKIE: u32 = 57;
-pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
-pub const SO_PEERGROUPS: u32 = 59;
-pub const SO_ZEROCOPY: u32 = 60;
-pub const SO_TXTIME: u32 = 61;
-pub const SCM_TXTIME: u32 = 61;
-pub const SO_BINDTOIFINDEX: u32 = 62;
-pub const SO_TIMESTAMP_OLD: u32 = 29;
-pub const SO_TIMESTAMPNS_OLD: u32 = 35;
-pub const SO_TIMESTAMPING_OLD: u32 = 37;
-pub const SO_TIMESTAMP_NEW: u32 = 63;
-pub const SO_TIMESTAMPNS_NEW: u32 = 64;
-pub const SO_TIMESTAMPING_NEW: u32 = 65;
-pub const SO_RCVTIMEO_NEW: u32 = 66;
-pub const SO_SNDTIMEO_NEW: u32 = 67;
-pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_TIMESTAMP: u32 = 29;
-pub const SO_TIMESTAMPNS: u32 = 35;
-pub const SO_TIMESTAMPING: u32 = 37;
-pub const SO_RCVTIMEO: u32 = 20;
-pub const SO_SNDTIMEO: u32 = 21;
-pub const SCM_TIMESTAMP: u32 = 29;
-pub const SCM_TIMESTAMPNS: u32 = 35;
-pub const SCM_TIMESTAMPING: u32 = 37;
-pub const __osockaddr_defined: u32 = 1;
-pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
-pub const IP_OPTIONS: u32 = 4;
-pub const IP_HDRINCL: u32 = 3;
-pub const IP_TOS: u32 = 1;
-pub const IP_TTL: u32 = 2;
-pub const IP_RECVOPTS: u32 = 6;
-pub const IP_RETOPTS: u32 = 7;
-pub const IP_MULTICAST_IF: u32 = 32;
-pub const IP_MULTICAST_TTL: u32 = 33;
-pub const IP_MULTICAST_LOOP: u32 = 34;
-pub const IP_ADD_MEMBERSHIP: u32 = 35;
-pub const IP_DROP_MEMBERSHIP: u32 = 36;
-pub const IP_UNBLOCK_SOURCE: u32 = 37;
-pub const IP_BLOCK_SOURCE: u32 = 38;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
-pub const IP_MSFILTER: u32 = 41;
-pub const MCAST_JOIN_GROUP: u32 = 42;
-pub const MCAST_BLOCK_SOURCE: u32 = 43;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
-pub const MCAST_LEAVE_GROUP: u32 = 45;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
-pub const MCAST_MSFILTER: u32 = 48;
-pub const IP_MULTICAST_ALL: u32 = 49;
-pub const IP_UNICAST_IF: u32 = 50;
-pub const MCAST_EXCLUDE: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const IP_ROUTER_ALERT: u32 = 5;
-pub const IP_PKTINFO: u32 = 8;
-pub const IP_PKTOPTIONS: u32 = 9;
-pub const IP_PMTUDISC: u32 = 10;
-pub const IP_MTU_DISCOVER: u32 = 10;
-pub const IP_RECVERR: u32 = 11;
-pub const IP_RECVTTL: u32 = 12;
-pub const IP_RECVTOS: u32 = 13;
-pub const IP_MTU: u32 = 14;
-pub const IP_FREEBIND: u32 = 15;
-pub const IP_IPSEC_POLICY: u32 = 16;
-pub const IP_XFRM_POLICY: u32 = 17;
-pub const IP_PASSSEC: u32 = 18;
-pub const IP_TRANSPARENT: u32 = 19;
-pub const IP_ORIGDSTADDR: u32 = 20;
-pub const IP_RECVORIGDSTADDR: u32 = 20;
-pub const IP_MINTTL: u32 = 21;
-pub const IP_NODEFRAG: u32 = 22;
-pub const IP_CHECKSUM: u32 = 23;
-pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
-pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_PMTUDISC_DONT: u32 = 0;
-pub const IP_PMTUDISC_WANT: u32 = 1;
-pub const IP_PMTUDISC_DO: u32 = 2;
-pub const IP_PMTUDISC_PROBE: u32 = 3;
-pub const IP_PMTUDISC_INTERFACE: u32 = 4;
-pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const SOL_IP: u32 = 0;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MAX_MEMBERSHIPS: u32 = 20;
-pub const IPV6_ADDRFORM: u32 = 1;
-pub const IPV6_2292PKTINFO: u32 = 2;
-pub const IPV6_2292HOPOPTS: u32 = 3;
-pub const IPV6_2292DSTOPTS: u32 = 4;
-pub const IPV6_2292RTHDR: u32 = 5;
-pub const IPV6_2292PKTOPTIONS: u32 = 6;
-pub const IPV6_CHECKSUM: u32 = 7;
-pub const IPV6_2292HOPLIMIT: u32 = 8;
-pub const IPV6_NEXTHOP: u32 = 9;
-pub const IPV6_AUTHHDR: u32 = 10;
-pub const IPV6_UNICAST_HOPS: u32 = 16;
-pub const IPV6_MULTICAST_IF: u32 = 17;
-pub const IPV6_MULTICAST_HOPS: u32 = 18;
-pub const IPV6_MULTICAST_LOOP: u32 = 19;
-pub const IPV6_JOIN_GROUP: u32 = 20;
-pub const IPV6_LEAVE_GROUP: u32 = 21;
-pub const IPV6_ROUTER_ALERT: u32 = 22;
-pub const IPV6_MTU_DISCOVER: u32 = 23;
-pub const IPV6_MTU: u32 = 24;
-pub const IPV6_RECVERR: u32 = 25;
-pub const IPV6_V6ONLY: u32 = 26;
-pub const IPV6_JOIN_ANYCAST: u32 = 27;
-pub const IPV6_LEAVE_ANYCAST: u32 = 28;
-pub const IPV6_MULTICAST_ALL: u32 = 29;
-pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_IPSEC_POLICY: u32 = 34;
-pub const IPV6_XFRM_POLICY: u32 = 35;
-pub const IPV6_HDRINCL: u32 = 36;
-pub const IPV6_RECVPKTINFO: u32 = 49;
-pub const IPV6_PKTINFO: u32 = 50;
-pub const IPV6_RECVHOPLIMIT: u32 = 51;
-pub const IPV6_HOPLIMIT: u32 = 52;
-pub const IPV6_RECVHOPOPTS: u32 = 53;
-pub const IPV6_HOPOPTS: u32 = 54;
-pub const IPV6_RTHDRDSTOPTS: u32 = 55;
-pub const IPV6_RECVRTHDR: u32 = 56;
-pub const IPV6_RTHDR: u32 = 57;
-pub const IPV6_RECVDSTOPTS: u32 = 58;
-pub const IPV6_DSTOPTS: u32 = 59;
-pub const IPV6_RECVPATHMTU: u32 = 60;
-pub const IPV6_PATHMTU: u32 = 61;
-pub const IPV6_DONTFRAG: u32 = 62;
-pub const IPV6_RECVTCLASS: u32 = 66;
-pub const IPV6_TCLASS: u32 = 67;
-pub const IPV6_AUTOFLOWLABEL: u32 = 70;
-pub const IPV6_ADDR_PREFERENCES: u32 = 72;
-pub const IPV6_MINHOPCOUNT: u32 = 73;
-pub const IPV6_ORIGDSTADDR: u32 = 74;
-pub const IPV6_RECVORIGDSTADDR: u32 = 74;
-pub const IPV6_TRANSPARENT: u32 = 75;
-pub const IPV6_UNICAST_IF: u32 = 76;
-pub const IPV6_RECVFRAGSIZE: u32 = 77;
-pub const IPV6_FREEBIND: u32 = 78;
-pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
-pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
-pub const IPV6_RXHOPOPTS: u32 = 54;
-pub const IPV6_RXDSTOPTS: u32 = 59;
-pub const IPV6_PMTUDISC_DONT: u32 = 0;
-pub const IPV6_PMTUDISC_WANT: u32 = 1;
-pub const IPV6_PMTUDISC_DO: u32 = 2;
-pub const IPV6_PMTUDISC_PROBE: u32 = 3;
-pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
-pub const IPV6_PMTUDISC_OMIT: u32 = 5;
-pub const SOL_IPV6: u32 = 41;
-pub const SOL_ICMPV6: u32 = 58;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
+pub const PF_MAX: u32 = 41;
+pub const NET_MAXID: u32 = 41;
+pub const NET_RT_DUMP: u32 = 1;
+pub const NET_RT_FLAGS: u32 = 2;
+pub const NET_RT_IFLIST: u32 = 3;
+pub const NET_RT_STAT: u32 = 4;
+pub const NET_RT_TRASH: u32 = 5;
+pub const NET_RT_IFLIST2: u32 = 6;
+pub const NET_RT_DUMP2: u32 = 7;
+pub const NET_RT_FLAGS_PRIV: u32 = 10;
+pub const NET_RT_MAXID: u32 = 11;
+pub const SOMAXCONN: u32 = 128;
+pub const MSG_OOB: u32 = 1;
+pub const MSG_PEEK: u32 = 2;
+pub const MSG_DONTROUTE: u32 = 4;
+pub const MSG_EOR: u32 = 8;
+pub const MSG_TRUNC: u32 = 16;
+pub const MSG_CTRUNC: u32 = 32;
+pub const MSG_WAITALL: u32 = 64;
+pub const MSG_DONTWAIT: u32 = 128;
+pub const MSG_EOF: u32 = 256;
+pub const MSG_WAITSTREAM: u32 = 512;
+pub const MSG_FLUSH: u32 = 1024;
+pub const MSG_HOLD: u32 = 2048;
+pub const MSG_SEND: u32 = 4096;
+pub const MSG_HAVEMORE: u32 = 8192;
+pub const MSG_RCVMORE: u32 = 16384;
+pub const MSG_NEEDSA: u32 = 65536;
+pub const MSG_NOSIGNAL: u32 = 524288;
+pub const SCM_RIGHTS: u32 = 1;
+pub const SCM_TIMESTAMP: u32 = 2;
+pub const SCM_CREDS: u32 = 3;
+pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
+pub const SHUT_RD: u32 = 0;
+pub const SHUT_WR: u32 = 1;
+pub const SHUT_RDWR: u32 = 2;
+pub const IPPROTO_IP: u32 = 0;
+pub const IPPROTO_HOPOPTS: u32 = 0;
+pub const IPPROTO_ICMP: u32 = 1;
+pub const IPPROTO_IGMP: u32 = 2;
+pub const IPPROTO_GGP: u32 = 3;
+pub const IPPROTO_IPV4: u32 = 4;
+pub const IPPROTO_IPIP: u32 = 4;
+pub const IPPROTO_TCP: u32 = 6;
+pub const IPPROTO_ST: u32 = 7;
+pub const IPPROTO_EGP: u32 = 8;
+pub const IPPROTO_PIGP: u32 = 9;
+pub const IPPROTO_RCCMON: u32 = 10;
+pub const IPPROTO_NVPII: u32 = 11;
+pub const IPPROTO_PUP: u32 = 12;
+pub const IPPROTO_ARGUS: u32 = 13;
+pub const IPPROTO_EMCON: u32 = 14;
+pub const IPPROTO_XNET: u32 = 15;
+pub const IPPROTO_CHAOS: u32 = 16;
+pub const IPPROTO_UDP: u32 = 17;
+pub const IPPROTO_MUX: u32 = 18;
+pub const IPPROTO_MEAS: u32 = 19;
+pub const IPPROTO_HMP: u32 = 20;
+pub const IPPROTO_PRM: u32 = 21;
+pub const IPPROTO_IDP: u32 = 22;
+pub const IPPROTO_TRUNK1: u32 = 23;
+pub const IPPROTO_TRUNK2: u32 = 24;
+pub const IPPROTO_LEAF1: u32 = 25;
+pub const IPPROTO_LEAF2: u32 = 26;
+pub const IPPROTO_RDP: u32 = 27;
+pub const IPPROTO_IRTP: u32 = 28;
+pub const IPPROTO_TP: u32 = 29;
+pub const IPPROTO_BLT: u32 = 30;
+pub const IPPROTO_NSP: u32 = 31;
+pub const IPPROTO_INP: u32 = 32;
+pub const IPPROTO_SEP: u32 = 33;
+pub const IPPROTO_3PC: u32 = 34;
+pub const IPPROTO_IDPR: u32 = 35;
+pub const IPPROTO_XTP: u32 = 36;
+pub const IPPROTO_DDP: u32 = 37;
+pub const IPPROTO_CMTP: u32 = 38;
+pub const IPPROTO_TPXX: u32 = 39;
+pub const IPPROTO_IL: u32 = 40;
+pub const IPPROTO_IPV6: u32 = 41;
+pub const IPPROTO_SDRP: u32 = 42;
+pub const IPPROTO_ROUTING: u32 = 43;
+pub const IPPROTO_FRAGMENT: u32 = 44;
+pub const IPPROTO_IDRP: u32 = 45;
+pub const IPPROTO_RSVP: u32 = 46;
+pub const IPPROTO_GRE: u32 = 47;
+pub const IPPROTO_MHRP: u32 = 48;
+pub const IPPROTO_BHA: u32 = 49;
+pub const IPPROTO_ESP: u32 = 50;
+pub const IPPROTO_AH: u32 = 51;
+pub const IPPROTO_INLSP: u32 = 52;
+pub const IPPROTO_SWIPE: u32 = 53;
+pub const IPPROTO_NHRP: u32 = 54;
+pub const IPPROTO_ICMPV6: u32 = 58;
+pub const IPPROTO_NONE: u32 = 59;
+pub const IPPROTO_DSTOPTS: u32 = 60;
+pub const IPPROTO_AHIP: u32 = 61;
+pub const IPPROTO_CFTP: u32 = 62;
+pub const IPPROTO_HELLO: u32 = 63;
+pub const IPPROTO_SATEXPAK: u32 = 64;
+pub const IPPROTO_KRYPTOLAN: u32 = 65;
+pub const IPPROTO_RVD: u32 = 66;
+pub const IPPROTO_IPPC: u32 = 67;
+pub const IPPROTO_ADFS: u32 = 68;
+pub const IPPROTO_SATMON: u32 = 69;
+pub const IPPROTO_VISA: u32 = 70;
+pub const IPPROTO_IPCV: u32 = 71;
+pub const IPPROTO_CPNX: u32 = 72;
+pub const IPPROTO_CPHB: u32 = 73;
+pub const IPPROTO_WSN: u32 = 74;
+pub const IPPROTO_PVP: u32 = 75;
+pub const IPPROTO_BRSATMON: u32 = 76;
+pub const IPPROTO_ND: u32 = 77;
+pub const IPPROTO_WBMON: u32 = 78;
+pub const IPPROTO_WBEXPAK: u32 = 79;
+pub const IPPROTO_EON: u32 = 80;
+pub const IPPROTO_VMTP: u32 = 81;
+pub const IPPROTO_SVMTP: u32 = 82;
+pub const IPPROTO_VINES: u32 = 83;
+pub const IPPROTO_TTP: u32 = 84;
+pub const IPPROTO_IGP: u32 = 85;
+pub const IPPROTO_DGP: u32 = 86;
+pub const IPPROTO_TCF: u32 = 87;
+pub const IPPROTO_IGRP: u32 = 88;
+pub const IPPROTO_OSPFIGP: u32 = 89;
+pub const IPPROTO_SRPC: u32 = 90;
+pub const IPPROTO_LARP: u32 = 91;
+pub const IPPROTO_MTP: u32 = 92;
+pub const IPPROTO_AX25: u32 = 93;
+pub const IPPROTO_IPEIP: u32 = 94;
+pub const IPPROTO_MICP: u32 = 95;
+pub const IPPROTO_SCCSP: u32 = 96;
+pub const IPPROTO_ETHERIP: u32 = 97;
+pub const IPPROTO_ENCAP: u32 = 98;
+pub const IPPROTO_APES: u32 = 99;
+pub const IPPROTO_GMTP: u32 = 100;
+pub const IPPROTO_PIM: u32 = 103;
+pub const IPPROTO_IPCOMP: u32 = 108;
+pub const IPPROTO_PGM: u32 = 113;
+pub const IPPROTO_SCTP: u32 = 132;
+pub const IPPROTO_DIVERT: u32 = 254;
+pub const IPPROTO_RAW: u32 = 255;
+pub const IPPROTO_MAX: u32 = 256;
+pub const IPPROTO_DONE: u32 = 257;
+pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
+pub const IPPORT_USERRESERVED: u32 = 5000;
+pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
+pub const IPPORT_HILASTAUTO: u32 = 65535;
+pub const IPPORT_RESERVEDSTART: u32 = 600;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1125,56 +1392,275 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
+pub const IN_CLASSD_NET: u32 = 4026531840;
+pub const IN_CLASSD_NSHIFT: u32 = 28;
+pub const IN_CLASSD_HOST: u32 = 268435455;
+pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
+pub const IP_OPTIONS: u32 = 1;
+pub const IP_HDRINCL: u32 = 2;
+pub const IP_TOS: u32 = 3;
+pub const IP_TTL: u32 = 4;
+pub const IP_RECVOPTS: u32 = 5;
+pub const IP_RECVRETOPTS: u32 = 6;
+pub const IP_RECVDSTADDR: u32 = 7;
+pub const IP_RETOPTS: u32 = 8;
+pub const IP_MULTICAST_IF: u32 = 9;
+pub const IP_MULTICAST_TTL: u32 = 10;
+pub const IP_MULTICAST_LOOP: u32 = 11;
+pub const IP_ADD_MEMBERSHIP: u32 = 12;
+pub const IP_DROP_MEMBERSHIP: u32 = 13;
+pub const IP_MULTICAST_VIF: u32 = 14;
+pub const IP_RSVP_ON: u32 = 15;
+pub const IP_RSVP_OFF: u32 = 16;
+pub const IP_RSVP_VIF_ON: u32 = 17;
+pub const IP_RSVP_VIF_OFF: u32 = 18;
+pub const IP_PORTRANGE: u32 = 19;
+pub const IP_RECVIF: u32 = 20;
+pub const IP_IPSEC_POLICY: u32 = 21;
+pub const IP_FAITH: u32 = 22;
+pub const IP_STRIPHDR: u32 = 23;
+pub const IP_RECVTTL: u32 = 24;
+pub const IP_BOUND_IF: u32 = 25;
+pub const IP_PKTINFO: u32 = 26;
+pub const IP_RECVPKTINFO: u32 = 26;
+pub const IP_RECVTOS: u32 = 27;
+pub const IP_DONTFRAG: u32 = 28;
+pub const IP_FW_ADD: u32 = 40;
+pub const IP_FW_DEL: u32 = 41;
+pub const IP_FW_FLUSH: u32 = 42;
+pub const IP_FW_ZERO: u32 = 43;
+pub const IP_FW_GET: u32 = 44;
+pub const IP_FW_RESETLOG: u32 = 45;
+pub const IP_OLD_FW_ADD: u32 = 50;
+pub const IP_OLD_FW_DEL: u32 = 51;
+pub const IP_OLD_FW_FLUSH: u32 = 52;
+pub const IP_OLD_FW_ZERO: u32 = 53;
+pub const IP_OLD_FW_GET: u32 = 54;
+pub const IP_NAT__XXX: u32 = 55;
+pub const IP_OLD_FW_RESETLOG: u32 = 56;
+pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
+pub const IP_DUMMYNET_DEL: u32 = 61;
+pub const IP_DUMMYNET_FLUSH: u32 = 62;
+pub const IP_DUMMYNET_GET: u32 = 64;
+pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
+pub const IP_MULTICAST_IFINDEX: u32 = 66;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
+pub const IP_BLOCK_SOURCE: u32 = 72;
+pub const IP_UNBLOCK_SOURCE: u32 = 73;
+pub const IP_MSFILTER: u32 = 74;
+pub const MCAST_JOIN_GROUP: u32 = 80;
+pub const MCAST_LEAVE_GROUP: u32 = 81;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
+pub const MCAST_BLOCK_SOURCE: u32 = 84;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MIN_MEMBERSHIPS: u32 = 31;
+pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
+pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
+pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
+pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
+pub const MCAST_UNDEFINED: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const MCAST_EXCLUDE: u32 = 2;
+pub const IP_PORTRANGE_DEFAULT: u32 = 0;
+pub const IP_PORTRANGE_HIGH: u32 = 1;
+pub const IP_PORTRANGE_LOW: u32 = 2;
+pub const IPPROTO_MAXID: u32 = 52;
+pub const IPCTL_FORWARDING: u32 = 1;
+pub const IPCTL_SENDREDIRECTS: u32 = 2;
+pub const IPCTL_DEFTTL: u32 = 3;
+pub const IPCTL_RTEXPIRE: u32 = 5;
+pub const IPCTL_RTMINEXPIRE: u32 = 6;
+pub const IPCTL_RTMAXCACHE: u32 = 7;
+pub const IPCTL_SOURCEROUTE: u32 = 8;
+pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
+pub const IPCTL_INTRQMAXLEN: u32 = 10;
+pub const IPCTL_INTRQDROPS: u32 = 11;
+pub const IPCTL_STATS: u32 = 12;
+pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
+pub const IPCTL_FASTFORWARDING: u32 = 14;
+pub const IPCTL_KEEPFAITH: u32 = 15;
+pub const IPCTL_GIF_TTL: u32 = 16;
+pub const IPCTL_MAXID: u32 = 17;
+pub const __KAME_VERSION: &'static [u8; 18usize] = b"2009/apple-darwin\0";
+pub const IPV6PORT_RESERVED: u32 = 1024;
+pub const IPV6PORT_ANONMIN: u32 = 49152;
+pub const IPV6PORT_ANONMAX: u32 = 65535;
+pub const IPV6PORT_RESERVEDMIN: u32 = 600;
+pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const _RPC_NETDB_H: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
+pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
+pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
+pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
+pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
+pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
+pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
+pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
+pub const IPV6_UNICAST_HOPS: u32 = 4;
+pub const IPV6_MULTICAST_IF: u32 = 9;
+pub const IPV6_MULTICAST_HOPS: u32 = 10;
+pub const IPV6_MULTICAST_LOOP: u32 = 11;
+pub const IPV6_JOIN_GROUP: u32 = 12;
+pub const IPV6_LEAVE_GROUP: u32 = 13;
+pub const IPV6_PORTRANGE: u32 = 14;
+pub const ICMP6_FILTER: u32 = 18;
+pub const IPV6_2292PKTINFO: u32 = 19;
+pub const IPV6_2292HOPLIMIT: u32 = 20;
+pub const IPV6_2292NEXTHOP: u32 = 21;
+pub const IPV6_2292HOPOPTS: u32 = 22;
+pub const IPV6_2292DSTOPTS: u32 = 23;
+pub const IPV6_2292RTHDR: u32 = 24;
+pub const IPV6_2292PKTOPTIONS: u32 = 25;
+pub const IPV6_CHECKSUM: u32 = 26;
+pub const IPV6_V6ONLY: u32 = 27;
+pub const IPV6_BINDV6ONLY: u32 = 27;
+pub const IPV6_IPSEC_POLICY: u32 = 28;
+pub const IPV6_FAITH: u32 = 29;
+pub const IPV6_FW_ADD: u32 = 30;
+pub const IPV6_FW_DEL: u32 = 31;
+pub const IPV6_FW_FLUSH: u32 = 32;
+pub const IPV6_FW_ZERO: u32 = 33;
+pub const IPV6_FW_GET: u32 = 34;
+pub const IPV6_RECVTCLASS: u32 = 35;
+pub const IPV6_TCLASS: u32 = 36;
+pub const IPV6_BOUND_IF: u32 = 125;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
+pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
+pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
+pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
+pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
+pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
+pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
+pub const IPV6_PORTRANGE_HIGH: u32 = 1;
+pub const IPV6_PORTRANGE_LOW: u32 = 2;
+pub const IPV6PROTO_MAXID: u32 = 104;
+pub const IPV6CTL_FORWARDING: u32 = 1;
+pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
+pub const IPV6CTL_DEFHLIM: u32 = 3;
+pub const IPV6CTL_FORWSRCRT: u32 = 5;
+pub const IPV6CTL_STATS: u32 = 6;
+pub const IPV6CTL_MRTSTATS: u32 = 7;
+pub const IPV6CTL_MRTPROTO: u32 = 8;
+pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
+pub const IPV6CTL_SOURCECHECK: u32 = 10;
+pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
+pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
+pub const IPV6CTL_KEEPFAITH: u32 = 13;
+pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
+pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
+pub const IPV6CTL_DAD_COUNT: u32 = 16;
+pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
+pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
+pub const IPV6CTL_GIF_HLIM: u32 = 19;
+pub const IPV6CTL_KAME_VERSION: u32 = 20;
+pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
+pub const IPV6CTL_RR_PRUNE: u32 = 22;
+pub const IPV6CTL_V6ONLY: u32 = 24;
+pub const IPV6CTL_RTEXPIRE: u32 = 25;
+pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
+pub const IPV6CTL_RTMAXCACHE: u32 = 27;
+pub const IPV6CTL_USETEMPADDR: u32 = 32;
+pub const IPV6CTL_TEMPPLTIME: u32 = 33;
+pub const IPV6CTL_TEMPVLTIME: u32 = 34;
+pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
+pub const IPV6CTL_RIP6STATS: u32 = 36;
+pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
+pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
+pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
+pub const IPV6CTL_MAXFRAGS: u32 = 41;
+pub const IPV6CTL_MCAST_PMTU: u32 = 44;
+pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
+pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
+pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
+pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
+pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
+pub const IPV6CTL_MAXID: u32 = 51;
 pub const _PATH_HEQUIV: &'static [u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &'static [u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &'static [u8; 14usize] = b"/etc/networks\0";
-pub const _PATH_NSSWITCH_CONF: &'static [u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &'static [u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &'static [u8; 14usize] = b"/etc/services\0";
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
+pub const EAI_ADDRFAMILY: u32 = 1;
+pub const EAI_AGAIN: u32 = 2;
+pub const EAI_BADFLAGS: u32 = 3;
+pub const EAI_FAIL: u32 = 4;
+pub const EAI_FAMILY: u32 = 5;
+pub const EAI_MEMORY: u32 = 6;
+pub const EAI_NODATA: u32 = 7;
+pub const EAI_NONAME: u32 = 8;
+pub const EAI_SERVICE: u32 = 9;
+pub const EAI_SOCKTYPE: u32 = 10;
+pub const EAI_SYSTEM: u32 = 11;
+pub const EAI_BADHINTS: u32 = 12;
+pub const EAI_PROTOCOL: u32 = 13;
+pub const EAI_OVERFLOW: u32 = 14;
+pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_V4MAPPED: u32 = 8;
-pub const AI_ALL: u32 = 16;
-pub const AI_ADDRCONFIG: u32 = 32;
-pub const AI_NUMERICSERV: u32 = 1024;
-pub const EAI_BADFLAGS: i32 = -1;
-pub const EAI_NONAME: i32 = -2;
-pub const EAI_AGAIN: i32 = -3;
-pub const EAI_FAIL: i32 = -4;
-pub const EAI_FAMILY: i32 = -6;
-pub const EAI_SOCKTYPE: i32 = -7;
-pub const EAI_SERVICE: i32 = -8;
-pub const EAI_MEMORY: i32 = -10;
-pub const EAI_SYSTEM: i32 = -11;
-pub const EAI_OVERFLOW: i32 = -12;
+pub const AI_NUMERICSERV: u32 = 4096;
+pub const AI_ALL: u32 = 256;
+pub const AI_V4MAPPED_CFG: u32 = 512;
+pub const AI_ADDRCONFIG: u32 = 1024;
+pub const AI_V4MAPPED: u32 = 2048;
+pub const AI_DEFAULT: u32 = 1536;
+pub const AI_UNUSABLE: u32 = 268435456;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NUMERICHOST: u32 = 1;
-pub const NI_NUMERICSERV: u32 = 2;
-pub const NI_NOFQDN: u32 = 4;
-pub const NI_NAMEREQD: u32 = 8;
+pub const NI_NOFQDN: u32 = 1;
+pub const NI_NUMERICHOST: u32 = 2;
+pub const NI_NAMEREQD: u32 = 4;
+pub const NI_NUMERICSERV: u32 = 8;
+pub const NI_NUMERICSCOPE: u32 = 256;
 pub const NI_DGRAM: u32 = 16;
-pub const _PWD_H: u32 = 1;
-pub const NSS_BUFLEN_PASSWD: u32 = 1024;
+pub const NI_WITHSCOPEID: u32 = 32;
+pub const SCOPE_DELIMITER: u8 = 37u8;
+pub const _PATH_PWD: &'static [u8; 5usize] = b"/etc\0";
+pub const _PATH_PASSWD: &'static [u8; 12usize] = b"/etc/passwd\0";
+pub const _PASSWD: &'static [u8; 7usize] = b"passwd\0";
+pub const _PATH_MASTERPASSWD: &'static [u8; 19usize] = b"/etc/master.passwd\0";
+pub const _PATH_MASTERPASSWD_LOCK: &'static [u8; 10usize] = b"/etc/ptmp\0";
+pub const _MASTERPASSWD: &'static [u8; 14usize] = b"master.passwd\0";
+pub const _PATH_MP_DB: &'static [u8; 12usize] = b"/etc/pwd.db\0";
+pub const _MP_DB: &'static [u8; 7usize] = b"pwd.db\0";
+pub const _PATH_SMP_DB: &'static [u8; 13usize] = b"/etc/spwd.db\0";
+pub const _SMP_DB: &'static [u8; 8usize] = b"spwd.db\0";
+pub const _PATH_PWD_MKDB: &'static [u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
+pub const _PW_KEYBYNAME: u8 = 49u8;
+pub const _PW_KEYBYNUM: u8 = 50u8;
+pub const _PW_KEYBYUID: u8 = 51u8;
+pub const _PASSWORD_EFMT1: u8 = 95u8;
+pub const _PASSWORD_LEN: u32 = 128;
+pub const _PASSWORD_NOUID: u32 = 1;
+pub const _PASSWORD_NOGID: u32 = 2;
+pub const _PASSWORD_NOCHG: u32 = 4;
+pub const _PASSWORD_NOEXP: u32 = 8;
+pub const _PASSWORD_WARNDAYS: u32 = 14;
+pub const _PASSWORD_CHGNOW: i32 = -1;
 pub const PGINVALID_SOCKET: i32 = -1;
 pub const PG_BACKEND_VERSIONSTR: &'static [u8; 29usize] = b"postgres (PostgreSQL) 10.16\n\0";
 pub const EXE: &'static [u8; 1usize] = b"\0";
 pub const DEVNULL: &'static [u8; 10usize] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
-pub const _SETJMP_H: u32 = 1;
-pub const _BITS_SETJMP_H: u32 = 1;
+pub const _JBLEN: u32 = 37;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1283,84 +1769,121 @@ pub const SK_SEARCHARRAY: u32 = 32;
 pub const SK_SEARCHNULL: u32 = 64;
 pub const SK_SEARCHNOTNULL: u32 = 128;
 pub const SK_ORDER_BY: u32 = 256;
-pub const _LIBC_LIMITS_H_: u32 = 1;
-pub const MB_LEN_MAX: u32 = 16;
-pub const _BITS_POSIX1_LIM_H: u32 = 1;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
+pub const __DARWIN_CLK_TCK: u32 = 100;
+pub const CHAR_BIT: u32 = 8;
+pub const MB_LEN_MAX: u32 = 6;
+pub const CLK_TCK: u32 = 100;
+pub const SCHAR_MAX: u32 = 127;
+pub const SCHAR_MIN: i32 = -128;
+pub const UCHAR_MAX: u32 = 255;
+pub const CHAR_MAX: u32 = 127;
+pub const CHAR_MIN: i32 = -128;
+pub const USHRT_MAX: u32 = 65535;
+pub const SHRT_MAX: u32 = 32767;
+pub const SHRT_MIN: i32 = -32768;
+pub const UINT_MAX: u32 = 4294967295;
+pub const INT_MAX: u32 = 2147483647;
+pub const INT_MIN: i32 = -2147483648;
+pub const ULONG_MAX: i32 = -1;
+pub const LONG_MAX: u64 = 9223372036854775807;
+pub const LONG_MIN: i64 = -9223372036854775808;
+pub const ULLONG_MAX: i32 = -1;
+pub const LLONG_MAX: u64 = 9223372036854775807;
+pub const LLONG_MIN: i64 = -9223372036854775808;
+pub const LONG_BIT: u32 = 64;
+pub const SSIZE_MAX: u64 = 9223372036854775807;
+pub const WORD_BIT: u32 = 32;
+pub const SIZE_T_MAX: i32 = -1;
+pub const UQUAD_MAX: i32 = -1;
+pub const QUAD_MAX: u64 = 9223372036854775807;
+pub const QUAD_MIN: i64 = -9223372036854775808;
+pub const ARG_MAX: u32 = 1048576;
+pub const CHILD_MAX: u32 = 266;
+pub const GID_MAX: u32 = 2147483647;
+pub const LINK_MAX: u32 = 32767;
+pub const MAX_CANON: u32 = 1024;
+pub const MAX_INPUT: u32 = 1024;
+pub const NAME_MAX: u32 = 255;
+pub const NGROUPS_MAX: u32 = 16;
+pub const UID_MAX: u32 = 2147483647;
+pub const OPEN_MAX: u32 = 10240;
+pub const PATH_MAX: u32 = 1024;
+pub const PIPE_BUF: u32 = 512;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const CHARCLASS_NAME_MAX: u32 = 14;
+pub const COLL_WEIGHTS_MAX: u32 = 2;
+pub const EQUIV_CLASS_MAX: u32 = 2;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 255;
+pub const NZERO: u32 = 20;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_RTSIG_MAX: u32 = 8;
-pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
-pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
-pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
 pub const _POSIX_SSIZE_MAX: u32 = 32767;
 pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_SYMLINK_MAX: u32 = 255;
-pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_TTY_NAME_MAX: u32 = 9;
 pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const NR_OPEN: u32 = 1024;
-pub const NGROUPS_MAX: u32 = 65536;
-pub const ARG_MAX: u32 = 131072;
-pub const LINK_MAX: u32 = 127;
-pub const MAX_CANON: u32 = 255;
-pub const MAX_INPUT: u32 = 255;
-pub const NAME_MAX: u32 = 255;
-pub const PATH_MAX: u32 = 4096;
-pub const PIPE_BUF: u32 = 4096;
-pub const XATTR_NAME_MAX: u32 = 255;
-pub const XATTR_SIZE_MAX: u32 = 65536;
-pub const XATTR_LIST_MAX: u32 = 65536;
-pub const RTSIG_MAX: u32 = 32;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const PTHREAD_KEYS_MAX: u32 = 1024;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const AIO_PRIO_DELTA_MAX: u32 = 20;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const DELAYTIMER_MAX: u32 = 2147483647;
-pub const TTY_NAME_MAX: u32 = 32;
-pub const LOGIN_NAME_MAX: u32 = 256;
-pub const HOST_NAME_MAX: u32 = 64;
-pub const MQ_PRIO_MAX: u32 = 32768;
-pub const SEM_VALUE_MAX: u32 = 2147483647;
-pub const _BITS_POSIX2_LIM_H: u32 = 1;
 pub const _POSIX2_BC_BASE_MAX: u32 = 99;
 pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
 pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
 pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
+pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
 pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
 pub const _POSIX2_LINE_MAX: u32 = 2048;
 pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RTSIG_MAX: u32 = 8;
+pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
+pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
+pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_KEYS_MAX: u32 = 512;
+pub const PTHREAD_STACK_MIN: u32 = 8192;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
+pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SYMLINK_MAX: u32 = 255;
+pub const _POSIX_SYMLOOP_MAX: u32 = 8;
+pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
+pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
+pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
+pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TTY_NAME_MAX: u32 = 9;
 pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const COLL_WEIGHTS_MAX: u32 = 255;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const CHARCLASS_NAME_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 32767;
+pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
+pub const OFF_MIN: i64 = -9223372036854775808;
+pub const OFF_MAX: u64 = 9223372036854775807;
+pub const PASS_MAX: u32 = 128;
+pub const NL_ARGMAX: u32 = 9;
+pub const NL_LANGMAX: u32 = 14;
+pub const NL_MSGMAX: u32 = 32767;
+pub const NL_NMAX: u32 = 1;
+pub const NL_SETMAX: u32 = 255;
+pub const NL_TEXTMAX: u32 = 2048;
+pub const _XOPEN_IOV_MAX: u32 = 16;
+pub const IOV_MAX: u32 = 1024;
+pub const _XOPEN_NAME_MAX: u32 = 255;
+pub const _XOPEN_PATH_MAX: u32 = 1024;
 pub const DSM_IMPL_NONE: u32 = 0;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
@@ -1386,139 +1909,153 @@ pub const ShareRowExclusiveLock: u32 = 6;
 pub const ExclusiveLock: u32 = 7;
 pub const AccessExclusiveLock: u32 = 8;
 pub const BITS_PER_BITMAPWORD: u32 = 32;
-pub const _FCNTL_H: u32 = 1;
-pub const __O_LARGEFILE: u32 = 0;
-pub const F_GETLK64: u32 = 5;
-pub const F_SETLK64: u32 = 6;
-pub const F_SETLKW64: u32 = 7;
-pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_CREAT: u32 = 64;
-pub const O_EXCL: u32 = 128;
-pub const O_NOCTTY: u32 = 256;
-pub const O_TRUNC: u32 = 512;
-pub const O_APPEND: u32 = 1024;
-pub const O_NONBLOCK: u32 = 2048;
-pub const O_NDELAY: u32 = 2048;
-pub const O_SYNC: u32 = 1052672;
-pub const O_FSYNC: u32 = 1052672;
-pub const O_ASYNC: u32 = 8192;
-pub const __O_DIRECTORY: u32 = 65536;
-pub const __O_NOFOLLOW: u32 = 131072;
-pub const __O_CLOEXEC: u32 = 524288;
-pub const __O_DIRECT: u32 = 16384;
-pub const __O_NOATIME: u32 = 262144;
-pub const __O_PATH: u32 = 2097152;
-pub const __O_DSYNC: u32 = 4096;
-pub const __O_TMPFILE: u32 = 4259840;
-pub const F_GETLK: u32 = 5;
-pub const F_SETLK: u32 = 6;
-pub const F_SETLKW: u32 = 7;
-pub const O_DIRECTORY: u32 = 65536;
-pub const O_NOFOLLOW: u32 = 131072;
-pub const O_CLOEXEC: u32 = 524288;
-pub const O_DSYNC: u32 = 4096;
-pub const O_RSYNC: u32 = 1052672;
+pub const O_ACCMODE: u32 = 3;
+pub const FREAD: u32 = 1;
+pub const FWRITE: u32 = 2;
+pub const O_NONBLOCK: u32 = 4;
+pub const O_APPEND: u32 = 8;
+pub const O_SYNC: u32 = 128;
+pub const O_SHLOCK: u32 = 16;
+pub const O_EXLOCK: u32 = 32;
+pub const O_ASYNC: u32 = 64;
+pub const O_FSYNC: u32 = 128;
+pub const O_NOFOLLOW: u32 = 256;
+pub const O_CREAT: u32 = 512;
+pub const O_TRUNC: u32 = 1024;
+pub const O_EXCL: u32 = 2048;
+pub const O_EVTONLY: u32 = 32768;
+pub const O_NOCTTY: u32 = 131072;
+pub const O_DIRECTORY: u32 = 1048576;
+pub const O_SYMLINK: u32 = 2097152;
+pub const O_DSYNC: u32 = 4194304;
+pub const O_CLOEXEC: u32 = 16777216;
+pub const O_NOFOLLOW_ANY: u32 = 536870912;
+pub const AT_FDCWD: i32 = -2;
+pub const AT_EACCESS: u32 = 16;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
+pub const AT_SYMLINK_FOLLOW: u32 = 64;
+pub const AT_REMOVEDIR: u32 = 128;
+pub const AT_REALDEV: u32 = 512;
+pub const AT_FDONLY: u32 = 1024;
+pub const O_DP_GETRAWENCRYPTED: u32 = 1;
+pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
+pub const FAPPEND: u32 = 8;
+pub const FASYNC: u32 = 64;
+pub const FFSYNC: u32 = 128;
+pub const FFDSYNC: u32 = 4194304;
+pub const FNONBLOCK: u32 = 4;
+pub const FNDELAY: u32 = 4;
+pub const O_NDELAY: u32 = 4;
+pub const CPF_OVERWRITE: u32 = 1;
+pub const CPF_IGNORE_MODE: u32 = 2;
+pub const CPF_MASK: u32 = 3;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const __F_SETOWN: u32 = 8;
-pub const __F_GETOWN: u32 = 9;
-pub const F_SETOWN: u32 = 8;
-pub const F_GETOWN: u32 = 9;
-pub const __F_SETSIG: u32 = 10;
-pub const __F_GETSIG: u32 = 11;
-pub const __F_SETOWN_EX: u32 = 15;
-pub const __F_GETOWN_EX: u32 = 16;
-pub const F_DUPFD_CLOEXEC: u32 = 1030;
+pub const F_GETOWN: u32 = 5;
+pub const F_SETOWN: u32 = 6;
+pub const F_GETLK: u32 = 7;
+pub const F_SETLK: u32 = 8;
+pub const F_SETLKW: u32 = 9;
+pub const F_SETLKWTIMEOUT: u32 = 10;
+pub const F_FLUSH_DATA: u32 = 40;
+pub const F_CHKCLEAN: u32 = 41;
+pub const F_PREALLOCATE: u32 = 42;
+pub const F_SETSIZE: u32 = 43;
+pub const F_RDADVISE: u32 = 44;
+pub const F_RDAHEAD: u32 = 45;
+pub const F_NOCACHE: u32 = 48;
+pub const F_LOG2PHYS: u32 = 49;
+pub const F_GETPATH: u32 = 50;
+pub const F_FULLFSYNC: u32 = 51;
+pub const F_PATHPKG_CHECK: u32 = 52;
+pub const F_FREEZE_FS: u32 = 53;
+pub const F_THAW_FS: u32 = 54;
+pub const F_GLOBAL_NOCACHE: u32 = 55;
+pub const F_ADDSIGS: u32 = 59;
+pub const F_ADDFILESIGS: u32 = 61;
+pub const F_NODIRECT: u32 = 62;
+pub const F_GETPROTECTIONCLASS: u32 = 63;
+pub const F_SETPROTECTIONCLASS: u32 = 64;
+pub const F_LOG2PHYS_EXT: u32 = 65;
+pub const F_GETLKPID: u32 = 66;
+pub const F_SETBACKINGSTORE: u32 = 70;
+pub const F_GETPATH_MTMINFO: u32 = 71;
+pub const F_GETCODEDIR: u32 = 72;
+pub const F_SETNOSIGPIPE: u32 = 73;
+pub const F_GETNOSIGPIPE: u32 = 74;
+pub const F_TRANSCODEKEY: u32 = 75;
+pub const F_SINGLE_WRITER: u32 = 76;
+pub const F_GETPROTECTIONLEVEL: u32 = 77;
+pub const F_FINDSIGS: u32 = 78;
+pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
+pub const F_BARRIERFSYNC: u32 = 85;
+pub const F_ADDFILESIGS_RETURN: u32 = 97;
+pub const F_CHECK_LV: u32 = 98;
+pub const F_PUNCHHOLE: u32 = 99;
+pub const F_TRIM_ACTIVE_FILE: u32 = 100;
+pub const F_SPECULATIVE_READ: u32 = 101;
+pub const F_GETPATH_NOFIRMLINK: u32 = 102;
+pub const F_ADDFILESIGS_INFO: u32 = 103;
+pub const F_ADDFILESUPPL: u32 = 104;
+pub const F_GETSIGSINFO: u32 = 105;
+pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
+pub const F_DUPFD_CLOEXEC: u32 = 67;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 0;
-pub const F_WRLCK: u32 = 1;
+pub const F_RDLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_EXLCK: u32 = 4;
-pub const F_SHLCK: u32 = 8;
+pub const F_WRLCK: u32 = 3;
+pub const SEEK_HOLE: u32 = 3;
+pub const SEEK_DATA: u32 = 4;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_IFWHT: u32 = 57344;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXG: u32 = 56;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXO: u32 = 7;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_ISTXT: u32 = 512;
+pub const S_IREAD: u32 = 256;
+pub const S_IWRITE: u32 = 128;
+pub const S_IEXEC: u32 = 64;
+pub const F_ALLOCATECONTIG: u32 = 2;
+pub const F_ALLOCATEALL: u32 = 4;
+pub const F_PEOFPOSMODE: u32 = 3;
+pub const F_VOLPOSMODE: u32 = 4;
+pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
+pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const FAPPEND: u32 = 1024;
-pub const FFSYNC: u32 = 1052672;
-pub const FASYNC: u32 = 8192;
-pub const FNONBLOCK: u32 = 2048;
-pub const FNDELAY: u32 = 2048;
-pub const __POSIX_FADV_DONTNEED: u32 = 4;
-pub const __POSIX_FADV_NOREUSE: u32 = 5;
-pub const POSIX_FADV_NORMAL: u32 = 0;
-pub const POSIX_FADV_RANDOM: u32 = 1;
-pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
-pub const POSIX_FADV_WILLNEED: u32 = 3;
-pub const POSIX_FADV_DONTNEED: u32 = 4;
-pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const _BITS_STAT_H: u32 = 1;
-pub const _STAT_VER_KERNEL: u32 = 0;
-pub const _STAT_VER_LINUX: u32 = 1;
-pub const _MKNOD_VER_LINUX: u32 = 0;
-pub const _STAT_VER: u32 = 1;
-pub const __S_IFMT: u32 = 61440;
-pub const __S_IFDIR: u32 = 16384;
-pub const __S_IFCHR: u32 = 8192;
-pub const __S_IFBLK: u32 = 24576;
-pub const __S_IFREG: u32 = 32768;
-pub const __S_IFIFO: u32 = 4096;
-pub const __S_IFLNK: u32 = 40960;
-pub const __S_IFSOCK: u32 = 49152;
-pub const __S_ISUID: u32 = 2048;
-pub const __S_ISGID: u32 = 1024;
-pub const __S_ISVTX: u32 = 512;
-pub const __S_IREAD: u32 = 256;
-pub const __S_IWRITE: u32 = 128;
-pub const __S_IEXEC: u32 = 64;
-pub const UTIME_NOW: u32 = 1073741823;
-pub const UTIME_OMIT: u32 = 1073741822;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXG: u32 = 56;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_IRWXO: u32 = 7;
-pub const R_OK: u32 = 4;
-pub const W_OK: u32 = 2;
-pub const X_OK: u32 = 1;
-pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
-pub const F_ULOCK: u32 = 0;
-pub const F_LOCK: u32 = 1;
-pub const F_TLOCK: u32 = 2;
-pub const F_TEST: u32 = 3;
+pub const O_POPUP: u32 = 2147483648;
+pub const O_ALERT: u32 = 536870912;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 1052672;
-pub const OPEN_DATASYNC_FLAG: u32 = 4096;
+pub const OPEN_SYNC_FLAG: u32 = 128;
+pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
 pub const MAX_TIMESTAMP_PRECISION: u32 = 6;
 pub const MAX_INTERVAL_PRECISION: u32 = 6;
 pub const TS_PREC_INV: f64 = 1000000.0;
@@ -1562,24 +2099,8 @@ pub const HEAP_INSERT_SKIP_FSM: u32 = 2;
 pub const HEAP_INSERT_FROZEN: u32 = 4;
 pub const HEAP_INSERT_SPECULATIVE: u32 = 8;
 pub const HEAP_INSERT_NO_LOGICAL: u32 = 16;
-pub const _TIME_H: u32 = 1;
-pub const _BITS_TIME_H: u32 = 1;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_TAI: u32 = 11;
-pub const TIMER_ABSTIME: u32 = 1;
-pub const __struct_tm_defined: u32 = 1;
-pub const __itimerspec_defined: u32 = 1;
+pub const CLOCKS_PER_SEC: u32 = 1000000;
 pub const TIME_UTC: u32 = 1;
-pub const PG_INSTR_CLOCK: u32 = 1;
 pub const PARAM_FLAG_CONST: u32 = 1;
 pub const HASH_PARTITION: u32 = 1;
 pub const HASH_SEGMENT: u32 = 2;
@@ -1655,6 +2176,7 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
+pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const FORKNAMECHARS: u32 = 4;
 pub const InvalidBackendId: i32 = -1;
@@ -1682,9 +2204,25 @@ pub const XLR_MAX_BLOCK_ID: u32 = 32;
 pub const XLR_BLOCK_ID_DATA_SHORT: u32 = 255;
 pub const XLR_BLOCK_ID_DATA_LONG: u32 = 254;
 pub const XLR_BLOCK_ID_ORIGIN: u32 = 253;
-pub const _DIRENT_H: u32 = 1;
-pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
+pub const __DARWIN_MAXNAMLEN: u32 = 255;
+pub const __DARWIN_MAXPATHLEN: u32 = 1024;
 pub const MAXNAMLEN: u32 = 255;
+pub const DT_UNKNOWN: u32 = 0;
+pub const DT_FIFO: u32 = 1;
+pub const DT_CHR: u32 = 2;
+pub const DT_DIR: u32 = 4;
+pub const DT_BLK: u32 = 6;
+pub const DT_REG: u32 = 8;
+pub const DT_LNK: u32 = 10;
+pub const DT_SOCK: u32 = 12;
+pub const DT_WHT: u32 = 14;
+pub const DIRBLKSIZ: u32 = 1024;
+pub const DTF_HIDEW: u32 = 1;
+pub const DTF_NODUP: u32 = 2;
+pub const DTF_REWIND: u32 = 4;
+pub const __DTF_READALL: u32 = 8;
+pub const __DTF_SKIPREAD: u32 = 16;
+pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const SYNC_METHOD_FSYNC: u32 = 0;
@@ -1832,85 +2370,6 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
-pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGILL: u32 = 4;
-pub const SIGABRT: u32 = 6;
-pub const SIGFPE: u32 = 8;
-pub const SIGSEGV: u32 = 11;
-pub const SIGTERM: u32 = 15;
-pub const SIGHUP: u32 = 1;
-pub const SIGQUIT: u32 = 3;
-pub const SIGTRAP: u32 = 5;
-pub const SIGKILL: u32 = 9;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGXCPU: u32 = 24;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
-pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
-pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
-pub const __sig_atomic_t_defined: u32 = 1;
-pub const __siginfo_t_defined: u32 = 1;
-pub const __SI_MAX_SIZE: u32 = 128;
-pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
-pub const __SI_ERRNO_THEN_CODE: u32 = 1;
-pub const __SI_HAVE_SIGSYS: u32 = 1;
-pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
-pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
-pub const __sigevent_t_defined: u32 = 1;
-pub const __SIGEV_MAX_SIZE: u32 = 64;
-pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
-pub const _BITS_SIGACTION_H: u32 = 1;
-pub const SA_NOCLDSTOP: u32 = 1;
-pub const SA_NOCLDWAIT: u32 = 2;
-pub const SA_SIGINFO: u32 = 4;
-pub const SA_ONSTACK: u32 = 134217728;
-pub const SA_RESTART: u32 = 268435456;
-pub const SA_NODEFER: u32 = 1073741824;
-pub const SA_RESETHAND: u32 = 2147483648;
-pub const SA_INTERRUPT: u32 = 536870912;
-pub const SA_NOMASK: u32 = 1073741824;
-pub const SA_ONESHOT: u32 = 2147483648;
-pub const SA_STACK: u32 = 134217728;
-pub const SIG_BLOCK: u32 = 0;
-pub const SIG_UNBLOCK: u32 = 1;
-pub const SIG_SETMASK: u32 = 2;
-pub const _BITS_SIGCONTEXT_H: u32 = 1;
-pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
-pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
-pub const __stack_t_defined: u32 = 1;
-pub const _SYS_UCONTEXT_H: u32 = 1;
-pub const __NGREG: u32 = 23;
-pub const NGREG: u32 = 23;
-pub const _BITS_SIGSTACK_H: u32 = 1;
-pub const MINSIGSTKSZ: u32 = 2048;
-pub const SIGSTKSZ: u32 = 8192;
-pub const _BITS_SS_FLAGS_H: u32 = 1;
-pub const __sigstack_defined: u32 = 1;
-pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -1929,7 +2388,13 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const _SYS_UN_H: u32 = 1;
+pub const SOL_LOCAL: u32 = 0;
+pub const LOCAL_PEERCRED: u32 = 1;
+pub const LOCAL_PEERPID: u32 = 2;
+pub const LOCAL_PEEREPID: u32 = 3;
+pub const LOCAL_PEERUUID: u32 = 4;
+pub const LOCAL_PEEREUUID: u32 = 5;
+pub const LOCAL_PEERTOKEN: u32 = 6;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -2602,6 +3067,7 @@ pub const PROCARRAY_FLAGS_DEFAULT: u32 = 16;
 pub const PROCARRAY_FLAGS_VACUUM: u32 = 18;
 pub const PROCARRAY_FLAGS_ANALYZE: u32 = 20;
 pub const PROCARRAY_FLAGS_VACUUM_ANALYZE: u32 = 22;
+pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &'static [u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -2627,18 +3093,11 @@ pub const GUC_UNIT_MIN: u32 = 196608;
 pub const GUC_UNIT_TIME: u32 = 983040;
 pub const GUC_UNIT: u32 = 1044480;
 pub const STACK_DEPTH_SLOP: u32 = 524288;
-pub const _MATH_H: u32 = 1;
-pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
-pub const __FP_LOGB0_IS_MIN: u32 = 1;
-pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
+pub const FP_SUPERNORMAL: u32 = 6;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
-pub const __MATH_DECLARING_DOUBLE: u32 = 1;
-pub const __MATH_DECLARING_FLOATN: u32 = 0;
-pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
-pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -2652,6 +3111,12 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
+pub const DOMAIN: u32 = 1;
+pub const SING: u32 = 2;
+pub const OVERFLOW: u32 = 3;
+pub const UNDERFLOW: u32 = 4;
+pub const TLOSS: u32 = 5;
+pub const PLOSS: u32 = 6;
 pub const MAX_TIME_PRECISION: u32 = 6;
 pub const NUMERIC_MAX_PRECISION: u32 = 1000;
 pub const NUMERIC_MAX_DISPLAY_SCALE: u32 = 1000;
@@ -2717,195 +3182,428 @@ pub const TYPECACHE_RANGE_INFO: u32 = 2048;
 pub const TYPECACHE_DOMAIN_INFO: u32 = 4096;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
-pub type va_list = __builtin_va_list;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type __u_char = ::std::os::raw::c_uchar;
-pub type __u_short = ::std::os::raw::c_ushort;
-pub type __u_int = ::std::os::raw::c_uint;
-pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_long;
-pub type __uint64_t = ::std::os::raw::c_ulong;
-pub type __int_least8_t = __int8_t;
-pub type __uint_least8_t = __uint8_t;
-pub type __int_least16_t = __int16_t;
-pub type __uint_least16_t = __uint16_t;
-pub type __int_least32_t = __int32_t;
-pub type __uint_least32_t = __uint32_t;
-pub type __int_least64_t = __int64_t;
-pub type __uint_least64_t = __uint64_t;
-pub type __quad_t = ::std::os::raw::c_long;
-pub type __u_quad_t = ::std::os::raw::c_ulong;
-pub type __intmax_t = ::std::os::raw::c_long;
-pub type __uintmax_t = ::std::os::raw::c_ulong;
-pub type __dev_t = ::std::os::raw::c_ulong;
-pub type __uid_t = ::std::os::raw::c_uint;
-pub type __gid_t = ::std::os::raw::c_uint;
-pub type __ino_t = ::std::os::raw::c_ulong;
-pub type __ino64_t = ::std::os::raw::c_ulong;
-pub type __mode_t = ::std::os::raw::c_uint;
-pub type __nlink_t = ::std::os::raw::c_ulong;
-pub type __off_t = ::std::os::raw::c_long;
-pub type __off64_t = ::std::os::raw::c_long;
-pub type __pid_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __fsid_t {
-    pub __val: [::std::os::raw::c_int; 2usize],
-}
-pub type __clock_t = ::std::os::raw::c_long;
-pub type __rlim_t = ::std::os::raw::c_ulong;
-pub type __rlim64_t = ::std::os::raw::c_ulong;
-pub type __id_t = ::std::os::raw::c_uint;
-pub type __time_t = ::std::os::raw::c_long;
-pub type __useconds_t = ::std::os::raw::c_uint;
-pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
-pub type __daddr_t = ::std::os::raw::c_int;
-pub type __key_t = ::std::os::raw::c_int;
-pub type __clockid_t = ::std::os::raw::c_int;
-pub type __timer_t = *mut ::std::os::raw::c_void;
-pub type __blksize_t = ::std::os::raw::c_long;
-pub type __blkcnt_t = ::std::os::raw::c_long;
-pub type __blkcnt64_t = ::std::os::raw::c_long;
-pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
-pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsword_t = ::std::os::raw::c_long;
-pub type __ssize_t = ::std::os::raw::c_long;
-pub type __syscall_slong_t = ::std::os::raw::c_long;
-pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
-pub type __loff_t = __off64_t;
-pub type __caddr_t = *mut ::std::os::raw::c_char;
-pub type __intptr_t = ::std::os::raw::c_long;
-pub type __socklen_t = ::std::os::raw::c_uint;
-pub type __sig_atomic_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_longlong;
+pub type __uint64_t = ::std::os::raw::c_ulonglong;
+pub type __darwin_intptr_t = ::std::os::raw::c_long;
+pub type __darwin_natural_t = ::std::os::raw::c_uint;
+pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct __mbstate_t {
-    pub __count: ::std::os::raw::c_int,
-    pub __value: __mbstate_t__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __mbstate_t__bindgen_ty_1 {
-    pub __wch: ::std::os::raw::c_uint,
-    pub __wchb: [::std::os::raw::c_char; 4usize],
-    _bindgen_union_align: u32,
-}
-impl Default for __mbstate_t__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+pub union __mbstate_t {
+    pub __mbstate8: [::std::os::raw::c_char; 128usize],
+    pub _mbstateL: ::std::os::raw::c_longlong,
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub type __darwin_mbstate_t = __mbstate_t;
+pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
+pub type __darwin_size_t = ::std::os::raw::c_ulong;
+pub type __darwin_va_list = __builtin_va_list;
+pub type __darwin_wchar_t = ::std::os::raw::c_int;
+pub type __darwin_rune_t = __darwin_wchar_t;
+pub type __darwin_wint_t = ::std::os::raw::c_int;
+pub type __darwin_clock_t = ::std::os::raw::c_ulong;
+pub type __darwin_socklen_t = __uint32_t;
+pub type __darwin_ssize_t = ::std::os::raw::c_long;
+pub type __darwin_time_t = ::std::os::raw::c_long;
+pub type __darwin_blkcnt_t = __int64_t;
+pub type __darwin_blksize_t = __int32_t;
+pub type __darwin_dev_t = __int32_t;
+pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_gid_t = __uint32_t;
+pub type __darwin_id_t = __uint32_t;
+pub type __darwin_ino64_t = __uint64_t;
+pub type __darwin_ino_t = __darwin_ino64_t;
+pub type __darwin_mach_port_name_t = __darwin_natural_t;
+pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
+pub type __darwin_mode_t = __uint16_t;
+pub type __darwin_off_t = __int64_t;
+pub type __darwin_pid_t = __int32_t;
+pub type __darwin_sigset_t = __uint32_t;
+pub type __darwin_suseconds_t = __int32_t;
+pub type __darwin_uid_t = __uint32_t;
+pub type __darwin_useconds_t = __uint32_t;
+pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
+pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_pthread_handler_rec {
+    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+    pub __arg: *mut ::std::os::raw::c_void,
+    pub __next: *mut __darwin_pthread_handler_rec,
+}
+impl Default for __darwin_pthread_handler_rec {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _G_fpos_t {
-    pub __pos: __off_t,
-    pub __state: __mbstate_t,
+pub struct _opaque_pthread_attr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
 }
-impl Default for _G_fpos_t {
+impl Default for _opaque_pthread_attr_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _G_fpos64_t {
-    pub __pos: __off64_t,
-    pub __state: __mbstate_t,
+pub struct _opaque_pthread_cond_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 40usize],
 }
-impl Default for _G_fpos64_t {
+impl Default for _opaque_pthread_cond_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __fpos64_t = _G_fpos64_t;
-pub type __FILE = _IO_FILE;
-pub type FILE = _IO_FILE;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_condattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_mutex_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
-    _unused: [u8; 0],
-}
-pub type _IO_lock_t = ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_FILE {
-    pub _flags: ::std::os::raw::c_int,
-    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    pub _IO_read_end: *mut ::std::os::raw::c_char,
-    pub _IO_read_base: *mut ::std::os::raw::c_char,
-    pub _IO_write_base: *mut ::std::os::raw::c_char,
-    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    pub _IO_write_end: *mut ::std::os::raw::c_char,
-    pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    pub _IO_save_base: *mut ::std::os::raw::c_char,
-    pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    pub _IO_save_end: *mut ::std::os::raw::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::std::os::raw::c_int,
-    pub _flags2: ::std::os::raw::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::std::os::raw::c_ushort,
-    pub _vtable_offset: ::std::os::raw::c_schar,
-    pub _shortbuf: [::std::os::raw::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::std::os::raw::c_void,
-    pub __pad5: usize,
-    pub _mode: ::std::os::raw::c_int,
-    pub _unused2: [::std::os::raw::c_char; 20usize],
-}
-impl Default for _IO_FILE {
+impl Default for _opaque_pthread_mutex_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type off_t = __off_t;
-pub type fpos_t = __fpos_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_mutexattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_once_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_rwlock_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 192usize],
+}
+impl Default for _opaque_pthread_rwlock_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_rwlockattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 16usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
+    pub __opaque: [::std::os::raw::c_char; 8176usize],
+}
+impl Default for _opaque_pthread_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
+pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
+pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
+pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
+pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
+pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
+pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
+pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
+pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
+pub type __darwin_pthread_t = *mut _opaque_pthread_t;
+pub type __darwin_nl_item = ::std::os::raw::c_int;
+pub type __darwin_wctrans_t = ::std::os::raw::c_int;
+pub type __darwin_wctype_t = __uint32_t;
+pub type u_int8_t = ::std::os::raw::c_uchar;
+pub type u_int16_t = ::std::os::raw::c_ushort;
+pub type u_int32_t = ::std::os::raw::c_uint;
+pub type u_int64_t = ::std::os::raw::c_ulonglong;
+pub type register_t = i64;
+pub type user_addr_t = u_int64_t;
+pub type user_size_t = u_int64_t;
+pub type user_ssize_t = i64;
+pub type user_long_t = i64;
+pub type user_ulong_t = u_int64_t;
+pub type user_time_t = i64;
+pub type user_off_t = i64;
+pub type syscall_arg_t = u_int64_t;
+pub type va_list = __darwin_va_list;
 #[pg_guard]
 extern "C" {
-    pub static mut stdin: *mut FILE;
+    pub fn renameat(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut stdout: *mut FILE;
+    pub fn renamex_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut stderr: *mut FILE;
+    pub fn renameatx_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fpos_t = __darwin_off_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sbuf {
+    pub _base: *mut ::std::os::raw::c_uchar,
+    pub _size: ::std::os::raw::c_int,
+}
+impl Default for __sbuf {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sFILEX {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sFILE {
+    pub _p: *mut ::std::os::raw::c_uchar,
+    pub _r: ::std::os::raw::c_int,
+    pub _w: ::std::os::raw::c_int,
+    pub _flags: ::std::os::raw::c_short,
+    pub _file: ::std::os::raw::c_short,
+    pub _bf: __sbuf,
+    pub _lbfsize: ::std::os::raw::c_int,
+    pub _cookie: *mut ::std::os::raw::c_void,
+    pub _close: ::std::option::Option<
+        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+    >,
+    pub _read: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: *mut ::std::os::raw::c_char,
+            arg3: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub _seek: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: fpos_t,
+            arg3: ::std::os::raw::c_int,
+        ) -> fpos_t,
+    >,
+    pub _write: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: *const ::std::os::raw::c_char,
+            arg3: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub _ub: __sbuf,
+    pub _extra: *mut __sFILEX,
+    pub _ur: ::std::os::raw::c_int,
+    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
+    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
+    pub _lb: __sbuf,
+    pub _blksize: ::std::os::raw::c_int,
+    pub _offset: fpos_t,
+}
+impl Default for __sFILE {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type FILE = __sFILE;
+#[pg_guard]
+extern "C" {
+    pub static mut __stdinp: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub static mut __stdoutp: *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __stderrp: *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr(arg1: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgets(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __mode: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fprintf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __nitems: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freopen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut FILE,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fscanf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseek(
+        arg1: *mut FILE,
+        arg2: ::std::os::raw::c_long,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __nitems: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn perror(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -2916,11 +3614,39 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn renameat(
-        __oldfd: ::std::os::raw::c_int,
-        __old: *const ::std::os::raw::c_char,
-        __newfd: ::std::os::raw::c_int,
-        __new: *const ::std::os::raw::c_char,
+    pub fn rewind(arg1: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setvbuf(
+        arg1: *mut FILE,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sprintf(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sscanf(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -2929,275 +3655,89 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tempnam(
-        __dir: *const ::std::os::raw::c_char,
-        __pfx: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freopen(
-        __filename: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
-        __stream: *mut FILE,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
-        -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmemopen(
-        __s: *mut ::std::os::raw::c_void,
-        __len: usize,
-        __modes: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn open_memstream(
-        __bufloc: *mut *mut ::std::os::raw::c_char,
-        __sizeloc: *mut usize,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setvbuf(
-        __stream: *mut FILE,
-        __buf: *mut ::std::os::raw::c_char,
-        __modes: ::std::os::raw::c_int,
-        __n: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setlinebuf(__stream: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn fprintf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vfprintf(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vprintf(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vsprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn snprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __maxlen: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        ...
+    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn popen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __svfscanf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vsnprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __maxlen: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
+    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vdprintf(
-        __fd: ::std::os::raw::c_int,
-        __fmt: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
+    pub fn flockfile(arg1: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn dprintf(
-        __fd: ::std::os::raw::c_int,
-        __fmt: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fscanf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn funlockfile(arg1: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sscanf(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_fscanf"]
-    pub fn fscanf1(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_scanf"]
-    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_sscanf"]
-    pub fn sscanf1(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vfscanf(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vscanf(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsscanf(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vfscanf"]
-    pub fn vfscanf1(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vscanf"]
-    pub fn vscanf1(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vsscanf"]
-    pub fn vsscanf1(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3205,231 +3745,2080 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgets(
-        __s: *mut ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_int,
-        __stream: *mut FILE,
+    pub fn tempnam(
+        __dir: *const ::std::os::raw::c_char,
+        __prefix: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-#[pg_guard]
-extern "C" {
-    pub fn __getdelim(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getdelim(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getline(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __n: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __n: ::std::os::raw::c_ulong,
-        __s: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread_unlocked(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
-        __n: usize,
-        __stream: *mut FILE,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite_unlocked(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: usize,
-        __n: usize,
-        __stream: *mut FILE,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fseek(
-        __stream: *mut FILE,
-        __off: ::std::os::raw::c_long,
-        __whence: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rewind(__stream: *mut FILE);
-}
+pub type off_t = __darwin_off_t;
 #[pg_guard]
 extern "C" {
     pub fn fseeko(
         __stream: *mut FILE,
-        __off: __off_t,
+        __offset: off_t,
         __whence: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> __off_t;
+    pub fn ftello(__stream: *mut FILE) -> off_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+    pub fn snprintf(
+        __str: *mut ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+    pub fn vfscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr(__stream: *mut FILE);
+    pub fn vscanf(
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vsnprintf(
+        __str: *mut ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vsscanf(
+        __str: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr_unlocked(__stream: *mut FILE);
+    pub fn dprintf(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vdprintf(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getdelim(
+        __linep: *mut *mut ::std::os::raw::c_char,
+        __linecapp: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn perror(__s: *const ::std::os::raw::c_char);
+    pub fn getline(
+        __linep: *mut *mut ::std::os::raw::c_char,
+        __linecapp: *mut usize,
+        __stream: *mut FILE,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn popen(
-        __command: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
+    pub fn fmemopen(
+        __buf: *mut ::std::os::raw::c_void,
+        __size: usize,
+        __mode: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn open_memstream(
+        __bufp: *mut *mut ::std::os::raw::c_char,
+        __sizep: *mut usize,
+    ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub static sys_nerr: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn flockfile(__stream: *mut FILE);
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn asprintf(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn funlockfile(__stream: *mut FILE);
+    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn fmtcheck(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *const ::std::os::raw::c_char;
 }
-pub type wchar_t = ::std::os::raw::c_int;
+#[pg_guard]
+extern "C" {
+    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuffer(
+        arg1: *mut FILE,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vasprintf(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn zopen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn funopen(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *mut ::std::os::raw::c_char,
+                arg3: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int,
+        >,
+        arg3: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_char,
+                arg3: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int,
+        >,
+        arg4: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: fpos_t,
+                arg3: ::std::os::raw::c_int,
+            ) -> fpos_t,
+        >,
+        arg5: ::std::option::Option<
+            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+        >,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __snprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+        arg5: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __vsprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __vsnprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+        arg5: *const ::std::os::raw::c_char,
+        arg6: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type pid_t = __darwin_pid_t;
+pub type id_t = __darwin_id_t;
+pub type sig_atomic_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_i386_thread_state {
+    pub __eax: ::std::os::raw::c_uint,
+    pub __ebx: ::std::os::raw::c_uint,
+    pub __ecx: ::std::os::raw::c_uint,
+    pub __edx: ::std::os::raw::c_uint,
+    pub __edi: ::std::os::raw::c_uint,
+    pub __esi: ::std::os::raw::c_uint,
+    pub __ebp: ::std::os::raw::c_uint,
+    pub __esp: ::std::os::raw::c_uint,
+    pub __ss: ::std::os::raw::c_uint,
+    pub __eflags: ::std::os::raw::c_uint,
+    pub __eip: ::std::os::raw::c_uint,
+    pub __cs: ::std::os::raw::c_uint,
+    pub __ds: ::std::os::raw::c_uint,
+    pub __es: ::std::os::raw::c_uint,
+    pub __fs: ::std::os::raw::c_uint,
+    pub __gs: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_fp_control {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+}
+impl __darwin_fp_control {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __pc: ::std::os::raw::c_ushort,
+        __rc: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 2u8, {
+            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
+            __pc as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 2u8, {
+            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
+            __rc as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_control_t = __darwin_fp_control;
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_fp_status {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+}
+impl __darwin_fp_status {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(6usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(9usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
+    }
+    #[inline]
+    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(11usize, 3u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(14usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(15usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __stkflt: ::std::os::raw::c_ushort,
+        __errsumm: ::std::os::raw::c_ushort,
+        __c0: ::std::os::raw::c_ushort,
+        __c1: ::std::os::raw::c_ushort,
+        __c2: ::std::os::raw::c_ushort,
+        __tos: ::std::os::raw::c_ushort,
+        __c3: ::std::os::raw::c_ushort,
+        __busy: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(6usize, 1u8, {
+            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
+            __stkflt as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
+            __errsumm as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 1u8, {
+            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
+            __c0 as u64
+        });
+        __bindgen_bitfield_unit.set(9usize, 1u8, {
+            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
+            __c1 as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 1u8, {
+            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
+            __c2 as u64
+        });
+        __bindgen_bitfield_unit.set(11usize, 3u8, {
+            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
+            __tos as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 1u8, {
+            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
+            __c3 as u64
+        });
+        __bindgen_bitfield_unit.set(15usize, 1u8, {
+            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
+            __busy as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_status_t = __darwin_fp_status;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_mmst_reg {
+    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
+    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_xmm_reg {
+    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_ymm_reg {
+    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_zmm_reg {
+    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
+}
+impl Default for __darwin_zmm_reg {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_opmask_reg {
+    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_float_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+impl Default for __darwin_i386_float_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_avx_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+}
+impl Default for __darwin_i386_avx_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_avx512_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+}
+impl Default for __darwin_i386_avx512_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_i386_exception_state {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_debug_state32 {
+    pub __dr0: ::std::os::raw::c_uint,
+    pub __dr1: ::std::os::raw::c_uint,
+    pub __dr2: ::std::os::raw::c_uint,
+    pub __dr3: ::std::os::raw::c_uint,
+    pub __dr4: ::std::os::raw::c_uint,
+    pub __dr5: ::std::os::raw::c_uint,
+    pub __dr6: ::std::os::raw::c_uint,
+    pub __dr7: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __x86_instruction_state {
+    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
+    pub __insn_offset: ::std::os::raw::c_int,
+    pub __out_of_synch: ::std::os::raw::c_int,
+    pub __insn_bytes: [__uint8_t; 2380usize],
+    pub __insn_cacheline: [__uint8_t; 64usize],
+}
+impl Default for __x86_instruction_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __last_branch_record {
+    pub __from_ip: __uint64_t,
+    pub __to_ip: __uint64_t,
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __bindgen_padding_0: u32,
+}
+impl __last_branch_record {
+    #[inline]
+    pub fn __mispredict(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___mispredict(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tsx_abort(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __in_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___in_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set___cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(19usize, 13u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __mispredict: __uint32_t,
+        __tsx_abort: __uint32_t,
+        __in_tsx: __uint32_t,
+        __cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
+            __mispredict as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
+            __tsx_abort as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
+            __in_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 16u8, {
+            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
+            __cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(19usize, 13u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __last_branch_state {
+    pub __lbr_count: ::std::os::raw::c_int,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __lbrs: [__last_branch_record; 32usize],
+}
+impl __last_branch_state {
+    #[inline]
+    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 30u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __lbr_supported_tsx: __uint32_t,
+        __lbr_supported_cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
+            __lbr_supported_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __lbr_supported_cycle_count: u32 =
+                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
+            __lbr_supported_cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 30u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __x86_pagein_state {
+    pub __pagein_error: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_thread_state64 {
+    pub __rax: __uint64_t,
+    pub __rbx: __uint64_t,
+    pub __rcx: __uint64_t,
+    pub __rdx: __uint64_t,
+    pub __rdi: __uint64_t,
+    pub __rsi: __uint64_t,
+    pub __rbp: __uint64_t,
+    pub __rsp: __uint64_t,
+    pub __r8: __uint64_t,
+    pub __r9: __uint64_t,
+    pub __r10: __uint64_t,
+    pub __r11: __uint64_t,
+    pub __r12: __uint64_t,
+    pub __r13: __uint64_t,
+    pub __r14: __uint64_t,
+    pub __r15: __uint64_t,
+    pub __rip: __uint64_t,
+    pub __rflags: __uint64_t,
+    pub __cs: __uint64_t,
+    pub __fs: __uint64_t,
+    pub __gs: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_thread_full_state64 {
+    pub __ss64: __darwin_x86_thread_state64,
+    pub __ds: __uint64_t,
+    pub __es: __uint64_t,
+    pub __ss: __uint64_t,
+    pub __gsbase: __uint64_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_float_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+impl Default for __darwin_x86_float_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_avx_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+}
+impl Default for __darwin_x86_avx_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_avx512_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+    pub __fpu_zmmh8: __darwin_ymm_reg,
+    pub __fpu_zmmh9: __darwin_ymm_reg,
+    pub __fpu_zmmh10: __darwin_ymm_reg,
+    pub __fpu_zmmh11: __darwin_ymm_reg,
+    pub __fpu_zmmh12: __darwin_ymm_reg,
+    pub __fpu_zmmh13: __darwin_ymm_reg,
+    pub __fpu_zmmh14: __darwin_ymm_reg,
+    pub __fpu_zmmh15: __darwin_ymm_reg,
+    pub __fpu_zmm16: __darwin_zmm_reg,
+    pub __fpu_zmm17: __darwin_zmm_reg,
+    pub __fpu_zmm18: __darwin_zmm_reg,
+    pub __fpu_zmm19: __darwin_zmm_reg,
+    pub __fpu_zmm20: __darwin_zmm_reg,
+    pub __fpu_zmm21: __darwin_zmm_reg,
+    pub __fpu_zmm22: __darwin_zmm_reg,
+    pub __fpu_zmm23: __darwin_zmm_reg,
+    pub __fpu_zmm24: __darwin_zmm_reg,
+    pub __fpu_zmm25: __darwin_zmm_reg,
+    pub __fpu_zmm26: __darwin_zmm_reg,
+    pub __fpu_zmm27: __darwin_zmm_reg,
+    pub __fpu_zmm28: __darwin_zmm_reg,
+    pub __fpu_zmm29: __darwin_zmm_reg,
+    pub __fpu_zmm30: __darwin_zmm_reg,
+    pub __fpu_zmm31: __darwin_zmm_reg,
+}
+impl Default for __darwin_x86_avx512_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_exception_state64 {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_debug_state64 {
+    pub __dr0: __uint64_t,
+    pub __dr1: __uint64_t,
+    pub __dr2: __uint64_t,
+    pub __dr3: __uint64_t,
+    pub __dr4: __uint64_t,
+    pub __dr5: __uint64_t,
+    pub __dr6: __uint64_t,
+    pub __dr7: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_cpmu_state64 {
+    pub __ctrs: [__uint64_t; 16usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_float_state,
+}
+impl Default for __darwin_mcontext32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx_state,
+}
+impl Default for __darwin_mcontext_avx32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx512_state,
+}
+impl Default for __darwin_mcontext_avx512_32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+impl Default for __darwin_mcontext64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+impl Default for __darwin_mcontext64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+impl Default for __darwin_mcontext_avx64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+impl Default for __darwin_mcontext_avx64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+impl Default for __darwin_mcontext_avx512_64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+impl Default for __darwin_mcontext_avx512_64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type mcontext_t = *mut __darwin_mcontext64;
+pub type pthread_attr_t = __darwin_pthread_attr_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_sigaltstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_size: __darwin_size_t,
+    pub ss_flags: ::std::os::raw::c_int,
+}
+impl Default for __darwin_sigaltstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type stack_t = __darwin_sigaltstack;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_ucontext {
+    pub uc_onstack: ::std::os::raw::c_int,
+    pub uc_sigmask: __darwin_sigset_t,
+    pub uc_stack: __darwin_sigaltstack,
+    pub uc_link: *mut __darwin_ucontext,
+    pub uc_mcsize: __darwin_size_t,
+    pub uc_mcontext: *mut __darwin_mcontext64,
+}
+impl Default for __darwin_ucontext {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type ucontext_t = __darwin_ucontext;
+pub type sigset_t = __darwin_sigset_t;
+pub type uid_t = __darwin_uid_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
+}
+impl Default for sigval {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_value: sigval,
+    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
+    pub sigev_notify_attributes: *mut pthread_attr_t,
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __siginfo {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub si_pid: pid_t,
+    pub si_uid: uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_value: sigval,
+    pub si_band: ::std::os::raw::c_long,
+    pub __pad: [::std::os::raw::c_ulong; 7usize],
+}
+impl Default for __siginfo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type siginfo_t = __siginfo;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __sigaction_u {
+    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub __sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut __siginfo,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for __sigaction_u {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __sigaction {
+    pub __sigaction_u: __sigaction_u,
+    pub sa_tramp: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: ::std::os::raw::c_int,
+            arg3: ::std::os::raw::c_int,
+            arg4: *mut siginfo_t,
+            arg5: *mut ::std::os::raw::c_void,
+        ),
+    >,
+    pub sa_mask: sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+}
+impl Default for __sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_u: __sigaction_u,
+    pub sa_mask: sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sigvec {
+    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub sv_mask: ::std::os::raw::c_int,
+    pub sv_flags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_char,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn signal(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+        ),
+    >;
+}
+pub type int_least8_t = i8;
+pub type int_least16_t = i16;
+pub type int_least32_t = i32;
+pub type int_least64_t = i64;
+pub type uint_least8_t = u8;
+pub type uint_least16_t = u16;
+pub type uint_least32_t = u32;
+pub type uint_least64_t = u64;
+pub type int_fast8_t = i8;
+pub type int_fast16_t = i16;
+pub type int_fast32_t = i32;
+pub type int_fast64_t = i64;
+pub type uint_fast8_t = u8;
+pub type uint_fast16_t = u16;
+pub type uint_fast32_t = u32;
+pub type uint_fast64_t = u64;
+pub type intmax_t = ::std::os::raw::c_long;
+pub type uintmax_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __darwin_time_t,
+    pub tv_usec: __darwin_suseconds_t,
+}
+pub type rlim_t = __uint64_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage {
+    pub ru_utime: timeval,
+    pub ru_stime: timeval,
+    pub ru_maxrss: ::std::os::raw::c_long,
+    pub ru_ixrss: ::std::os::raw::c_long,
+    pub ru_idrss: ::std::os::raw::c_long,
+    pub ru_isrss: ::std::os::raw::c_long,
+    pub ru_minflt: ::std::os::raw::c_long,
+    pub ru_majflt: ::std::os::raw::c_long,
+    pub ru_nswap: ::std::os::raw::c_long,
+    pub ru_inblock: ::std::os::raw::c_long,
+    pub ru_oublock: ::std::os::raw::c_long,
+    pub ru_msgsnd: ::std::os::raw::c_long,
+    pub ru_msgrcv: ::std::os::raw::c_long,
+    pub ru_nsignals: ::std::os::raw::c_long,
+    pub ru_nvcsw: ::std::os::raw::c_long,
+    pub ru_nivcsw: ::std::os::raw::c_long,
+}
+pub type rusage_info_t = *mut ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v0 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v1 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v2 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v3 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v4 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v5 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+    pub ri_flags: u64,
+}
+pub type rusage_info_current = rusage_info_v5;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rlimit {
+    pub rlim_cur: rlim_t,
+    pub rlim_max: rlim_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct proc_rlimit_control_wakeupmon {
+    pub wm_flags: u32,
+    pub wm_rate: i32,
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getiopolicy_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setpriority(
+        arg1: ::std::os::raw::c_int,
+        arg2: id_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setiopolicy_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union wait {
+    pub w_status: ::std::os::raw::c_int,
+    pub w_T: wait__bindgen_ty_1,
+    pub w_S: wait__bindgen_ty_2,
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct wait__bindgen_ty_1 {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+impl wait__bindgen_ty_1 {
+    #[inline]
+    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 7u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        w_Termsig: ::std::os::raw::c_uint,
+        w_Coredump: ::std::os::raw::c_uint,
+        w_Retcode: ::std::os::raw::c_uint,
+        w_Filler: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 7u8, {
+            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
+            w_Termsig as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
+            w_Coredump as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 8u8, {
+            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
+            w_Retcode as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
+            w_Filler as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct wait__bindgen_ty_2 {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+impl wait__bindgen_ty_2 {
+    #[inline]
+    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        w_Stopval: ::std::os::raw::c_uint,
+        w_Stopsig: ::std::os::raw::c_uint,
+        w_Filler: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 8u8, {
+            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
+            w_Stopval as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 8u8, {
+            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
+            w_Stopsig as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
+            w_Filler as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+impl Default for wait {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn waitpid(
+        arg1: pid_t,
+        arg2: *mut ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn waitid(
+        arg1: idtype_t,
+        arg2: id_t,
+        arg3: *mut siginfo_t,
+        arg4: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait3(
+        arg1: *mut ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut rusage,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait4(
+        arg1: pid_t,
+        arg2: *mut ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut rusage,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+}
+pub type ct_rune_t = __darwin_ct_rune_t;
+pub type rune_t = __darwin_rune_t;
+pub type wchar_t = __darwin_wchar_t;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -3450,595 +5839,7 @@ pub struct lldiv_t {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_get_mb_cur_max() -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtod(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtof(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtold(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtol(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoul(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoq(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtouq(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoll(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoull(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-pub type u_char = __u_char;
-pub type u_short = __u_short;
-pub type u_int = __u_int;
-pub type u_long = __u_long;
-pub type quad_t = __quad_t;
-pub type u_quad_t = __u_quad_t;
-pub type fsid_t = __fsid_t;
-pub type loff_t = __loff_t;
-pub type ino_t = __ino_t;
-pub type dev_t = __dev_t;
-pub type gid_t = __gid_t;
-pub type mode_t = __mode_t;
-pub type nlink_t = __nlink_t;
-pub type uid_t = __uid_t;
-pub type pid_t = __pid_t;
-pub type id_t = __id_t;
-pub type daddr_t = __daddr_t;
-pub type caddr_t = __caddr_t;
-pub type key_t = __key_t;
-pub type clock_t = __clock_t;
-pub type clockid_t = __clockid_t;
-pub type time_t = __time_t;
-pub type timer_t = __timer_t;
-pub type ulong = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_int8_t = __uint8_t;
-pub type u_int16_t = __uint16_t;
-pub type u_int32_t = __uint32_t;
-pub type u_int64_t = __uint64_t;
-pub type register_t = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sigset_t {
-    pub __val: [::std::os::raw::c_ulong; 16usize],
-}
-pub type sigset_t = __sigset_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __time_t,
-    pub tv_usec: __suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __time_t,
-    pub tv_nsec: __syscall_slong_t,
-}
-pub type suseconds_t = __suseconds_t;
-pub type __fd_mask = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub __fds_bits: [__fd_mask; 16usize],
-}
-pub type fd_mask = __fd_mask;
-#[pg_guard]
-extern "C" {
-    pub fn select(
-        __nfds: ::std::os::raw::c_int,
-        __readfds: *mut fd_set,
-        __writefds: *mut fd_set,
-        __exceptfds: *mut fd_set,
-        __timeout: *mut timeval,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pselect(
-        __nfds: ::std::os::raw::c_int,
-        __readfds: *mut fd_set,
-        __writefds: *mut fd_set,
-        __exceptfds: *mut fd_set,
-        __timeout: *const timespec,
-        __sigmask: *const __sigset_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type blksize_t = __blksize_t;
-pub type blkcnt_t = __blkcnt_t;
-pub type fsblkcnt_t = __fsblkcnt_t;
-pub type fsfilcnt_t = __fsfilcnt_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_internal_list {
-    pub __prev: *mut __pthread_internal_list,
-    pub __next: *mut __pthread_internal_list,
-}
-impl Default for __pthread_internal_list {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __pthread_list_t = __pthread_internal_list;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_internal_slist {
-    pub __next: *mut __pthread_internal_slist,
-}
-impl Default for __pthread_internal_slist {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __pthread_slist_t = __pthread_internal_slist;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_mutex_s {
-    pub __lock: ::std::os::raw::c_int,
-    pub __count: ::std::os::raw::c_uint,
-    pub __owner: ::std::os::raw::c_int,
-    pub __nusers: ::std::os::raw::c_uint,
-    pub __kind: ::std::os::raw::c_int,
-    pub __spins: ::std::os::raw::c_short,
-    pub __elision: ::std::os::raw::c_short,
-    pub __list: __pthread_list_t,
-}
-impl Default for __pthread_mutex_s {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_rwlock_arch_t {
-    pub __readers: ::std::os::raw::c_uint,
-    pub __writers: ::std::os::raw::c_uint,
-    pub __wrphase_futex: ::std::os::raw::c_uint,
-    pub __writers_futex: ::std::os::raw::c_uint,
-    pub __pad3: ::std::os::raw::c_uint,
-    pub __pad4: ::std::os::raw::c_uint,
-    pub __cur_writer: ::std::os::raw::c_int,
-    pub __shared: ::std::os::raw::c_int,
-    pub __rwelision: ::std::os::raw::c_schar,
-    pub __pad1: [::std::os::raw::c_uchar; 7usize],
-    pub __pad2: ::std::os::raw::c_ulong,
-    pub __flags: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __pthread_cond_s {
-    pub __bindgen_anon_1: __pthread_cond_s__bindgen_ty_1,
-    pub __bindgen_anon_2: __pthread_cond_s__bindgen_ty_2,
-    pub __g_refs: [::std::os::raw::c_uint; 2usize],
-    pub __g_size: [::std::os::raw::c_uint; 2usize],
-    pub __g1_orig_size: ::std::os::raw::c_uint,
-    pub __wrefs: ::std::os::raw::c_uint,
-    pub __g_signals: [::std::os::raw::c_uint; 2usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __pthread_cond_s__bindgen_ty_1 {
-    pub __wseq: ::std::os::raw::c_ulonglong,
-    pub __wseq32: __pthread_cond_s__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_cond_s__bindgen_ty_1__bindgen_ty_1 {
-    pub __low: ::std::os::raw::c_uint,
-    pub __high: ::std::os::raw::c_uint,
-}
-impl Default for __pthread_cond_s__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __pthread_cond_s__bindgen_ty_2 {
-    pub __g1_start: ::std::os::raw::c_ulonglong,
-    pub __g1_start32: __pthread_cond_s__bindgen_ty_2__bindgen_ty_1,
-    _bindgen_union_align: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_cond_s__bindgen_ty_2__bindgen_ty_1 {
-    pub __low: ::std::os::raw::c_uint,
-    pub __high: ::std::os::raw::c_uint,
-}
-impl Default for __pthread_cond_s__bindgen_ty_2 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for __pthread_cond_s {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
-}
-pub type pthread_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_mutexattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_mutexattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_condattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_condattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type pthread_key_t = ::std::os::raw::c_uint;
-pub type pthread_once_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_attr_t {
-    pub __size: [::std::os::raw::c_char; 56usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 7usize],
-}
-impl Default for pthread_attr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_mutex_t {
-    pub __data: __pthread_mutex_s,
-    pub __size: [::std::os::raw::c_char; 40usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 5usize],
-}
-impl Default for pthread_mutex_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_cond_t {
-    pub __data: __pthread_cond_s,
-    pub __size: [::std::os::raw::c_char; 48usize],
-    pub __align: ::std::os::raw::c_longlong,
-    _bindgen_union_align: [u64; 6usize],
-}
-impl Default for pthread_cond_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_rwlock_t {
-    pub __data: __pthread_rwlock_arch_t,
-    pub __size: [::std::os::raw::c_char; 56usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 7usize],
-}
-impl Default for pthread_rwlock_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_rwlockattr_t {
-    pub __size: [::std::os::raw::c_char; 8usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: u64,
-}
-impl Default for pthread_rwlockattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type pthread_spinlock_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_barrier_t {
-    pub __size: [::std::os::raw::c_char; 32usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 4usize],
-}
-impl Default for pthread_barrier_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_barrierattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_barrierattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom(__seed: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn initstate(
-        __seed: ::std::os::raw::c_uint,
-        __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct random_data {
-    pub fptr: *mut i32,
-    pub rptr: *mut i32,
-    pub state: *mut i32,
-    pub rand_type: ::std::os::raw::c_int,
-    pub rand_deg: ::std::os::raw::c_int,
-    pub rand_sep: ::std::os::raw::c_int,
-    pub end_ptr: *mut i32,
-}
-impl Default for random_data {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom_r(
-        __seed: ::std::os::raw::c_uint,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn initstate_r(
-        __seed: ::std::os::raw::c_uint,
-        __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: usize,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate_r(
-        __statebuf: *mut ::std::os::raw::c_char,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand(__seed: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48(__seedval: ::std::os::raw::c_long);
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct drand48_data {
-    pub __x: [::std::os::raw::c_ushort; 3usize],
-    pub __old_x: [::std::os::raw::c_ushort; 3usize],
-    pub __c: ::std::os::raw::c_ushort,
-    pub __init: ::std::os::raw::c_ushort,
-    pub __a: ::std::os::raw::c_ulonglong,
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut f64,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48_r(
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48_r(
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48_r(
-        __seedval: ::std::os::raw::c_long,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48_r(
-        __seed16v: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48_r(
-        __param: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
+    pub static mut __mb_cur_max: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -4047,9 +5848,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn calloc(
-        __nmemb: ::std::os::raw::c_ulong,
+        __count: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4060,23 +5865,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn reallocarray(
-        __ptr: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
-    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -4088,247 +5881,74 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
     pub fn abort();
 }
 #[pg_guard]
 extern "C" {
-    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn at_quick_exit(
-        __func: ::std::option::Option<unsafe extern "C" fn()>,
-    ) -> ::std::os::raw::c_int;
+    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn on_exit(
-        __func: ::std::option::Option<
-            unsafe extern "C" fn(
-                __status: ::std::os::raw::c_int,
-                __arg: *mut ::std::os::raw::c_void,
-            ),
-        >,
-        __arg: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
+    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exit(__status: ::std::os::raw::c_int);
+    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn quick_exit(__status: ::std::os::raw::c_int);
+    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _Exit(__status: ::std::os::raw::c_int);
+    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
 }
-#[pg_guard]
-extern "C" {
-    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __replace: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn clearenv() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemps(
-        __template: *mut ::std::os::raw::c_char,
-        __suffixlen: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn realpath(
-        __name: *const ::std::os::raw::c_char,
-        __resolved: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-pub type __compar_fn_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int,
->;
 #[pg_guard]
 extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-        __compar: __compar_fn_t,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-        __compar: __compar_fn_t,
-    );
+    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn exit(arg1: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
+    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
+    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lldiv(
-        __numer: ::std::os::raw::c_longlong,
-        __denom: ::std::os::raw::c_longlong,
-    ) -> lldiv_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gcvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qecvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qfcvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qgcvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt_r(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt_r(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qecvt_r(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qfcvt_r(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
 }
 #[pg_guard]
 extern "C" {
@@ -4336,70 +5956,594 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
     pub fn mbtowc(
-        __pwc: *mut wchar_t,
-        __s: *const ::std::os::raw::c_char,
-        __n: usize,
+        arg1: *mut wchar_t,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn rand() -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
+    pub fn srand(arg1: ::std::os::raw::c_uint);
 }
 #[pg_guard]
 extern "C" {
-    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn strtod(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtof(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtol(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtold(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoll(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoul(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoull(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _Exit(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gcvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn getsubopt(
-        __optionp: *mut *mut ::std::os::raw::c_char,
-        __tokens: *const *mut ::std::os::raw::c_char,
-        __valuep: *mut *mut ::std::os::raw::c_char,
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const *mut ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
+    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memcpy(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+    pub fn initstate(
+        arg1: ::std::os::raw::c_uint,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ptsname_r(
+        fildes: ::std::os::raw::c_int,
+        buffer: *mut ::std::os::raw::c_char,
+        buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn random() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
+    pub fn realpath(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setenv(
+        __name: *const ::std::os::raw::c_char,
+        __value: *const ::std::os::raw::c_char,
+        __overwrite: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setkey(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48(arg1: ::std::os::raw::c_long);
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom(arg1: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+pub type dev_t = __darwin_dev_t;
+pub type mode_t = __darwin_mode_t;
+#[pg_guard]
+extern "C" {
+    pub fn arc4random() -> u32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_stir();
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bsearch_b(
+        __key: *const ::std::os::raw::c_void,
+        __base: *const ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmove(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+    pub fn cgetcap(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetclose() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetent(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+        arg3: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetfirst(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetmatch(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetnext(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetnum(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetstr(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetustr(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_daemon$1050"]
+    pub fn daemon(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn devname_r(
+        arg1: dev_t,
+        arg2: mode_t,
+        buf: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getbsize(
+        arg1: *mut ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_long,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprogname() -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn heapsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn heapsort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mergesort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mergesort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort_r(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        arg1: *mut ::std::os::raw::c_void,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+                arg3: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn qsort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn qsort_r(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        arg1: *mut ::std::os::raw::c_void,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+                arg3: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn radixsort(
+        __base: *mut *const ::std::os::raw::c_uchar,
+        __nel: ::std::os::raw::c_int,
+        __table: *const ::std::os::raw::c_uchar,
+        __endbyte: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sradixsort(
+        __base: *mut *const ::std::os::raw::c_uchar,
+        __nel: ::std::os::raw::c_int,
+        __table: *const ::std::os::raw::c_uchar,
+        __endbyte: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sranddev();
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandomdev();
+}
+#[pg_guard]
+extern "C" {
+    pub fn reallocf(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memccpy(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __n: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn strtonum(
+        __numstr: *const ::std::os::raw::c_char,
+        __minval: ::std::os::raw::c_longlong,
+        __maxval: ::std::os::raw::c_longlong,
+        __errstrp: *mut *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memset(
-        __s: *mut ::std::os::raw::c_void,
+    pub fn strtoq(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtouq(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut suboptarg: *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -4414,114 +6558,33 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
+    pub fn memcpy(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn memmove(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __len: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn memset(
+        __b: *mut ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __len: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
     pub fn strcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcmp(
-        __s1: *const ::std::os::raw::c_char,
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncmp(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strxfrm(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __locale_struct {
-    pub __locales: [*mut __locale_data; 13usize],
-    pub __ctype_b: *const ::std::os::raw::c_ushort,
-    pub __ctype_tolower: *const ::std::os::raw::c_int,
-    pub __ctype_toupper: *const ::std::os::raw::c_int,
-    pub __names: [*const ::std::os::raw::c_char; 13usize],
-}
-impl Default for __locale_struct {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __locale_t = *mut __locale_struct;
-pub type locale_t = __locale_t;
-#[pg_guard]
-extern "C" {
-    pub fn strcoll_l(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __l: locale_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strxfrm_l(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: usize,
-        __l: locale_t,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strndup(
-        __string: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -4533,69 +6596,31 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strrchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strcmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strcspn(
         __s: *const ::std::os::raw::c_char,
-        __reject: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strspn(
-        __s: *const ::std::os::raw::c_char,
-        __accept: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strpbrk(
-        __s: *const ::std::os::raw::c_char,
-        __accept: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strstr(
-        __haystack: *const ::std::os::raw::c_char,
-        __needle: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtok(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __strtok_r(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-        __save_ptr: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtok_r(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-        __save_ptr: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
@@ -4603,76 +6628,19 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}__xpg_strerror_r"]
-    pub fn strerror_r(
-        __errnum: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strerror_l(
-        __errnum: ::std::os::raw::c_int,
-        __l: locale_t,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcmp(
-        __s1: *const ::std::os::raw::c_void,
-        __s2: *const ::std::os::raw::c_void,
-        __n: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcopy(
-        __src: *const ::std::os::raw::c_void,
-        __dest: *mut ::std::os::raw::c_void,
-        __n: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
-}
-#[pg_guard]
-extern "C" {
-    pub fn index(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rindex(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcasecmp(
-        __s1: *const ::std::os::raw::c_char,
+    pub fn strncat(
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncasecmp(
+    pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
@@ -4680,24 +6648,192 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcasecmp_l(
-        __s1: *const ::std::os::raw::c_char,
+    pub fn strncpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strrchr(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strstr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtok(
+        __str: *mut ::std::os::raw::c_char,
+        __sep: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm(
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-        __loc: locale_t,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtok_r(
+        __str: *mut ::std::os::raw::c_char,
+        __sep: *const ::std::os::raw::c_char,
+        __lasts: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strerror_r(
+        __errnum: ::std::os::raw::c_int,
+        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncasecmp_l(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: usize,
-        __loc: locale_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+    pub fn memccpy(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn stpcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn stpncpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strndup(
+        __s1: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+pub type rsize_t = __darwin_size_t;
+pub type errno_t = ::std::os::raw::c_int;
+#[pg_guard]
+extern "C" {
+    pub fn memset_s(
+        __s: *mut ::std::os::raw::c_void,
+        __smax: rsize_t,
+        __c: ::std::os::raw::c_int,
+        __n: rsize_t,
+    ) -> errno_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memmem(
+        __big: *const ::std::os::raw::c_void,
+        __big_len: usize,
+        __little: *const ::std::os::raw::c_void,
+        __little_len: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern4(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern4: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern8(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern8: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern16(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern16: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcasestr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnstr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+        __len: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dst: *mut ::std::os::raw::c_char,
+        __source: *const ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __source: *const ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
@@ -4708,67 +6844,158 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+    pub fn swab(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: isize,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn __stpcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
+    pub fn timingsafe_bcmp(
+        __b1: *const ::std::os::raw::c_void,
+        __b2: *const ::std::os::raw::c_void,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strsignal_r(
+        __sig: ::std::os::raw::c_int,
+        __strsignalbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcmp(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcopy(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
+}
+#[pg_guard]
+extern "C" {
+    pub fn index(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
+    pub fn rindex(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __stpncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: usize,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn strcasecmp(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
 }
+#[pg_guard]
+extern "C" {
+    pub fn strncasecmp(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+pub type max_align_t = u128;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type u_char = ::std::os::raw::c_uchar;
+pub type u_short = ::std::os::raw::c_ushort;
+pub type u_int = ::std::os::raw::c_uint;
+pub type u_long = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_quad_t = u_int64_t;
+pub type quad_t = i64;
+pub type qaddr_t = *mut quad_t;
+pub type caddr_t = *mut ::std::os::raw::c_char;
+pub type daddr_t = i32;
+pub type fixpt_t = u_int32_t;
+pub type blkcnt_t = __darwin_blkcnt_t;
+pub type blksize_t = __darwin_blksize_t;
+pub type gid_t = __darwin_gid_t;
+pub type in_addr_t = __uint32_t;
+pub type in_port_t = __uint16_t;
+pub type ino_t = __darwin_ino_t;
+pub type ino64_t = __darwin_ino64_t;
+pub type key_t = __int32_t;
+pub type nlink_t = __uint16_t;
+pub type segsz_t = i32;
+pub type swblk_t = i32;
+pub type clock_t = __darwin_clock_t;
+pub type time_t = __darwin_time_t;
+pub type useconds_t = __darwin_useconds_t;
+pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
-#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct max_align_t {
-    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
-    pub __bindgen_padding_0: u64,
-    pub __clang_max_align_nonce2: u128,
+pub struct fd_set {
+    pub fds_bits: [__int32_t; 32usize],
 }
-pub type int_least8_t = __int_least8_t;
-pub type int_least16_t = __int_least16_t;
-pub type int_least32_t = __int_least32_t;
-pub type int_least64_t = __int_least64_t;
-pub type uint_least8_t = __uint_least8_t;
-pub type uint_least16_t = __uint_least16_t;
-pub type uint_least32_t = __uint_least32_t;
-pub type uint_least64_t = __uint_least64_t;
-pub type int_fast8_t = ::std::os::raw::c_schar;
-pub type int_fast16_t = ::std::os::raw::c_long;
-pub type int_fast32_t = ::std::os::raw::c_long;
-pub type int_fast64_t = ::std::os::raw::c_long;
-pub type uint_fast8_t = ::std::os::raw::c_uchar;
-pub type uint_fast16_t = ::std::os::raw::c_ulong;
-pub type uint_fast32_t = ::std::os::raw::c_ulong;
-pub type uint_fast64_t = ::std::os::raw::c_ulong;
-pub type intmax_t = __intmax_t;
-pub type uintmax_t = __uintmax_t;
 #[pg_guard]
 extern "C" {
-    pub fn __errno_location() -> *mut ::std::os::raw::c_int;
+    pub fn __darwin_check_fd_set_overflow(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fd_mask = __int32_t;
+pub type pthread_cond_t = __darwin_pthread_cond_t;
+pub type pthread_condattr_t = __darwin_pthread_condattr_t;
+pub type pthread_mutex_t = __darwin_pthread_mutex_t;
+pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
+pub type pthread_once_t = __darwin_pthread_once_t;
+pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
+pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
+pub type pthread_t = __darwin_pthread_t;
+pub type pthread_key_t = __darwin_pthread_key_t;
+pub type fsblkcnt_t = __darwin_fsblkcnt_t;
+pub type fsfilcnt_t = __darwin_fsfilcnt_t;
+#[pg_guard]
+extern "C" {
+    pub fn __error() -> *mut ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -4792,8 +7019,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_p_sep_by_space: ::std::os::raw::c_char,
     pub int_n_cs_precedes: ::std::os::raw::c_char,
+    pub int_p_sep_by_space: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -4805,34 +7032,14 @@ impl Default for lconv {
 }
 #[pg_guard]
 extern "C" {
-    pub fn setlocale(
-        __category: ::std::os::raw::c_int,
-        __locale: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
     pub fn localeconv() -> *mut lconv;
 }
 #[pg_guard]
 extern "C" {
-    pub fn newlocale(
-        __category_mask: ::std::os::raw::c_int,
-        __locale: *const ::std::os::raw::c_char,
-        __base: locale_t,
-    ) -> locale_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn duplocale(__dataset: locale_t) -> locale_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freelocale(__dataset: locale_t);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uselocale(__dataset: locale_t) -> locale_t;
+    pub fn setlocale(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 pub type BoolPtr = *mut bool;
 pub type Pointer = *mut ::std::os::raw::c_char;
@@ -4917,7 +7124,6 @@ pub union PGAlignedBlock {
     pub data: [::std::os::raw::c_char; 8192usize],
     pub force_align_d: f64,
     pub force_align_i64: int64,
-    _bindgen_union_align: [u64; 1024usize],
 }
 impl Default for PGAlignedBlock {
     fn default() -> Self {
@@ -4930,174 +7136,121 @@ pub union PGAlignedXLogBlock {
     pub data: [::std::os::raw::c_char; 8192usize],
     pub force_align_d: f64,
     pub force_align_i64: int64,
-    _bindgen_union_align: [u64; 1024usize],
 }
 impl Default for PGAlignedXLogBlock {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub const _ISupper: ::std::os::raw::c_uint = 256;
-pub const _ISlower: ::std::os::raw::c_uint = 512;
-pub const _ISalpha: ::std::os::raw::c_uint = 1024;
-pub const _ISdigit: ::std::os::raw::c_uint = 2048;
-pub const _ISxdigit: ::std::os::raw::c_uint = 4096;
-pub const _ISspace: ::std::os::raw::c_uint = 8192;
-pub const _ISprint: ::std::os::raw::c_uint = 16384;
-pub const _ISgraph: ::std::os::raw::c_uint = 32768;
-pub const _ISblank: ::std::os::raw::c_uint = 1;
-pub const _IScntrl: ::std::os::raw::c_uint = 2;
-pub const _ISpunct: ::std::os::raw::c_uint = 4;
-pub const _ISalnum: ::std::os::raw::c_uint = 8;
-pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
+    pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+pub type wint_t = __darwin_wint_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _RuneEntry {
+    pub __min: __darwin_rune_t,
+    pub __max: __darwin_rune_t,
+    pub __map: __darwin_rune_t,
+    pub __types: *mut __uint32_t,
+}
+impl Default for _RuneEntry {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _RuneRange {
+    pub __nranges: ::std::os::raw::c_int,
+    pub __ranges: *mut _RuneEntry,
+}
+impl Default for _RuneRange {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _RuneCharClass {
+    pub __name: [::std::os::raw::c_char; 14usize],
+    pub __mask: __uint32_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _RuneLocale {
+    pub __magic: [::std::os::raw::c_char; 8usize],
+    pub __encoding: [::std::os::raw::c_char; 32usize],
+    pub __sgetrune: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *const ::std::os::raw::c_char,
+            arg2: __darwin_size_t,
+            arg3: *mut *const ::std::os::raw::c_char,
+        ) -> __darwin_rune_t,
+    >,
+    pub __sputrune: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: __darwin_rune_t,
+            arg2: *mut ::std::os::raw::c_char,
+            arg3: __darwin_size_t,
+            arg4: *mut *mut ::std::os::raw::c_char,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub __invalid_rune: __darwin_rune_t,
+    pub __runetype: [__uint32_t; 256usize],
+    pub __maplower: [__darwin_rune_t; 256usize],
+    pub __mapupper: [__darwin_rune_t; 256usize],
+    pub __runetype_ext: _RuneRange,
+    pub __maplower_ext: _RuneRange,
+    pub __mapupper_ext: _RuneRange,
+    pub __variable: *mut ::std::os::raw::c_void,
+    pub __variable_len: ::std::os::raw::c_int,
+    pub __ncharclasses: ::std::os::raw::c_int,
+    pub __charclasses: *mut _RuneCharClass,
+}
+impl Default for _RuneLocale {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
+    pub static mut _DefaultRuneLocale: _RuneLocale;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
+    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __maskrune(
+        arg1: __darwin_ct_rune_t,
+        arg2: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
-#[pg_guard]
-extern "C" {
-    pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
+pub type socklen_t = __darwin_socklen_t;
+pub type sa_family_t = __uint8_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -5109,131 +7262,23 @@ impl Default for iovec {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type socklen_t = __socklen_t;
-pub const __socket_type_SOCK_STREAM: __socket_type = 1;
-pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
-pub const __socket_type_SOCK_RAW: __socket_type = 3;
-pub const __socket_type_SOCK_RDM: __socket_type = 4;
-pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
-pub const __socket_type_SOCK_DCCP: __socket_type = 6;
-pub const __socket_type_SOCK_PACKET: __socket_type = 10;
-pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
-pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
-pub type __socket_type = ::std::os::raw::c_uint;
-pub type sa_family_t = ::std::os::raw::c_ushort;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr {
-    pub sa_family: sa_family_t,
-    pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_storage {
-    pub ss_family: sa_family_t,
-    pub __ss_padding: [::std::os::raw::c_char; 118usize],
-    pub __ss_align: ::std::os::raw::c_ulong,
-}
-impl Default for sockaddr_storage {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub const MSG_OOB: ::std::os::raw::c_uint = 1;
-pub const MSG_PEEK: ::std::os::raw::c_uint = 2;
-pub const MSG_DONTROUTE: ::std::os::raw::c_uint = 4;
-pub const MSG_CTRUNC: ::std::os::raw::c_uint = 8;
-pub const MSG_PROXY: ::std::os::raw::c_uint = 16;
-pub const MSG_TRUNC: ::std::os::raw::c_uint = 32;
-pub const MSG_DONTWAIT: ::std::os::raw::c_uint = 64;
-pub const MSG_EOR: ::std::os::raw::c_uint = 128;
-pub const MSG_WAITALL: ::std::os::raw::c_uint = 256;
-pub const MSG_FIN: ::std::os::raw::c_uint = 512;
-pub const MSG_SYN: ::std::os::raw::c_uint = 1024;
-pub const MSG_CONFIRM: ::std::os::raw::c_uint = 2048;
-pub const MSG_RST: ::std::os::raw::c_uint = 4096;
-pub const MSG_ERRQUEUE: ::std::os::raw::c_uint = 8192;
-pub const MSG_NOSIGNAL: ::std::os::raw::c_uint = 16384;
-pub const MSG_MORE: ::std::os::raw::c_uint = 32768;
-pub const MSG_WAITFORONE: ::std::os::raw::c_uint = 65536;
-pub const MSG_BATCH: ::std::os::raw::c_uint = 262144;
-pub const MSG_ZEROCOPY: ::std::os::raw::c_uint = 67108864;
-pub const MSG_FASTOPEN: ::std::os::raw::c_uint = 536870912;
-pub const MSG_CMSG_CLOEXEC: ::std::os::raw::c_uint = 1073741824;
-pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
+pub type sae_associd_t = __uint32_t;
+pub type sae_connid_t = __uint32_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct msghdr {
-    pub msg_name: *mut ::std::os::raw::c_void,
-    pub msg_namelen: socklen_t,
-    pub msg_iov: *mut iovec,
-    pub msg_iovlen: usize,
-    pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: usize,
-    pub msg_flags: ::std::os::raw::c_int,
+pub struct sa_endpoints {
+    pub sae_srcif: ::std::os::raw::c_uint,
+    pub sae_srcaddr: *const sockaddr,
+    pub sae_srcaddrlen: socklen_t,
+    pub sae_dstaddr: *const sockaddr,
+    pub sae_dstaddrlen: socklen_t,
 }
-impl Default for msghdr {
+impl Default for sa_endpoints {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct cmsghdr {
-    pub cmsg_len: usize,
-    pub cmsg_level: ::std::os::raw::c_int,
-    pub cmsg_type: ::std::os::raw::c_int,
-    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
-}
-pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
-pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __kernel_fd_set {
-    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
-}
-pub type __kernel_sighandler_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
-pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = __kernel_ulong_t;
-pub type __kernel_ssize_t = __kernel_long_t;
-pub type __kernel_ptrdiff_t = __kernel_long_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __kernel_fsid_t {
-    pub val: [::std::os::raw::c_int; 2usize],
-}
-pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
-pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
-pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type sa_endpoints_t = sa_endpoints;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct linger {
@@ -5242,175 +7287,273 @@ pub struct linger {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct osockaddr {
-    pub sa_family: ::std::os::raw::c_ushort,
-    pub sa_data: [::std::os::raw::c_uchar; 14usize],
+pub struct so_np_extensions {
+    pub npx_flags: u_int32_t,
+    pub npx_mask: u_int32_t,
 }
-pub const SHUT_RD: ::std::os::raw::c_uint = 0;
-pub const SHUT_WR: ::std::os::raw::c_uint = 1;
-pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
-pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr {
+    pub sa_len: __uint8_t,
+    pub sa_family: sa_family_t,
+    pub sa_data: [::std::os::raw::c_char; 14usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockproto {
+    pub sp_family: __uint16_t,
+    pub sp_protocol: __uint16_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_storage {
+    pub ss_len: __uint8_t,
+    pub ss_family: sa_family_t,
+    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
+    pub __ss_align: __int64_t,
+    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+}
+impl Default for sockaddr_storage {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct msghdr {
+    pub msg_name: *mut ::std::os::raw::c_void,
+    pub msg_namelen: socklen_t,
+    pub msg_iov: *mut iovec,
+    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_control: *mut ::std::os::raw::c_void,
+    pub msg_controllen: socklen_t,
+    pub msg_flags: ::std::os::raw::c_int,
+}
+impl Default for msghdr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct cmsghdr {
+    pub cmsg_len: socklen_t,
+    pub cmsg_level: ::std::os::raw::c_int,
+    pub cmsg_type: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sf_hdtr {
+    pub headers: *mut iovec,
+    pub hdr_cnt: ::std::os::raw::c_int,
+    pub trailers: *mut iovec,
+    pub trl_cnt: ::std::os::raw::c_int,
+}
+impl Default for sf_hdtr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[pg_guard]
 extern "C" {
-    pub fn socket(
-        __domain: ::std::os::raw::c_int,
-        __type: ::std::os::raw::c_int,
-        __protocol: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn socketpair(
-        __domain: ::std::os::raw::c_int,
-        __type: ::std::os::raw::c_int,
-        __protocol: ::std::os::raw::c_int,
-        __fds: *mut ::std::os::raw::c_int,
+    pub fn accept(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn bind(
-        __fd: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __len: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockname(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sockaddr,
+        arg3: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn connect(
-        __fd: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __len: socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sockaddr,
+        arg3: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn getpeername(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn send(
-        __fd: ::std::os::raw::c_int,
-        __buf: *const ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-    ) -> isize;
+    pub fn getsockname(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsockopt(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_void,
+        arg5: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn listen(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn recv(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendto(
-        __fd: ::std::os::raw::c_int,
-        __buf: *const ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __addr_len: socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn recvfrom(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __addr_len: *mut socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendmsg(
-        __fd: ::std::os::raw::c_int,
-        __message: *const msghdr,
-        __flags: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+        arg5: *mut sockaddr,
+        arg6: *mut socklen_t,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn recvmsg(
-        __fd: ::std::os::raw::c_int,
-        __message: *mut msghdr,
-        __flags: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut msghdr,
+        arg3: ::std::os::raw::c_int,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getsockopt(
-        __fd: ::std::os::raw::c_int,
-        __level: ::std::os::raw::c_int,
-        __optname: ::std::os::raw::c_int,
-        __optval: *mut ::std::os::raw::c_void,
-        __optlen: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn send(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendmsg(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const msghdr,
+        arg3: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendto(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+        arg5: *const sockaddr,
+        arg6: socklen_t,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn setsockopt(
-        __fd: ::std::os::raw::c_int,
-        __level: ::std::os::raw::c_int,
-        __optname: ::std::os::raw::c_int,
-        __optval: *const ::std::os::raw::c_void,
-        __optlen: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn accept(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __addr_len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_void,
+        arg5: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn shutdown(
-        __fd: ::std::os::raw::c_int,
-        __how: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isfdtype(
-        __fd: ::std::os::raw::c_int,
-        __fdtype: ::std::os::raw::c_int,
+    pub fn socket(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
-pub type in_addr_t = u32;
+#[pg_guard]
+extern "C" {
+    pub fn socketpair(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendfile(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: off_t,
+        arg4: *mut off_t,
+        arg5: *mut sf_hdtr,
+        arg6: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
+}
+#[pg_guard]
+extern "C" {
+    pub fn connectx(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sa_endpoints_t,
+        arg3: sae_associd_t,
+        arg4: ::std::os::raw::c_uint,
+        arg5: *const iovec,
+        arg6: ::std::os::raw::c_uint,
+        arg7: *mut usize,
+        arg8: *mut sae_connid_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn disconnectx(
+        arg1: ::std::os::raw::c_int,
+        arg2: sae_associd_t,
+        arg3: sae_connid_t,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_len: __uint8_t,
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5425,6 +7568,12 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -5432,88 +7581,113 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_sourceaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
+}
+impl Default for group_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
+}
+impl Default for group_source_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct __msfilterreq {
+    pub msfr_ifindex: u32,
+    pub msfr_fmode: u32,
+    pub msfr_nsrcs: u32,
+    pub __msfr_align: u32,
+    pub msfr_group: sockaddr_storage,
+    pub msfr_srcs: *mut sockaddr_storage,
+}
+impl Default for __msfilterreq {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setipv4sourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: in_addr,
+        arg3: in_addr,
+        arg4: u32,
+        arg5: u32,
+        arg6: *mut in_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipv4sourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: in_addr,
+        arg3: in_addr,
+        arg4: *mut u32,
+        arg5: *mut u32,
+        arg6: *mut in_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setsourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: u32,
+        arg3: *mut sockaddr,
+        arg4: socklen_t,
+        arg5: u32,
+        arg6: u32,
+        arg7: *mut sockaddr_storage,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: u32,
+        arg3: *mut sockaddr,
+        arg4: socklen_t,
+        arg5: *mut u32,
+        arg6: *mut u32,
+        arg7: *mut sockaddr_storage,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_int,
+    pub ipi_ifindex: ::std::os::raw::c_uint,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
-pub const IPPROTO_IP: ::std::os::raw::c_uint = 0;
-pub const IPPROTO_ICMP: ::std::os::raw::c_uint = 1;
-pub const IPPROTO_IGMP: ::std::os::raw::c_uint = 2;
-pub const IPPROTO_IPIP: ::std::os::raw::c_uint = 4;
-pub const IPPROTO_TCP: ::std::os::raw::c_uint = 6;
-pub const IPPROTO_EGP: ::std::os::raw::c_uint = 8;
-pub const IPPROTO_PUP: ::std::os::raw::c_uint = 12;
-pub const IPPROTO_UDP: ::std::os::raw::c_uint = 17;
-pub const IPPROTO_IDP: ::std::os::raw::c_uint = 22;
-pub const IPPROTO_TP: ::std::os::raw::c_uint = 29;
-pub const IPPROTO_DCCP: ::std::os::raw::c_uint = 33;
-pub const IPPROTO_IPV6: ::std::os::raw::c_uint = 41;
-pub const IPPROTO_RSVP: ::std::os::raw::c_uint = 46;
-pub const IPPROTO_GRE: ::std::os::raw::c_uint = 47;
-pub const IPPROTO_ESP: ::std::os::raw::c_uint = 50;
-pub const IPPROTO_AH: ::std::os::raw::c_uint = 51;
-pub const IPPROTO_MTP: ::std::os::raw::c_uint = 92;
-pub const IPPROTO_BEETPH: ::std::os::raw::c_uint = 94;
-pub const IPPROTO_ENCAP: ::std::os::raw::c_uint = 98;
-pub const IPPROTO_PIM: ::std::os::raw::c_uint = 103;
-pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
-pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
-pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
-pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
-pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
-pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
-pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
-pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
-pub const IPPROTO_FRAGMENT: ::std::os::raw::c_uint = 44;
-pub const IPPROTO_ICMPV6: ::std::os::raw::c_uint = 58;
-pub const IPPROTO_NONE: ::std::os::raw::c_uint = 59;
-pub const IPPROTO_DSTOPTS: ::std::os::raw::c_uint = 60;
-pub const IPPROTO_MH: ::std::os::raw::c_uint = 135;
-pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
-pub type in_port_t = u16;
-pub const IPPORT_ECHO: ::std::os::raw::c_uint = 7;
-pub const IPPORT_DISCARD: ::std::os::raw::c_uint = 9;
-pub const IPPORT_SYSTAT: ::std::os::raw::c_uint = 11;
-pub const IPPORT_DAYTIME: ::std::os::raw::c_uint = 13;
-pub const IPPORT_NETSTAT: ::std::os::raw::c_uint = 15;
-pub const IPPORT_FTP: ::std::os::raw::c_uint = 21;
-pub const IPPORT_TELNET: ::std::os::raw::c_uint = 23;
-pub const IPPORT_SMTP: ::std::os::raw::c_uint = 25;
-pub const IPPORT_TIMESERVER: ::std::os::raw::c_uint = 37;
-pub const IPPORT_NAMESERVER: ::std::os::raw::c_uint = 42;
-pub const IPPORT_WHOIS: ::std::os::raw::c_uint = 43;
-pub const IPPORT_MTP: ::std::os::raw::c_uint = 57;
-pub const IPPORT_TFTP: ::std::os::raw::c_uint = 69;
-pub const IPPORT_RJE: ::std::os::raw::c_uint = 77;
-pub const IPPORT_FINGER: ::std::os::raw::c_uint = 79;
-pub const IPPORT_TTYLINK: ::std::os::raw::c_uint = 87;
-pub const IPPORT_SUPDUP: ::std::os::raw::c_uint = 95;
-pub const IPPORT_EXECSERVER: ::std::os::raw::c_uint = 512;
-pub const IPPORT_LOGINSERVER: ::std::os::raw::c_uint = 513;
-pub const IPPORT_CMDSERVER: ::std::os::raw::c_uint = 514;
-pub const IPPORT_EFSSERVER: ::std::os::raw::c_uint = 520;
-pub const IPPORT_BIFFUDP: ::std::os::raw::c_uint = 512;
-pub const IPPORT_WHOSERVER: ::std::os::raw::c_uint = 513;
-pub const IPPORT_ROUTESERVER: ::std::os::raw::c_uint = 520;
-pub const IPPORT_RESERVED: ::std::os::raw::c_uint = 1024;
-pub const IPPORT_USERRESERVED: ::std::os::raw::c_uint = 5000;
-pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __in6_u: in6_addr__bindgen_ty_1,
+    pub __u6_addr: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [u8; 16usize],
-    pub __u6_addr16: [u16; 8usize],
-    pub __u6_addr32: [u32; 4usize],
-    _bindgen_union_align: [u32; 4usize],
+    pub __u6_addr8: [__uint8_t; 16usize],
+    pub __u6_addr16: [__uint16_t; 8usize],
+    pub __u6_addr32: [__uint32_t; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -5521,6 +7695,22 @@ impl Default for in6_addr__bindgen_ty_1 {
     }
 }
 impl Default for in6_addr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type in6_addr_t = in6_addr;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_len: __uint8_t,
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: __uint32_t,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: __uint32_t,
+}
+impl Default for sockaddr_in6 {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
@@ -5533,40 +7723,21 @@ extern "C" {
 extern "C" {
     pub static in6addr_loopback: in6_addr;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+#[pg_guard]
+extern "C" {
+    pub static in6addr_nodelocal_allnodes: in6_addr;
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_in6 {
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: u32,
-    pub sin6_addr: in6_addr,
-    pub sin6_scope_id: u32,
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allnodes: in6_addr;
 }
-impl Default for sockaddr_in6 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allrouters: in6_addr;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-    pub imr_sourceaddr: in_addr,
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allv2routers: in6_addr;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5581,165 +7752,234 @@ impl Default for ipv6_mreq {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
+pub struct in6_pktinfo {
+    pub ipi6_addr: in6_addr,
+    pub ipi6_ifindex: ::std::os::raw::c_uint,
 }
-impl Default for group_req {
+impl Default for in6_pktinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
+pub struct ip6_mtuinfo {
+    pub ip6m_addr: sockaddr_in6,
+    pub ip6m_mtu: u32,
 }
-impl Default for group_source_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_msfilter {
-    pub imsf_multiaddr: in_addr,
-    pub imsf_interface: in_addr,
-    pub imsf_fmode: u32,
-    pub imsf_numsrc: u32,
-    pub imsf_slist: [in_addr; 1usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct group_filter {
-    pub gf_interface: u32,
-    pub gf_group: sockaddr_storage,
-    pub gf_fmode: u32,
-    pub gf_numsrc: u32,
-    pub gf_slist: [sockaddr_storage; 1usize],
-}
-impl Default for group_filter {
+impl Default for ip6_mtuinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn ntohl(__netlong: u32) -> u32;
+    pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ntohs(__netshort: u16) -> u16;
+    pub fn inet6_option_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *mut *mut cmsghdr,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn htonl(__hostlong: u32) -> u32;
+    pub fn inet6_option_append(
+        arg1: *mut cmsghdr,
+        arg2: *const __uint8_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn htons(__hostshort: u16) -> u16;
+    pub fn inet6_option_alloc(
+        arg1: *mut cmsghdr,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> *mut __uint8_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_option_next(
+        arg1: *const cmsghdr,
+        arg2: *mut *mut __uint8_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_option_find(
+        arg1: *const cmsghdr,
+        arg2: *mut *mut __uint8_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut cmsghdr;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_add(
+        arg1: *mut cmsghdr,
+        arg2: *const in6_addr,
+        arg3: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_lasthop(
+        arg1: *mut cmsghdr,
+        arg2: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_getaddr(arg1: *mut cmsghdr, arg2: ::std::os::raw::c_int) -> *mut in6_addr;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_getflags(
+        arg1: *const cmsghdr,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_append(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: __uint8_t,
+        arg5: socklen_t,
+        arg6: __uint8_t,
+        arg7: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_finish(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_set_val(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_next(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut __uint8_t,
+        arg5: *mut socklen_t,
+        arg6: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_find(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: __uint8_t,
+        arg5: *mut socklen_t,
+        arg6: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_get_val(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> socklen_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_add(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *const in6_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_reverse(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_getaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut in6_addr;
 }
 #[pg_guard]
 extern "C" {
     pub fn bindresvport(
-        __sockfd: ::std::os::raw::c_int,
-        __sock_in: *mut sockaddr_in,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr_in,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bindresvport6(
-        __sockfd: ::std::os::raw::c_int,
-        __sock_in: *mut sockaddr_in6,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endrpcent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent() -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
+    pub fn bindresvport_sa(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getrpcbynumber_r(
-        __number: ::std::os::raw::c_int,
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent_r(
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn herror(__str: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub static mut h_errno: ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5755,135 +7995,18 @@ impl Default for hostent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn sethostent(__stay_open: ::std::os::raw::c_int);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
 }
-#[pg_guard]
-extern "C" {
-    pub fn endhostent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent() -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr(
-        __addr: *const ::std::os::raw::c_void,
-        __len: __socklen_t,
-        __type: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2(
-        __name: *const ::std::os::raw::c_char,
-        __af: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent_r(
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr_r(
-        __addr: *const ::std::os::raw::c_void,
-        __len: __socklen_t,
-        __type: ::std::os::raw::c_int,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2_r(
-        __name: *const ::std::os::raw::c_char,
-        __af: ::std::os::raw::c_int,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent() -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent_r(
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr_r(
-        __net: u32,
-        __type: ::std::os::raw::c_int,
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+impl Default for netent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5898,63 +8021,6 @@ impl Default for servent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn setservent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endservent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent() -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname(
-        __name: *const ::std::os::raw::c_char,
-        __proto: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport(
-        __port: ::std::os::raw::c_int,
-        __proto: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent_r(
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __proto: *const ::std::os::raw::c_char,
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport_r(
-        __port: ::std::os::raw::c_int,
-        __proto: *const ::std::os::raw::c_char,
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -5967,185 +8033,6 @@ impl Default for protoent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endprotoent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent() -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent_r(
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber_r(
-        __proto: ::std::os::raw::c_int,
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetgrent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetgrent(
-        __hostp: *mut *mut ::std::os::raw::c_char,
-        __userp: *mut *mut ::std::os::raw::c_char,
-        __domainp: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn innetgr(
-        __netgroup: *const ::std::os::raw::c_char,
-        __host: *const ::std::os::raw::c_char,
-        __user: *const ::std::os::raw::c_char,
-        __domain: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetgrent_r(
-        __hostp: *mut *mut ::std::os::raw::c_char,
-        __userp: *mut *mut ::std::os::raw::c_char,
-        __domainp: *mut *mut ::std::os::raw::c_char,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rcmd(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_ushort,
-        __locuser: *const ::std::os::raw::c_char,
-        __remuser: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rcmd_af(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_ushort,
-        __locuser: *const ::std::os::raw::c_char,
-        __remuser: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rexec(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_int,
-        __name: *const ::std::os::raw::c_char,
-        __pass: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rexec_af(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_int,
-        __name: *const ::std::os::raw::c_char,
-        __pass: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ruserok(
-        __rhost: *const ::std::os::raw::c_char,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ruserok_af(
-        __rhost: *const ::std::os::raw::c_char,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iruserok(
-        __raddr: u32,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iruserok_af(
-        __raddr: *const ::std::os::raw::c_void,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rresvport_af(
-        __alport: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct addrinfo {
@@ -6154,8 +8041,8 @@ pub struct addrinfo {
     pub ai_socktype: ::std::os::raw::c_int,
     pub ai_protocol: ::std::os::raw::c_int,
     pub ai_addrlen: socklen_t,
-    pub ai_addr: *mut sockaddr,
     pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_addr: *mut sockaddr,
     pub ai_next: *mut addrinfo,
 }
 impl Default for addrinfo {
@@ -6163,50 +8050,269 @@ impl Default for addrinfo {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn endhostent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endprotoent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endservent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn freeaddrinfo(arg1: *mut addrinfo);
+}
+#[pg_guard]
+extern "C" {
+    pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
 #[pg_guard]
 extern "C" {
     pub fn getaddrinfo(
-        __name: *const ::std::os::raw::c_char,
-        __service: *const ::std::os::raw::c_char,
-        __req: *const addrinfo,
-        __pai: *mut *mut addrinfo,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *const addrinfo,
+        arg4: *mut *mut addrinfo,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn freeaddrinfo(__ai: *mut addrinfo);
+    pub fn gethostbyaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut hostent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent() -> *mut hostent;
 }
 #[pg_guard]
 extern "C" {
     pub fn getnameinfo(
-        __sa: *const sockaddr,
-        __salen: socklen_t,
-        __host: *mut ::std::os::raw::c_char,
-        __hostlen: socklen_t,
-        __serv: *mut ::std::os::raw::c_char,
-        __servlen: socklen_t,
-        __flags: ::std::os::raw::c_int,
+        arg1: *const sockaddr,
+        arg2: socklen_t,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: socklen_t,
+        arg5: *mut ::std::os::raw::c_char,
+        arg6: socklen_t,
+        arg7: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent() -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent() -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent() -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sethostent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprotoent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setservent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn freehostent(arg1: *mut hostent);
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipnodebyaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipnodebyname(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcent() -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setrpcent(stayopen: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endrpcent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn herror(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn innetgr(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *const ::std::os::raw::c_char,
+        arg4: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetgrent(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetgrent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct passwd {
     pub pw_name: *mut ::std::os::raw::c_char,
     pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: __uid_t,
-    pub pw_gid: __gid_t,
+    pub pw_uid: uid_t,
+    pub pw_gid: gid_t,
+    pub pw_change: __darwin_time_t,
+    pub pw_class: *mut ::std::os::raw::c_char,
     pub pw_gecos: *mut ::std::os::raw::c_char,
     pub pw_dir: *mut ::std::os::raw::c_char,
     pub pw_shell: *mut ::std::os::raw::c_char,
+    pub pw_expire: __darwin_time_t,
 }
 impl Default for passwd {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid(arg1: uid_t) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid_r(
+        arg1: uid_t,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam_r(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwent() -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
@@ -6216,63 +8322,86 @@ extern "C" {
 extern "C" {
     pub fn endpwent();
 }
+pub type uuid_t = __darwin_uuid_t;
+pub type uuid_string_t = __darwin_uuid_string_t;
 #[pg_guard]
 extern "C" {
-    pub fn getpwent() -> *mut passwd;
+    pub static UUID_NULL: uuid_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
+    pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
 }
 #[pg_guard]
 extern "C" {
-    pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwent_r(
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_compare(
+        uu1: *mut ::std::os::raw::c_uchar,
+        uu2: *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwuid_r(
-        __uid: __uid_t,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_early_random(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_parse(
+        in_: *mut ::std::os::raw::c_char,
+        uu: *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwnam_r(
-        __name: *const ::std::os::raw::c_char,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
-    ) -> ::std::os::raw::c_int;
+    pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpwent_r(
-        __stream: *mut FILE,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_unparse_lower(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_unparse_upper(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn user_from_uid(arg1: uid_t, arg2: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuuid_r(
+        arg1: *mut ::std::os::raw::c_uchar,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -6539,34 +8668,6 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpeereid(
-        sock: ::std::os::raw::c_int,
-        uid: *mut uid_t,
-        gid: *mut gid_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
     pub fn pqStrerror(
         errnum: ::std::os::raw::c_int,
         strerrbuf: *mut ::std::os::raw::c_char,
@@ -6693,39 +8794,28 @@ extern "C" {
         include_command_not_found: bool,
     ) -> bool;
 }
-pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __jmp_buf_tag {
-    pub __jmpbuf: __jmp_buf,
-    pub __mask_was_saved: ::std::os::raw::c_int,
-    pub __saved_mask: __sigset_t,
-}
-pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type jmp_buf = [::std::os::raw::c_int; 37usize];
+pub type sigjmp_buf = [::std::os::raw::c_int; 38usize];
 #[pg_guard]
 extern "C" {
-    pub fn setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
+    pub fn setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sigsetjmp(
-        __env: *mut __jmp_buf_tag,
-        __savemask: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn _setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
+    pub fn _setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
+    pub fn _longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn _longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
+    pub fn longjmperror();
 }
-pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
     pub fn errstart(
@@ -8397,7 +10487,6 @@ pub union ListCell__bindgen_ty_1 {
     pub ptr_value: *mut ::std::os::raw::c_void,
     pub int_value: ::std::os::raw::c_int,
     pub oid_value: Oid,
-    _bindgen_union_align: u64,
 }
 impl Default for ListCell__bindgen_ty_1 {
     fn default() -> Self {
@@ -9755,83 +11844,239 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
+    pub l_start: off_t,
+    pub l_len: off_t,
+    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
-    pub l_start: __off_t,
-    pub l_len: __off_t,
-    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct stat {
-    pub st_dev: __dev_t,
-    pub st_ino: __ino_t,
-    pub st_nlink: __nlink_t,
-    pub st_mode: __mode_t,
-    pub st_uid: __uid_t,
-    pub st_gid: __gid_t,
-    pub __pad0: ::std::os::raw::c_int,
-    pub st_rdev: __dev_t,
-    pub st_size: __off_t,
-    pub st_blksize: __blksize_t,
-    pub st_blocks: __blkcnt_t,
-    pub st_atim: timespec,
-    pub st_mtim: timespec,
-    pub st_ctim: timespec,
-    pub __glibc_reserved: [__syscall_slong_t; 3usize],
+pub struct timespec {
+    pub tv_sec: __darwin_time_t,
+    pub tv_nsec: ::std::os::raw::c_long,
 }
-#[pg_guard]
-extern "C" {
-    pub fn fcntl(
-        __fd: ::std::os::raw::c_int,
-        __cmd: ::std::os::raw::c_int,
-        ...
-    ) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct flocktimeout {
+    pub fl: flock,
+    pub timeout: timespec,
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct radvisory {
+    pub ra_offset: off_t,
+    pub ra_count: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsignatures {
+    pub fs_file_start: off_t,
+    pub fs_blob_start: *mut ::std::os::raw::c_void,
+    pub fs_blob_size: usize,
+    pub fs_fsignatures_size: usize,
+    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
+    pub fs_hash_type: ::std::os::raw::c_int,
+}
+impl Default for fsignatures {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fsignatures_t = fsignatures;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fsupplement {
+    pub fs_file_start: off_t,
+    pub fs_blob_start: off_t,
+    pub fs_blob_size: usize,
+    pub fs_orig_fd: ::std::os::raw::c_int,
+}
+pub type fsupplement_t = fsupplement;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fchecklv {
+    pub lv_file_start: off_t,
+    pub lv_error_message_size: usize,
+    pub lv_error_message: *mut ::std::os::raw::c_void,
+}
+impl Default for fchecklv {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fchecklv_t = fchecklv;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fgetsigsinfo {
+    pub fg_file_start: off_t,
+    pub fg_info_request: ::std::os::raw::c_int,
+    pub fg_sig_is_platform: ::std::os::raw::c_int,
+}
+pub type fgetsigsinfo_t = fgetsigsinfo;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fstore {
+    pub fst_flags: ::std::os::raw::c_uint,
+    pub fst_posmode: ::std::os::raw::c_int,
+    pub fst_offset: off_t,
+    pub fst_length: off_t,
+    pub fst_bytesalloc: off_t,
+}
+pub type fstore_t = fstore;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fpunchhole {
+    pub fp_flags: ::std::os::raw::c_uint,
+    pub reserved: ::std::os::raw::c_uint,
+    pub fp_offset: off_t,
+    pub fp_length: off_t,
+}
+pub type fpunchhole_t = fpunchhole;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ftrimactivefile {
+    pub fta_offset: off_t,
+    pub fta_length: off_t,
+}
+pub type ftrimactivefile_t = ftrimactivefile;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fspecread {
+    pub fsr_flags: ::std::os::raw::c_uint,
+    pub reserved: ::std::os::raw::c_uint,
+    pub fsr_offset: off_t,
+    pub fsr_length: off_t,
+}
+pub type fspecread_t = fspecread;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fbootstraptransfer {
+    pub fbt_offset: off_t,
+    pub fbt_length: usize,
+    pub fbt_buffer: *mut ::std::os::raw::c_void,
+}
+impl Default for fbootstraptransfer {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fbootstraptransfer_t = fbootstraptransfer;
+#[repr(C, packed(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct log2phys {
+    pub l2p_flags: ::std::os::raw::c_uint,
+    pub l2p_contigbytes: off_t,
+    pub l2p_devoffset: off_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _filesec {
+    _unused: [u8; 0],
+}
+pub type filesec_t = *mut _filesec;
+pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
+pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
+pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
+pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
+pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
+pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
+pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
+pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
+pub type filesec_property_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn open(
-        __file: *const ::std::os::raw::c_char,
-        __oflag: ::std::os::raw::c_int,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn openat(
-        __fd: ::std::os::raw::c_int,
-        __file: *const ::std::os::raw::c_char,
-        __oflag: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn creat(__file: *const ::std::os::raw::c_char, __mode: mode_t) -> ::std::os::raw::c_int;
+    pub fn creat(arg1: *const ::std::os::raw::c_char, arg2: mode_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lockf(
-        __fd: ::std::os::raw::c_int,
-        __cmd: ::std::os::raw::c_int,
-        __len: off_t,
+    pub fn fcntl(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix_fadvise(
-        __fd: ::std::os::raw::c_int,
-        __offset: off_t,
-        __len: off_t,
-        __advise: ::std::os::raw::c_int,
+    pub fn openx_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: filesec_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix_fallocate(
-        __fd: ::std::os::raw::c_int,
-        __offset: off_t,
-        __len: off_t,
+    pub fn open_dprotected_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flock(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_init() -> filesec_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_free(arg1: filesec_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_get_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_query_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_set_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_unset_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
     ) -> ::std::os::raw::c_int;
 }
 pub type XLogRecPtr = uint64;
@@ -11666,115 +13911,20 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *const ::std::os::raw::c_char,
+    pub tm_zone: *mut ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct itimerspec {
-    pub it_interval: timespec,
-    pub it_value: timespec,
+#[pg_guard]
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock() -> clock_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn time(__timer: *mut time_t) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktime(__tp: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strftime(
-        __s: *mut ::std::os::raw::c_char,
-        __maxsize: usize,
-        __format: *const ::std::os::raw::c_char,
-        __tp: *const tm,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strftime_l(
-        __s: *mut ::std::os::raw::c_char,
-        __maxsize: usize,
-        __format: *const ::std::os::raw::c_char,
-        __tp: *const tm,
-        __loc: locale_t,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime(__timer: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime(__timer: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime_r(
-        __tp: *const tm,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctime_r(
-        __timer: *const time_t,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __daylight: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __timezone: ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
-}
-#[pg_guard]
-extern "C" {
-    pub fn tzset();
-}
-#[pg_guard]
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
+    pub static mut getdate_err: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -11782,23 +13932,120 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn timegm(__tp: *mut tm) -> time_t;
+    pub static mut daylight: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timelocal(__tp: *mut tm) -> time_t;
+    pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn clock() -> clock_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nanosleep(
-        __requested_time: *const timespec,
-        __remaining: *mut timespec,
-    ) -> ::std::os::raw::c_int;
+    pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
 }
+#[pg_guard]
+extern "C" {
+    pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime(arg1: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime(arg1: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktime(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strftime(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: *const ::std::os::raw::c_char,
+        arg4: *const tm,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strptime(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut tm,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn time(arg1: *mut time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tzset();
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime_r(
+        arg1: *const tm,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ctime_r(
+        arg1: *const time_t,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn posix2time(arg1: time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tzsetwall();
+}
+#[pg_guard]
+extern "C" {
+    pub fn time2posix(arg1: time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timelocal(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timegm(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanosleep(__rqtp: *const timespec, __rmtp: *mut timespec) -> ::std::os::raw::c_int;
+}
+pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
+pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
+pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
+pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
+pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
+pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
+pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
+pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
+pub type clockid_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn clock_getres(__clock_id: clockid_t, __res: *mut timespec) -> ::std::os::raw::c_int;
@@ -11809,56 +14056,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
+}
+#[pg_guard]
+extern "C" {
     pub fn clock_settime(__clock_id: clockid_t, __tp: *const timespec) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock_nanosleep(
-        __clock_id: clockid_t,
-        __flags: ::std::os::raw::c_int,
-        __req: *const timespec,
-        __rem: *mut timespec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn clock_getcpuclockid(__pid: pid_t, __clock_id: *mut clockid_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_create(
-        __clock_id: clockid_t,
-        __evp: *mut sigevent,
-        __timerid: *mut timer_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_settime(
-        __timerid: timer_t,
-        __flags: ::std::os::raw::c_int,
-        __value: *const itimerspec,
-        __ovalue: *mut itimerspec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_gettime(__timerid: timer_t, __value: *mut itimerspec) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timespec_get(
-        __ts: *mut timespec,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn timespec_get(ts: *mut timespec, base: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type instr_time = timespec;
 #[repr(C)]
@@ -14849,7 +17055,6 @@ pub struct Value {
 pub union Value_ValUnion {
     pub ival: ::std::os::raw::c_long,
     pub str_: *mut ::std::os::raw::c_char,
-    _bindgen_union_align: u64,
 }
 impl Default for Value_ValUnion {
     fn default() -> Self {
@@ -18174,82 +20379,104 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __ino_t,
-    pub d_off: __off_t,
-    pub d_reclen: ::std::os::raw::c_ushort,
-    pub d_type: ::std::os::raw::c_uchar,
-    pub d_name: [::std::os::raw::c_char; 256usize],
+    pub d_ino: __uint64_t,
+    pub d_seekoff: __uint64_t,
+    pub d_reclen: __uint16_t,
+    pub d_namlen: __uint16_t,
+    pub d_type: __uint8_t,
+    pub d_name: [::std::os::raw::c_char; 1024usize],
 }
 impl Default for dirent {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub const DT_UNKNOWN: ::std::os::raw::c_uint = 0;
-pub const DT_FIFO: ::std::os::raw::c_uint = 1;
-pub const DT_CHR: ::std::os::raw::c_uint = 2;
-pub const DT_DIR: ::std::os::raw::c_uint = 4;
-pub const DT_BLK: ::std::os::raw::c_uint = 6;
-pub const DT_REG: ::std::os::raw::c_uint = 8;
-pub const DT_LNK: ::std::os::raw::c_uint = 10;
-pub const DT_SOCK: ::std::os::raw::c_uint = 12;
-pub const DT_WHT: ::std::os::raw::c_uint = 14;
-pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __dirstream {
+pub struct _telldir {
     _unused: [u8; 0],
 }
-pub type DIR = __dirstream;
-#[pg_guard]
-extern "C" {
-    pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct DIR {
+    pub __dd_fd: ::std::os::raw::c_int,
+    pub __dd_loc: ::std::os::raw::c_long,
+    pub __dd_size: ::std::os::raw::c_long,
+    pub __dd_buf: *mut ::std::os::raw::c_char,
+    pub __dd_len: ::std::os::raw::c_int,
+    pub __dd_seek: ::std::os::raw::c_long,
+    pub __padding: ::std::os::raw::c_long,
+    pub __dd_flags: ::std::os::raw::c_int,
+    pub __dd_lock: __darwin_pthread_mutex_t,
+    pub __dd_td: *mut _telldir,
+}
+impl Default for DIR {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
-    pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
+    pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_opendir$INODE64"]
+    pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+    #[link_name = "\u{1}_readdir$INODE64"]
+    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_readdir_r$INODE64"]
     pub fn readdir_r(
-        __dirp: *mut DIR,
-        __entry: *mut dirent,
-        __result: *mut *mut dirent,
+        arg1: *mut DIR,
+        arg2: *mut dirent,
+        arg3: *mut *mut dirent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rewinddir(__dirp: *mut DIR);
+    #[link_name = "\u{1}_rewinddir$INODE64"]
+    pub fn rewinddir(arg1: *mut DIR);
 }
 #[pg_guard]
 extern "C" {
-    pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
+    #[link_name = "\u{1}_seekdir$INODE64"]
+    pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
 }
 #[pg_guard]
 extern "C" {
-    pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
+    #[link_name = "\u{1}_telldir$INODE64"]
+    pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_fdopendir$INODE64"]
+    pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_alphasort$INODE64"]
+    pub fn alphasort(arg1: *mut *const dirent, arg2: *mut *const dirent) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_scandir$INODE64"]
     pub fn scandir(
-        __dir: *const ::std::os::raw::c_char,
-        __namelist: *mut *mut *mut dirent,
-        __selector: ::std::option::Option<
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut *mut dirent,
+        arg3: ::std::option::Option<
             unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
         >,
-        __cmp: ::std::option::Option<
+        arg4: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut *const dirent,
                 arg2: *mut *const dirent,
@@ -18259,16 +20486,29 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn alphasort(__e1: *mut *const dirent, __e2: *mut *const dirent) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_scandir_b$INODE64"]
+    pub fn scandir_b(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut *mut dirent,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
     pub fn getdirentries(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-        __basep: *mut __off_t,
-    ) -> __ssize_t;
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}___opendir2$INODE64"]
+    pub fn __opendir2(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int)
+        -> *mut DIR;
 }
 pub type FileName = *mut ::std::os::raw::c_char;
 pub type File = ::std::os::raw::c_int;
@@ -19106,7 +21346,6 @@ impl Default for ExpandedArrayHeader {
 pub union AnyArrayType {
     pub flt: ArrayType,
     pub xpn: ExpandedArrayHeader,
-    _bindgen_union_align: [u64; 17usize],
 }
 impl Default for AnyArrayType {
     fn default() -> Self {
@@ -21589,651 +23828,160 @@ extern "C" {
         nulls: *mut *mut bool,
     ) -> ::std::os::raw::c_int;
 }
-pub type sig_atomic_t = __sig_atomic_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-    _bindgen_union_align: u64,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __sigval_t = sigval;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub __pad0: ::std::os::raw::c_int,
-    pub _sifields: siginfo_t__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union siginfo_t__bindgen_ty_1 {
-    pub _pad: [::std::os::raw::c_int; 28usize],
-    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
-    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
-    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
-    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
-    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
-    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
-    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
-    _bindgen_union_align: [u64; 14usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
-    pub si_tid: ::std::os::raw::c_int,
-    pub si_overrun: ::std::os::raw::c_int,
-    pub si_sigval: __sigval_t,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-    pub si_sigval: __sigval_t,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_utime: __clock_t,
-    pub si_stime: __clock_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_addr_lsb: ::std::os::raw::c_short,
-    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
-    pub _pkey: __uint32_t,
-    _bindgen_union_align: [u64; 2usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-    pub _lower: *mut ::std::os::raw::c_void,
-    pub _upper: *mut ::std::os::raw::c_void,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
-    pub si_band: ::std::os::raw::c_long,
-    pub si_fd: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
-    pub _call_addr: *mut ::std::os::raw::c_void,
-    pub _syscall: ::std::os::raw::c_int,
-    pub _arch: ::std::os::raw::c_uint,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub const SI_ASYNCNL: ::std::os::raw::c_int = -60;
-pub const SI_DETHREAD: ::std::os::raw::c_int = -7;
-pub const SI_TKILL: ::std::os::raw::c_int = -6;
-pub const SI_SIGIO: ::std::os::raw::c_int = -5;
-pub const SI_ASYNCIO: ::std::os::raw::c_int = -4;
-pub const SI_MESGQ: ::std::os::raw::c_int = -3;
-pub const SI_TIMER: ::std::os::raw::c_int = -2;
-pub const SI_QUEUE: ::std::os::raw::c_int = -1;
-pub const SI_USER: ::std::os::raw::c_int = 0;
-pub const SI_KERNEL: ::std::os::raw::c_int = 128;
-pub type _bindgen_ty_9 = ::std::os::raw::c_int;
-pub const ILL_ILLOPC: ::std::os::raw::c_uint = 1;
-pub const ILL_ILLOPN: ::std::os::raw::c_uint = 2;
-pub const ILL_ILLADR: ::std::os::raw::c_uint = 3;
-pub const ILL_ILLTRP: ::std::os::raw::c_uint = 4;
-pub const ILL_PRVOPC: ::std::os::raw::c_uint = 5;
-pub const ILL_PRVREG: ::std::os::raw::c_uint = 6;
-pub const ILL_COPROC: ::std::os::raw::c_uint = 7;
-pub const ILL_BADSTK: ::std::os::raw::c_uint = 8;
-pub const ILL_BADIADDR: ::std::os::raw::c_uint = 9;
-pub type _bindgen_ty_10 = ::std::os::raw::c_uint;
-pub const FPE_INTDIV: ::std::os::raw::c_uint = 1;
-pub const FPE_INTOVF: ::std::os::raw::c_uint = 2;
-pub const FPE_FLTDIV: ::std::os::raw::c_uint = 3;
-pub const FPE_FLTOVF: ::std::os::raw::c_uint = 4;
-pub const FPE_FLTUND: ::std::os::raw::c_uint = 5;
-pub const FPE_FLTRES: ::std::os::raw::c_uint = 6;
-pub const FPE_FLTINV: ::std::os::raw::c_uint = 7;
-pub const FPE_FLTSUB: ::std::os::raw::c_uint = 8;
-pub const FPE_FLTUNK: ::std::os::raw::c_uint = 14;
-pub const FPE_CONDTRAP: ::std::os::raw::c_uint = 15;
-pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
-pub const SEGV_MAPERR: ::std::os::raw::c_uint = 1;
-pub const SEGV_ACCERR: ::std::os::raw::c_uint = 2;
-pub const SEGV_BNDERR: ::std::os::raw::c_uint = 3;
-pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
-pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
-pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
-pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
-pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
-pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
-pub const BUS_OBJERR: ::std::os::raw::c_uint = 3;
-pub const BUS_MCEERR_AR: ::std::os::raw::c_uint = 4;
-pub const BUS_MCEERR_AO: ::std::os::raw::c_uint = 5;
-pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
-pub const CLD_EXITED: ::std::os::raw::c_uint = 1;
-pub const CLD_KILLED: ::std::os::raw::c_uint = 2;
-pub const CLD_DUMPED: ::std::os::raw::c_uint = 3;
-pub const CLD_TRAPPED: ::std::os::raw::c_uint = 4;
-pub const CLD_STOPPED: ::std::os::raw::c_uint = 5;
-pub const CLD_CONTINUED: ::std::os::raw::c_uint = 6;
-pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
-pub const POLL_IN: ::std::os::raw::c_uint = 1;
-pub const POLL_OUT: ::std::os::raw::c_uint = 2;
-pub const POLL_MSG: ::std::os::raw::c_uint = 3;
-pub const POLL_ERR: ::std::os::raw::c_uint = 4;
-pub const POLL_PRI: ::std::os::raw::c_uint = 5;
-pub const POLL_HUP: ::std::os::raw::c_uint = 6;
-pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
-pub type sigval_t = __sigval_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_value: __sigval_t,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub _sigev_un: sigevent__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigevent__bindgen_ty_1 {
-    pub _pad: [::std::os::raw::c_int; 12usize],
-    pub _tid: __pid_t,
-    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: [u64; 6usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
-    pub _attribute: *mut pthread_attr_t,
-}
-impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigevent__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sigevent_t = sigevent;
-pub const SIGEV_SIGNAL: ::std::os::raw::c_uint = 0;
-pub const SIGEV_NONE: ::std::os::raw::c_uint = 1;
-pub const SIGEV_THREAD: ::std::os::raw::c_uint = 2;
-pub const SIGEV_THREAD_ID: ::std::os::raw::c_uint = 4;
-pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
-pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[pg_guard]
 extern "C" {
-    pub fn __sysv_signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t)
-        -> __sighandler_t;
+    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ssignal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn siggetmask() -> ::std::os::raw::c_int;
-}
-pub type sig_t = __sighandler_t;
-#[pg_guard]
-extern "C" {
-    pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigaddset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigdelset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigismember(
-        __set: *const sigset_t,
-        __signo: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_handler: sigaction__bindgen_ty_1,
-    pub sa_mask: __sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigaction__bindgen_ty_1 {
-    pub sa_handler: __sighandler_t,
-    pub sa_sigaction: ::std::option::Option<
+    pub fn bsd_signal(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
-            arg2: *mut siginfo_t,
-            arg3: *mut ::std::os::raw::c_void,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
         ),
-    >,
-    _bindgen_union_align: u64,
-}
-impl Default for sigaction__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    >;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigprocmask(
-        __how: ::std::os::raw::c_int,
-        __set: *const sigset_t,
-        __oset: *mut sigset_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
+    pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaction(
-        __sig: ::std::os::raw::c_int,
-        __act: *const sigaction,
-        __oact: *mut sigaction,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigwait(
-        __set: *const sigset_t,
-        __sig: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigwaitinfo(__set: *const sigset_t, __info: *mut siginfo_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigtimedwait(
-        __set: *const sigset_t,
-        __info: *mut siginfo_t,
-        __timeout: *const timespec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigqueue(
-        __pid: __pid_t,
-        __sig: ::std::os::raw::c_int,
-        __val: sigval,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpx_sw_bytes {
-    pub magic1: __uint32_t,
-    pub extended_size: __uint32_t,
-    pub xstate_bv: __uint64_t,
-    pub xstate_size: __uint32_t,
-    pub __glibc_reserved1: [__uint32_t; 7usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpxreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _xmmreg {
-    pub element: [__uint32_t; 4usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpstate {
-    pub cwd: __uint16_t,
-    pub swd: __uint16_t,
-    pub ftw: __uint16_t,
-    pub fop: __uint16_t,
-    pub rip: __uint64_t,
-    pub rdp: __uint64_t,
-    pub mxcsr: __uint32_t,
-    pub mxcr_mask: __uint32_t,
-    pub _st: [_fpxreg; 8usize],
-    pub _xmm: [_xmmreg; 16usize],
-    pub __glibc_reserved1: [__uint32_t; 24usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigcontext {
-    pub r8: __uint64_t,
-    pub r9: __uint64_t,
-    pub r10: __uint64_t,
-    pub r11: __uint64_t,
-    pub r12: __uint64_t,
-    pub r13: __uint64_t,
-    pub r14: __uint64_t,
-    pub r15: __uint64_t,
-    pub rdi: __uint64_t,
-    pub rsi: __uint64_t,
-    pub rbp: __uint64_t,
-    pub rbx: __uint64_t,
-    pub rdx: __uint64_t,
-    pub rax: __uint64_t,
-    pub rcx: __uint64_t,
-    pub rsp: __uint64_t,
-    pub rip: __uint64_t,
-    pub eflags: __uint64_t,
-    pub cs: ::std::os::raw::c_ushort,
-    pub gs: ::std::os::raw::c_ushort,
-    pub fs: ::std::os::raw::c_ushort,
-    pub __pad0: ::std::os::raw::c_ushort,
-    pub err: __uint64_t,
-    pub trapno: __uint64_t,
-    pub oldmask: __uint64_t,
-    pub cr2: __uint64_t,
-    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
-    pub __reserved1: [__uint64_t; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigcontext__bindgen_ty_1 {
-    pub fpstate: *mut _fpstate,
-    pub __fpstate_word: __uint64_t,
-    _bindgen_union_align: u64,
-}
-impl Default for sigcontext__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigcontext {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _xsave_hdr {
-    pub xstate_bv: __uint64_t,
-    pub __glibc_reserved1: [__uint64_t; 2usize],
-    pub __glibc_reserved2: [__uint64_t; 5usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _ymmh_state {
-    pub ymmh_space: [__uint32_t; 64usize],
-}
-impl Default for _ymmh_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _xstate {
-    pub fpstate: _fpstate,
-    pub xstate_hdr: _xsave_hdr,
-    pub ymmh: _ymmh_state,
-}
-impl Default for _xstate {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigreturn(__scp: *mut sigcontext) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct stack_t {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_flags: ::std::os::raw::c_int,
-    pub ss_size: usize,
-}
-impl Default for stack_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type greg_t = ::std::os::raw::c_longlong;
-pub type gregset_t = [greg_t; 23usize];
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_fpxreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_xmmreg {
-    pub element: [__uint32_t; 4usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_fpstate {
-    pub cwd: __uint16_t,
-    pub swd: __uint16_t,
-    pub ftw: __uint16_t,
-    pub fop: __uint16_t,
-    pub rip: __uint64_t,
-    pub rdp: __uint64_t,
-    pub mxcsr: __uint32_t,
-    pub mxcr_mask: __uint32_t,
-    pub _st: [_libc_fpxreg; 8usize],
-    pub _xmm: [_libc_xmmreg; 16usize],
-    pub __glibc_reserved1: [__uint32_t; 24usize],
-}
-pub type fpregset_t = *mut _libc_fpstate;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct mcontext_t {
-    pub gregs: gregset_t,
-    pub fpregs: fpregset_t,
-    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
-}
-impl Default for mcontext_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ucontext_t {
-    pub uc_flags: ::std::os::raw::c_ulong,
-    pub uc_link: *mut ucontext_t,
-    pub uc_stack: stack_t,
-    pub uc_mcontext: mcontext_t,
-    pub uc_sigmask: sigset_t,
-    pub __fpregs_mem: _libc_fpstate,
-    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
-}
-impl Default for ucontext_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn siginterrupt(
-        __sig: ::std::os::raw::c_int,
-        __interrupt: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-pub const SS_ONSTACK: ::std::os::raw::c_uint = 1;
-pub const SS_DISABLE: ::std::os::raw::c_uint = 2;
-pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
-#[pg_guard]
-extern "C" {
-    pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigstack(__ss: *mut sigstack, __oss: *mut sigstack) -> ::std::os::raw::c_int;
+    pub fn pthread_kill(arg1: pthread_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn pthread_sigmask(
-        __how: ::std::os::raw::c_int,
-        __newmask: *const __sigset_t,
-        __oldmask: *mut __sigset_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigset_t,
+        arg3: *mut sigset_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_kill(
-        __threadid: pthread_t,
-        __signo: ::std::os::raw::c_int,
+    pub fn sigaction(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigaction,
+        arg3: *mut sigaction,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+    pub fn sigaddset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+    pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigdelset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn siginterrupt(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigismember(arg1: *const sigset_t, arg2: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigprocmask(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigset_t,
+        arg3: *mut sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigset(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+        ),
+    >;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigwait(
+        arg1: *const sigset_t,
+        arg2: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigvec(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sigvec,
+        arg3: *mut sigvec,
+    ) -> ::std::os::raw::c_int;
 }
 pub type pg_time_t = int64;
 #[repr(C)]
@@ -22837,8 +24585,9 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_un {
+    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 108usize],
+    pub sun_path: [::std::os::raw::c_char; 104usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -23108,7 +24857,6 @@ pub struct LWLock {
 pub union LWLockPadded {
     pub lock: LWLock,
     pub pad: [::std::os::raw::c_char; 128usize],
-    _bindgen_union_align: [u32; 32usize],
 }
 impl Default for LWLockPadded {
     fn default() -> Self {
@@ -23120,7 +24868,6 @@ impl Default for LWLockPadded {
 pub union LWLockMinimallyPadded {
     pub lock: LWLock,
     pub pad: [::std::os::raw::c_char; 32usize],
-    _bindgen_union_align: [u32; 8usize],
 }
 impl Default for LWLockMinimallyPadded {
     fn default() -> Self {
@@ -24433,7 +26180,6 @@ pub union PgStat_Msg {
     pub msg_funcpurge: PgStat_MsgFuncpurge,
     pub msg_recoveryconflict: PgStat_MsgRecoveryConflict,
     pub msg_deadlock: PgStat_MsgDeadlock,
-    _bindgen_union_align: [u64; 125usize],
 }
 impl Default for PgStat_Msg {
     fn default() -> Self {
@@ -25432,7 +27178,6 @@ pub struct HeapTupleFields {
 pub union HeapTupleFields__bindgen_ty_1 {
     pub t_cid: CommandId,
     pub t_xvac: TransactionId,
-    _bindgen_union_align: u32,
 }
 impl Default for HeapTupleFields__bindgen_ty_1 {
     fn default() -> Self {
@@ -25465,7 +27210,6 @@ pub struct HeapTupleHeaderData {
 pub union HeapTupleHeaderData__bindgen_ty_1 {
     pub t_heap: HeapTupleFields,
     pub t_datum: DatumTupleFields,
-    _bindgen_union_align: [u32; 3usize],
 }
 impl Default for HeapTupleHeaderData__bindgen_ty_1 {
     fn default() -> Self {
@@ -25651,7 +27395,6 @@ pub union relopt_value__bindgen_ty_1 {
     pub int_val: ::std::os::raw::c_int,
     pub real_val: f64,
     pub string_val: *mut ::std::os::raw::c_char,
-    _bindgen_union_align: u64,
 }
 impl Default for relopt_value__bindgen_ty_1 {
     fn default() -> Self {
@@ -26020,7 +27763,6 @@ pub union SharedInvalidationMessage {
     pub sm: SharedInvalSmgrMsg,
     pub rm: SharedInvalRelmapMsg,
     pub sn: SharedInvalSnapshotMsg,
-    _bindgen_union_align: [u32; 4usize],
 }
 impl Default for SharedInvalidationMessage {
     fn default() -> Self {
@@ -28419,7 +30161,6 @@ pub union CollectedCommand__bindgen_ty_1 {
     pub createopc: CollectedCommand__bindgen_ty_1__bindgen_ty_5,
     pub atscfg: CollectedCommand__bindgen_ty_1__bindgen_ty_6,
     pub defprivs: CollectedCommand__bindgen_ty_1__bindgen_ty_7,
-    _bindgen_union_align: [u64; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -35139,7 +36880,6 @@ pub union ReorderBufferChange__bindgen_ty_1 {
     pub snapshot: Snapshot,
     pub command_id: CommandId,
     pub tuplecid: ReorderBufferChange__bindgen_ty_1__bindgen_ty_3,
-    _bindgen_union_align: [u64; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -47690,963 +49430,403 @@ pub type float_t = f32;
 pub type double_t = f64;
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __math_errhandling() -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
+    pub fn acosf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
+    pub fn acos(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
+    pub fn acosl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acos(__x: f64) -> f64;
+    pub fn asinf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __acos(__x: f64) -> f64;
+    pub fn asin(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asin(__x: f64) -> f64;
+    pub fn asinl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __asin(__x: f64) -> f64;
+    pub fn atanf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan(__x: f64) -> f64;
+    pub fn atan(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atan(__x: f64) -> f64;
+    pub fn atanl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2(__y: f64, __x: f64) -> f64;
+    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atan2(__y: f64, __x: f64) -> f64;
+    pub fn atan2(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cos(__x: f64) -> f64;
+    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cos(__x: f64) -> f64;
+    pub fn cosf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sin(__x: f64) -> f64;
+    pub fn cos(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sin(__x: f64) -> f64;
+    pub fn cosl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tan(__x: f64) -> f64;
+    pub fn sinf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tan(__x: f64) -> f64;
+    pub fn sin(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosh(__x: f64) -> f64;
+    pub fn sinl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cosh(__x: f64) -> f64;
+    pub fn tanf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinh(__x: f64) -> f64;
+    pub fn tan(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sinh(__x: f64) -> f64;
+    pub fn tanl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanh(__x: f64) -> f64;
+    pub fn acoshf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tanh(__x: f64) -> f64;
+    pub fn acosh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosh(__x: f64) -> f64;
+    pub fn acoshl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __acosh(__x: f64) -> f64;
+    pub fn asinhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinh(__x: f64) -> f64;
+    pub fn asinh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __asinh(__x: f64) -> f64;
+    pub fn asinhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanh(__x: f64) -> f64;
+    pub fn atanhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atanh(__x: f64) -> f64;
+    pub fn atanh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp(__x: f64) -> f64;
+    pub fn atanhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __exp(__x: f64) -> f64;
+    pub fn coshf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
+    pub fn cosh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
+    pub fn coshl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
+    pub fn sinhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
+    pub fn sinh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log(__x: f64) -> f64;
+    pub fn sinhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log(__x: f64) -> f64;
+    pub fn tanhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10(__x: f64) -> f64;
+    pub fn tanh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log10(__x: f64) -> f64;
+    pub fn tanhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
+    pub fn expf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
+    pub fn exp(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1(__x: f64) -> f64;
+    pub fn expl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __expm1(__x: f64) -> f64;
+    pub fn exp2f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1p(__x: f64) -> f64;
+    pub fn exp2(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log1p(__x: f64) -> f64;
+    pub fn exp2l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logb(__x: f64) -> f64;
+    pub fn expm1f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __logb(__x: f64) -> f64;
+    pub fn expm1(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2(__x: f64) -> f64;
+    pub fn expm1l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __exp2(__x: f64) -> f64;
+    pub fn logf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2(__x: f64) -> f64;
+    pub fn log(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log2(__x: f64) -> f64;
+    pub fn logl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pow(__x: f64, __y: f64) -> f64;
+    pub fn log10f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __pow(__x: f64, __y: f64) -> f64;
+    pub fn log10(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sqrt(__x: f64) -> f64;
+    pub fn log10l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sqrt(__x: f64) -> f64;
+    pub fn log2f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn hypot(__x: f64, __y: f64) -> f64;
+    pub fn log2(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __hypot(__x: f64, __y: f64) -> f64;
+    pub fn log2l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cbrt(__x: f64) -> f64;
+    pub fn log1pf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cbrt(__x: f64) -> f64;
+    pub fn log1p(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ceil(__x: f64) -> f64;
+    pub fn log1pl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ceil(__x: f64) -> f64;
+    pub fn logbf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fabs(__x: f64) -> f64;
+    pub fn logb(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fabs(__x: f64) -> f64;
+    pub fn logbl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn floor(__x: f64) -> f64;
+    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __floor(__x: f64) -> f64;
+    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmod(__x: f64, __y: f64) -> f64;
+    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmod(__x: f64, __y: f64) -> f64;
+    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
+    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
+    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn drem(__x: f64, __y: f64) -> f64;
+    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __drem(__x: f64, __y: f64) -> f64;
+    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn significand(__x: f64) -> f64;
+    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __significand(__x: f64) -> f64;
+    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn copysign(__x: f64, __y: f64) -> f64;
+    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __copysign(__x: f64, __y: f64) -> f64;
+    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
+    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
+    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
+    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn j0(arg1: f64) -> f64;
+    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __j0(arg1: f64) -> f64;
+    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn j1(arg1: f64) -> f64;
+    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __j1(arg1: f64) -> f64;
+    pub fn fabsf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn fabs(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn fabsl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn y0(arg1: f64) -> f64;
+    pub fn cbrtf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __y0(arg1: f64) -> f64;
+    pub fn cbrt(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn y1(arg1: f64) -> f64;
+    pub fn cbrtl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __y1(arg1: f64) -> f64;
+    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn hypot(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn erf(arg1: f64) -> f64;
+    pub fn powf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erf(arg1: f64) -> f64;
+    pub fn pow(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
+    pub fn powl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfc(arg1: f64) -> f64;
+    pub fn sqrtf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
+    pub fn sqrt(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __gamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __rint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafter(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nextafter(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttoward(__x: f64, __y: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainder(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remainder(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nearbyint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn round(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __round(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn trunc(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __trunc(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdim(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fdim(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmax(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmax(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmin(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmin(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalb(__x: f64, __n: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalb(__x: f64, __n: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atan2f(__y: f32, __x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atan2f(__y: f32, __x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn coshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __coshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acoshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acoshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log10f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log10f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expm1f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expm1f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log1pf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log1pf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logbf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logbf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn exp2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __powf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sqrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __hypotf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cbrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceilf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ceilf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fabsf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __floorf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmodf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dremf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __dremf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn significandf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __significandf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __copysignf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+    pub fn sqrtl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
@@ -48654,583 +49834,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erff(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __gammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __rintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remainderf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nearbyintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __roundf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __truncf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdimf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fdimf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fminf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbf(__x: f32, __n: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbf(__x: f32, __n: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atan2l(__y: u128, __x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atan2l(__y: u128, __x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn coshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __coshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acoshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acoshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log10l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log10l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expm1l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expm1l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log1pl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log1pl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logbl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logbl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn exp2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __powl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sqrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __hypotl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cbrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceill(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ceill(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fabsl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __floorl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmodl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dreml(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __dreml(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn significandl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __significandl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __copysignl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+    pub fn erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -49238,7 +49842,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfl(arg1: u128) -> u128;
+    pub fn erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -49246,7 +49854,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfcl(arg1: u128) -> u128;
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -49254,7 +49866,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgammal(arg1: u128) -> u128;
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -49262,194 +49878,402 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tgammal(arg1: u128) -> u128;
+    pub fn ceilf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gammal(arg1: u128) -> u128;
+    pub fn ceil(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __gammal(arg1: u128) -> u128;
+    pub fn ceill(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+    pub fn floorf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+    pub fn floor(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rintl(__x: u128) -> u128;
+    pub fn floorl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __rintl(__x: u128) -> u128;
+    pub fn nearbyintf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+    pub fn nearbyint(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+    pub fn nearbyintl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+    pub fn rintf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+    pub fn rint(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remainderl(__x: u128, __y: u128) -> u128;
+    pub fn rintl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+    pub fn roundf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+    pub fn round(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+    pub fn roundl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nearbyintl(__x: u128) -> u128;
+    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nearbyintl(__x: u128) -> u128;
+    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn roundl(__x: u128) -> u128;
+    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __roundl(__x: u128) -> u128;
+    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn truncl(__x: u128) -> u128;
+    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __truncl(__x: u128) -> u128;
+    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn truncf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn trunc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn truncl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn fmod(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn remainder(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fdiml(__x: u128, __y: u128) -> u128;
+    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fminl(__x: u128, __y: u128) -> u128;
+    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fminl(__x: u128, __y: u128) -> u128;
+    pub fn copysign(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbl(__x: u128, __n: u128) -> u128;
+    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdim(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmax(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmin(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __inff() -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __inf() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __infl() -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nan() -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp10f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp10(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cospif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cospi(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinpif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinpi(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanpif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanpi(arg1: f64) -> f64;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __float2 {
+    pub __sinval: f32,
+    pub __cosval: f32,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __double2 {
+    pub __sinval: f64,
+    pub __cosval: f64,
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincosf_stret(arg1: f32) -> __float2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincos_stret(arg1: f64) -> __double2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincospif_stret(arg1: f32) -> __float2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincospi_stret(arg1: f64) -> __double2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalb(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-pub const FP_NAN: ::std::os::raw::c_uint = 0;
-pub const FP_INFINITE: ::std::os::raw::c_uint = 1;
-pub const FP_ZERO: ::std::os::raw::c_uint = 2;
-pub const FP_SUBNORMAL: ::std::os::raw::c_uint = 3;
-pub const FP_NORMAL: ::std::os::raw::c_uint = 4;
-pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
+#[pg_guard]
+extern "C" {
+    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drem(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significand(arg1: f64) -> f64;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct exception {
+    pub type_: ::std::os::raw::c_int,
+    pub name: *mut ::std::os::raw::c_char,
+    pub arg1: f64,
+    pub arg2: f64,
+    pub retval: f64,
+}
+impl Default for exception {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 pub type DateADT = int32;
 pub type TimeADT = int64;
 #[repr(C)]
@@ -49632,7 +50456,6 @@ pub union JsonbValue__bindgen_ty_1 {
     pub array: JsonbValue__bindgen_ty_1__bindgen_ty_2,
     pub object: JsonbValue__bindgen_ty_1__bindgen_ty_3,
     pub binary: JsonbValue__bindgen_ty_1__bindgen_ty_4,
-    _bindgen_union_align: [u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -51130,11 +51953,6 @@ impl Default for __va_list_tag {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __locale_data {
-    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -181,25 +181,24 @@ pub const BLCKSZ: u32 = 8192;
 pub const DEF_PGPORT: u32 = 28811;
 pub const DEF_PGPORT_STR: &'static [u8; 6usize] = b"28811\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
-pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_CBRT: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
 pub const HAVE_CRYPT: u32 = 1;
-pub const HAVE_CRYPT_H: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 1;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 0;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
 pub const HAVE_DECL_SNPRINTF: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 0;
-pub const HAVE_DECL_STRLCPY: u32 = 0;
+pub const HAVE_DECL_STRLCAT: u32 = 1;
+pub const HAVE_DECL_STRLCPY: u32 = 1;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DECL_VSNPRINTF: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
+pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -209,11 +208,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
-pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
+pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -223,6 +222,7 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTPTR_T: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
+pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
 pub const HAVE_ISINF: u32 = 1;
@@ -233,6 +233,7 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
 pub const HAVE_LONG_LONG_INT: u32 = 1;
+pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMMOVE: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
@@ -240,9 +241,8 @@ pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
-pub const HAVE_POSIX_FADVISE: u32 = 1;
-pub const HAVE_POSIX_FALLOCATE: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
+pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
 pub const HAVE_READLINE_HISTORY_H: u32 = 1;
@@ -252,7 +252,6 @@ pub const HAVE_RINT: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
-pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SNPRINTF: u32 = 1;
@@ -265,6 +264,8 @@ pub const HAVE_STRERROR: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
+pub const HAVE_STRLCAT: u32 = 1;
+pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRONG_RANDOM: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
@@ -272,26 +273,29 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
+pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
+pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
-pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
-pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
+pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
+pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TM_ZONE: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
 pub const HAVE_TZNAME: u32 = 1;
 pub const HAVE_UINTPTR_T: u32 = 1;
+pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNIX_SOCKETS: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
@@ -302,6 +306,7 @@ pub const HAVE_UTIMES: u32 = 1;
 pub const HAVE_UTIME_H: u32 = 1;
 pub const HAVE_VSNPRINTF: u32 = 1;
 pub const HAVE_WCHAR_H: u32 = 1;
+pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP16: u32 = 1;
@@ -315,6 +320,7 @@ pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const HAVE__VA_ARGS: u32 = 1;
 pub const INT64_MODIFIER: &'static [u8; 2usize] = b"l\0";
+pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &'static [u8; 26usize] = b"pgsql-bugs@postgresql.org\0";
@@ -327,8 +333,7 @@ pub const PG_KRB_SRVNAM: &'static [u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &'static [u8; 3usize] = b"11\0";
 pub const PG_VERSION: &'static [u8; 6usize] = b"11.11\0";
 pub const PG_VERSION_NUM: u32 = 110011;
-pub const PG_VERSION_STR: &'static [u8; 78usize] =
-    b"PostgreSQL 11.11 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.0, 64-bit\0";
+pub const PG_VERSION_STR : & 'static [u8 ; 114usize] = b"PostgreSQL 11.11 on x86_64-apple-darwin20.3.0, compiled by Apple clang version 12.0.5 (clang-1205.0.22.9), 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -336,13 +341,15 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const STRERROR_R_INT: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
+pub const USE_SYSV_SEMAPHORES: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
+pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -357,211 +364,510 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &'static [u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &'static [u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const _STDIO_H: u32 = 1;
-pub const _FEATURES_H: u32 = 1;
-pub const _DEFAULT_SOURCE: u32 = 1;
-pub const __GLIBC_USE_ISOC2X: u32 = 0;
-pub const __USE_ISOC11: u32 = 1;
-pub const __USE_ISOC99: u32 = 1;
-pub const __USE_ISOC95: u32 = 1;
-pub const __USE_POSIX_IMPLICITLY: u32 = 1;
-pub const _POSIX_SOURCE: u32 = 1;
-pub const _POSIX_C_SOURCE: u32 = 200809;
-pub const __USE_POSIX: u32 = 1;
-pub const __USE_POSIX2: u32 = 1;
-pub const __USE_POSIX199309: u32 = 1;
-pub const __USE_POSIX199506: u32 = 1;
-pub const __USE_XOPEN2K: u32 = 1;
-pub const __USE_XOPEN2K8: u32 = 1;
-pub const _ATFILE_SOURCE: u32 = 1;
-pub const __USE_MISC: u32 = 1;
-pub const __USE_ATFILE: u32 = 1;
-pub const __USE_FORTIFY_LEVEL: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const _STDC_PREDEF_H: u32 = 1;
-pub const __STDC_IEC_559__: u32 = 1;
-pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
-pub const __STDC_ISO_10646__: u32 = 201706;
-pub const __GNU_LIBRARY__: u32 = 6;
-pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 32;
-pub const _SYS_CDEFS_H: u32 = 1;
-pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
-pub const __HAVE_GENERIC_SELECTION: u32 = 1;
-pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const _BITS_TYPES_H: u32 = 1;
-pub const __TIMESIZE: u32 = 64;
-pub const _BITS_TYPESIZES_H: u32 = 1;
-pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
-pub const __INO_T_MATCHES_INO64_T: u32 = 1;
-pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
-pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
-pub const __FD_SETSIZE: u32 = 1024;
-pub const _BITS_TIME64_H: u32 = 1;
-pub const _____fpos_t_defined: u32 = 1;
-pub const ____mbstate_t_defined: u32 = 1;
-pub const _____fpos64_t_defined: u32 = 1;
-pub const ____FILE_defined: u32 = 1;
-pub const __FILE_defined: u32 = 1;
-pub const __struct_FILE_defined: u32 = 1;
-pub const _IO_EOF_SEEN: u32 = 16;
-pub const _IO_ERR_SEEN: u32 = 32;
-pub const _IO_USER_LOCK: u32 = 32768;
+pub const __darwin__: u32 = 1;
+pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
+pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
+pub const __DARWIN_UNIX03: u32 = 1;
+pub const __DARWIN_64_BIT_INO_T: u32 = 1;
+pub const __DARWIN_VERS_1050: u32 = 1;
+pub const __DARWIN_NON_CANCELABLE: u32 = 0;
+pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
+pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
+pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
+pub const __DARWIN_C_ANSI: u32 = 4096;
+pub const __DARWIN_C_FULL: u32 = 900000;
+pub const __DARWIN_C_LEVEL: u32 = 900000;
+pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
+pub const __DARWIN_NO_LONG_LONG: u32 = 0;
+pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
+pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
+pub const __API_TO_BE_DEPRECATED: u32 = 100000;
+pub const __MAC_10_0: u32 = 1000;
+pub const __MAC_10_1: u32 = 1010;
+pub const __MAC_10_2: u32 = 1020;
+pub const __MAC_10_3: u32 = 1030;
+pub const __MAC_10_4: u32 = 1040;
+pub const __MAC_10_5: u32 = 1050;
+pub const __MAC_10_6: u32 = 1060;
+pub const __MAC_10_7: u32 = 1070;
+pub const __MAC_10_8: u32 = 1080;
+pub const __MAC_10_9: u32 = 1090;
+pub const __MAC_10_10: u32 = 101000;
+pub const __MAC_10_10_2: u32 = 101002;
+pub const __MAC_10_10_3: u32 = 101003;
+pub const __MAC_10_11: u32 = 101100;
+pub const __MAC_10_11_2: u32 = 101102;
+pub const __MAC_10_11_3: u32 = 101103;
+pub const __MAC_10_11_4: u32 = 101104;
+pub const __MAC_10_12: u32 = 101200;
+pub const __MAC_10_12_1: u32 = 101201;
+pub const __MAC_10_12_2: u32 = 101202;
+pub const __MAC_10_12_4: u32 = 101204;
+pub const __MAC_10_13: u32 = 101300;
+pub const __MAC_10_13_1: u32 = 101301;
+pub const __MAC_10_13_2: u32 = 101302;
+pub const __MAC_10_13_4: u32 = 101304;
+pub const __MAC_10_14: u32 = 101400;
+pub const __MAC_10_14_1: u32 = 101401;
+pub const __MAC_10_14_4: u32 = 101404;
+pub const __MAC_10_14_6: u32 = 101406;
+pub const __MAC_10_15: u32 = 101500;
+pub const __MAC_10_15_1: u32 = 101501;
+pub const __MAC_10_15_4: u32 = 101504;
+pub const __MAC_10_16: u32 = 101600;
+pub const __MAC_11_0: u32 = 110000;
+pub const __MAC_11_1: u32 = 110100;
+pub const __IPHONE_2_0: u32 = 20000;
+pub const __IPHONE_2_1: u32 = 20100;
+pub const __IPHONE_2_2: u32 = 20200;
+pub const __IPHONE_3_0: u32 = 30000;
+pub const __IPHONE_3_1: u32 = 30100;
+pub const __IPHONE_3_2: u32 = 30200;
+pub const __IPHONE_4_0: u32 = 40000;
+pub const __IPHONE_4_1: u32 = 40100;
+pub const __IPHONE_4_2: u32 = 40200;
+pub const __IPHONE_4_3: u32 = 40300;
+pub const __IPHONE_5_0: u32 = 50000;
+pub const __IPHONE_5_1: u32 = 50100;
+pub const __IPHONE_6_0: u32 = 60000;
+pub const __IPHONE_6_1: u32 = 60100;
+pub const __IPHONE_7_0: u32 = 70000;
+pub const __IPHONE_7_1: u32 = 70100;
+pub const __IPHONE_8_0: u32 = 80000;
+pub const __IPHONE_8_1: u32 = 80100;
+pub const __IPHONE_8_2: u32 = 80200;
+pub const __IPHONE_8_3: u32 = 80300;
+pub const __IPHONE_8_4: u32 = 80400;
+pub const __IPHONE_9_0: u32 = 90000;
+pub const __IPHONE_9_1: u32 = 90100;
+pub const __IPHONE_9_2: u32 = 90200;
+pub const __IPHONE_9_3: u32 = 90300;
+pub const __IPHONE_10_0: u32 = 100000;
+pub const __IPHONE_10_1: u32 = 100100;
+pub const __IPHONE_10_2: u32 = 100200;
+pub const __IPHONE_10_3: u32 = 100300;
+pub const __IPHONE_11_0: u32 = 110000;
+pub const __IPHONE_11_1: u32 = 110100;
+pub const __IPHONE_11_2: u32 = 110200;
+pub const __IPHONE_11_3: u32 = 110300;
+pub const __IPHONE_11_4: u32 = 110400;
+pub const __IPHONE_12_0: u32 = 120000;
+pub const __IPHONE_12_1: u32 = 120100;
+pub const __IPHONE_12_2: u32 = 120200;
+pub const __IPHONE_12_3: u32 = 120300;
+pub const __IPHONE_12_4: u32 = 120400;
+pub const __IPHONE_13_0: u32 = 130000;
+pub const __IPHONE_13_1: u32 = 130100;
+pub const __IPHONE_13_2: u32 = 130200;
+pub const __IPHONE_13_3: u32 = 130300;
+pub const __IPHONE_13_4: u32 = 130400;
+pub const __IPHONE_13_5: u32 = 130500;
+pub const __IPHONE_13_6: u32 = 130600;
+pub const __IPHONE_13_7: u32 = 130700;
+pub const __IPHONE_14_0: u32 = 140000;
+pub const __IPHONE_14_1: u32 = 140100;
+pub const __IPHONE_14_2: u32 = 140200;
+pub const __IPHONE_14_3: u32 = 140300;
+pub const __TVOS_9_0: u32 = 90000;
+pub const __TVOS_9_1: u32 = 90100;
+pub const __TVOS_9_2: u32 = 90200;
+pub const __TVOS_10_0: u32 = 100000;
+pub const __TVOS_10_0_1: u32 = 100001;
+pub const __TVOS_10_1: u32 = 100100;
+pub const __TVOS_10_2: u32 = 100200;
+pub const __TVOS_11_0: u32 = 110000;
+pub const __TVOS_11_1: u32 = 110100;
+pub const __TVOS_11_2: u32 = 110200;
+pub const __TVOS_11_3: u32 = 110300;
+pub const __TVOS_11_4: u32 = 110400;
+pub const __TVOS_12_0: u32 = 120000;
+pub const __TVOS_12_1: u32 = 120100;
+pub const __TVOS_12_2: u32 = 120200;
+pub const __TVOS_12_3: u32 = 120300;
+pub const __TVOS_12_4: u32 = 120400;
+pub const __TVOS_13_0: u32 = 130000;
+pub const __TVOS_13_2: u32 = 130200;
+pub const __TVOS_13_3: u32 = 130300;
+pub const __TVOS_13_4: u32 = 130400;
+pub const __TVOS_14_0: u32 = 140000;
+pub const __TVOS_14_1: u32 = 140100;
+pub const __TVOS_14_2: u32 = 140200;
+pub const __TVOS_14_3: u32 = 140300;
+pub const __WATCHOS_1_0: u32 = 10000;
+pub const __WATCHOS_2_0: u32 = 20000;
+pub const __WATCHOS_2_1: u32 = 20100;
+pub const __WATCHOS_2_2: u32 = 20200;
+pub const __WATCHOS_3_0: u32 = 30000;
+pub const __WATCHOS_3_1: u32 = 30100;
+pub const __WATCHOS_3_1_1: u32 = 30101;
+pub const __WATCHOS_3_2: u32 = 30200;
+pub const __WATCHOS_4_0: u32 = 40000;
+pub const __WATCHOS_4_1: u32 = 40100;
+pub const __WATCHOS_4_2: u32 = 40200;
+pub const __WATCHOS_4_3: u32 = 40300;
+pub const __WATCHOS_5_0: u32 = 50000;
+pub const __WATCHOS_5_1: u32 = 50100;
+pub const __WATCHOS_5_2: u32 = 50200;
+pub const __WATCHOS_5_3: u32 = 50300;
+pub const __WATCHOS_6_0: u32 = 60000;
+pub const __WATCHOS_6_1: u32 = 60100;
+pub const __WATCHOS_6_2: u32 = 60200;
+pub const __WATCHOS_7_0: u32 = 70000;
+pub const __WATCHOS_7_1: u32 = 70100;
+pub const __WATCHOS_7_2: u32 = 70200;
+pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
+pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
+pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
+pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
+pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
+pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
+pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
+pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
+pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
+pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
+pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
+pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
+pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
+pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
+pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
+pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
+pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
+pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
+pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
+pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
+pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
+pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
+pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
+pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
+pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
+pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
+pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
+pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
+pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
+pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
+pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
+pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
+pub const MAC_OS_VERSION_11_0: u32 = 110000;
+pub const __DRIVERKIT_19_0: u32 = 190000;
+pub const __DRIVERKIT_20_0: u32 = 200000;
+pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
+pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
+pub const __PTHREAD_SIZE__: u32 = 8176;
+pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
+pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
+pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_COND_SIZE__: u32 = 40;
+pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
+pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
+pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
+pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
+pub const _FORTIFY_SOURCE: u32 = 2;
+pub const RENAME_SECLUDE: u32 = 1;
+pub const RENAME_SWAP: u32 = 2;
+pub const RENAME_EXCL: u32 = 4;
+pub const __SLBF: u32 = 1;
+pub const __SNBF: u32 = 2;
+pub const __SRD: u32 = 4;
+pub const __SWR: u32 = 8;
+pub const __SRW: u32 = 16;
+pub const __SEOF: u32 = 32;
+pub const __SERR: u32 = 64;
+pub const __SMBF: u32 = 128;
+pub const __SAPP: u32 = 256;
+pub const __SSTR: u32 = 512;
+pub const __SOPT: u32 = 1024;
+pub const __SNPT: u32 = 2048;
+pub const __SOFF: u32 = 4096;
+pub const __SMOD: u32 = 8192;
+pub const __SALC: u32 = 16384;
+pub const __SIGN: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 8192;
+pub const BUFSIZ: u32 = 1024;
 pub const EOF: i32 = -1;
+pub const FOPEN_MAX: u32 = 20;
+pub const FILENAME_MAX: u32 = 1024;
+pub const P_tmpdir: &'static [u8; 10usize] = b"/var/tmp/\0";
+pub const L_tmpnam: u32 = 1024;
+pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const P_tmpdir: &'static [u8; 5usize] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
-pub const L_tmpnam: u32 = 20;
-pub const TMP_MAX: u32 = 238328;
-pub const FILENAME_MAX: u32 = 4096;
-pub const L_ctermid: u32 = 9;
-pub const FOPEN_MAX: u32 = 16;
-pub const __HAVE_FLOAT128: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
-pub const __HAVE_FLOAT64X: u32 = 1;
-pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
-pub const __HAVE_FLOAT16: u32 = 0;
-pub const __HAVE_FLOAT32: u32 = 1;
-pub const __HAVE_FLOAT64: u32 = 1;
-pub const __HAVE_FLOAT32X: u32 = 1;
-pub const __HAVE_FLOAT128X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
-pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
+pub const L_ctermid: u32 = 1024;
+pub const _USE_FORTIFY_LEVEL: u32 = 2;
+pub const __DARWIN_NSIG: u32 = 32;
+pub const NSIG: u32 = 32;
+pub const _I386_SIGNAL_H_: u32 = 1;
+pub const SIGHUP: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGQUIT: u32 = 3;
+pub const SIGILL: u32 = 4;
+pub const SIGTRAP: u32 = 5;
+pub const SIGABRT: u32 = 6;
+pub const SIGIOT: u32 = 6;
+pub const SIGEMT: u32 = 7;
+pub const SIGFPE: u32 = 8;
+pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSEGV: u32 = 11;
+pub const SIGSYS: u32 = 12;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGTERM: u32 = 15;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGIO: u32 = 23;
+pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGWINCH: u32 = 28;
+pub const SIGINFO: u32 = 29;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
+pub const FP_PREC_24B: u32 = 0;
+pub const FP_PREC_53B: u32 = 2;
+pub const FP_PREC_64B: u32 = 3;
+pub const FP_RND_NEAR: u32 = 0;
+pub const FP_RND_DOWN: u32 = 1;
+pub const FP_RND_UP: u32 = 2;
+pub const FP_CHOP: u32 = 3;
+pub const FP_STATE_BYTES: u32 = 512;
+pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
+pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
+pub const __LASTBRANCH_MAX: u32 = 32;
+pub const SIGEV_NONE: u32 = 0;
+pub const SIGEV_SIGNAL: u32 = 1;
+pub const SIGEV_THREAD: u32 = 3;
+pub const ILL_NOOP: u32 = 0;
+pub const ILL_ILLOPC: u32 = 1;
+pub const ILL_ILLTRP: u32 = 2;
+pub const ILL_PRVOPC: u32 = 3;
+pub const ILL_ILLOPN: u32 = 4;
+pub const ILL_ILLADR: u32 = 5;
+pub const ILL_PRVREG: u32 = 6;
+pub const ILL_COPROC: u32 = 7;
+pub const ILL_BADSTK: u32 = 8;
+pub const FPE_NOOP: u32 = 0;
+pub const FPE_FLTDIV: u32 = 1;
+pub const FPE_FLTOVF: u32 = 2;
+pub const FPE_FLTUND: u32 = 3;
+pub const FPE_FLTRES: u32 = 4;
+pub const FPE_FLTINV: u32 = 5;
+pub const FPE_FLTSUB: u32 = 6;
+pub const FPE_INTDIV: u32 = 7;
+pub const FPE_INTOVF: u32 = 8;
+pub const SEGV_NOOP: u32 = 0;
+pub const SEGV_MAPERR: u32 = 1;
+pub const SEGV_ACCERR: u32 = 2;
+pub const BUS_NOOP: u32 = 0;
+pub const BUS_ADRALN: u32 = 1;
+pub const BUS_ADRERR: u32 = 2;
+pub const BUS_OBJERR: u32 = 3;
+pub const TRAP_BRKPT: u32 = 1;
+pub const TRAP_TRACE: u32 = 2;
+pub const CLD_NOOP: u32 = 0;
+pub const CLD_EXITED: u32 = 1;
+pub const CLD_KILLED: u32 = 2;
+pub const CLD_DUMPED: u32 = 3;
+pub const CLD_TRAPPED: u32 = 4;
+pub const CLD_STOPPED: u32 = 5;
+pub const CLD_CONTINUED: u32 = 6;
+pub const POLL_IN: u32 = 1;
+pub const POLL_OUT: u32 = 2;
+pub const POLL_MSG: u32 = 3;
+pub const POLL_ERR: u32 = 4;
+pub const POLL_PRI: u32 = 5;
+pub const POLL_HUP: u32 = 6;
+pub const SA_ONSTACK: u32 = 1;
+pub const SA_RESTART: u32 = 2;
+pub const SA_RESETHAND: u32 = 4;
+pub const SA_NOCLDSTOP: u32 = 8;
+pub const SA_NODEFER: u32 = 16;
+pub const SA_NOCLDWAIT: u32 = 32;
+pub const SA_SIGINFO: u32 = 64;
+pub const SA_USERTRAMP: u32 = 256;
+pub const SA_64REGSET: u32 = 512;
+pub const SA_USERSPACE_MASK: u32 = 127;
+pub const SIG_BLOCK: u32 = 1;
+pub const SIG_UNBLOCK: u32 = 2;
+pub const SIG_SETMASK: u32 = 3;
+pub const SI_USER: u32 = 65537;
+pub const SI_QUEUE: u32 = 65538;
+pub const SI_TIMER: u32 = 65539;
+pub const SI_ASYNCIO: u32 = 65540;
+pub const SI_MESGQ: u32 = 65541;
+pub const SS_ONSTACK: u32 = 1;
+pub const SS_DISABLE: u32 = 4;
+pub const MINSIGSTKSZ: u32 = 32768;
+pub const SIGSTKSZ: u32 = 131072;
+pub const SV_ONSTACK: u32 = 1;
+pub const SV_INTERRUPT: u32 = 2;
+pub const SV_RESETHAND: u32 = 4;
+pub const SV_NODEFER: u32 = 16;
+pub const SV_NOCLDSTOP: u32 = 8;
+pub const SV_SIGINFO: u32 = 64;
+pub const __WORDSIZE: u32 = 64;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const INT64_MAX: u64 = 9223372036854775807;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT64_MIN: i64 = -9223372036854775808;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const UINT64_MAX: i32 = -1;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const UINT_LEAST64_MAX: i32 = -1;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i32 = -32768;
+pub const INT_FAST32_MIN: i32 = -2147483648;
+pub const INT_FAST64_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u32 = 32767;
+pub const INT_FAST32_MAX: u32 = 2147483647;
+pub const INT_FAST64_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: u32 = 65535;
+pub const UINT_FAST32_MAX: u32 = 4294967295;
+pub const UINT_FAST64_MAX: i32 = -1;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const UINTPTR_MAX: i32 = -1;
+pub const SIZE_MAX: i32 = -1;
+pub const RSIZE_MAX: i32 = -1;
+pub const WINT_MIN: i32 = -2147483648;
+pub const WINT_MAX: u32 = 2147483647;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const PRIO_PROCESS: u32 = 0;
+pub const PRIO_PGRP: u32 = 1;
+pub const PRIO_USER: u32 = 2;
+pub const PRIO_DARWIN_THREAD: u32 = 3;
+pub const PRIO_DARWIN_PROCESS: u32 = 4;
+pub const PRIO_MIN: i32 = -20;
+pub const PRIO_MAX: u32 = 20;
+pub const PRIO_DARWIN_BG: u32 = 4096;
+pub const PRIO_DARWIN_NONUI: u32 = 4097;
+pub const RUSAGE_SELF: u32 = 0;
+pub const RUSAGE_CHILDREN: i32 = -1;
+pub const RUSAGE_INFO_V0: u32 = 0;
+pub const RUSAGE_INFO_V1: u32 = 1;
+pub const RUSAGE_INFO_V2: u32 = 2;
+pub const RUSAGE_INFO_V3: u32 = 3;
+pub const RUSAGE_INFO_V4: u32 = 4;
+pub const RUSAGE_INFO_V5: u32 = 5;
+pub const RUSAGE_INFO_CURRENT: u32 = 5;
+pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
+pub const RLIMIT_CPU: u32 = 0;
+pub const RLIMIT_FSIZE: u32 = 1;
+pub const RLIMIT_DATA: u32 = 2;
+pub const RLIMIT_STACK: u32 = 3;
+pub const RLIMIT_CORE: u32 = 4;
+pub const RLIMIT_AS: u32 = 5;
+pub const RLIMIT_RSS: u32 = 5;
+pub const RLIMIT_MEMLOCK: u32 = 6;
+pub const RLIMIT_NPROC: u32 = 7;
+pub const RLIMIT_NOFILE: u32 = 8;
+pub const RLIM_NLIMITS: u32 = 9;
+pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
+pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
+pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
+pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
+pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
+pub const WAKEMON_ENABLE: u32 = 1;
+pub const WAKEMON_DISABLE: u32 = 2;
+pub const WAKEMON_GET_PARAMS: u32 = 4;
+pub const WAKEMON_SET_DEFAULTS: u32 = 8;
+pub const WAKEMON_MAKE_FATAL: u32 = 16;
+pub const CPUMON_MAKE_FATAL: u32 = 4096;
+pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
+pub const IOPOL_TYPE_DISK: u32 = 0;
+pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
+pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
+pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
+pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
+pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
+pub const IOPOL_SCOPE_PROCESS: u32 = 0;
+pub const IOPOL_SCOPE_THREAD: u32 = 1;
+pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
+pub const IOPOL_DEFAULT: u32 = 0;
+pub const IOPOL_IMPORTANT: u32 = 1;
+pub const IOPOL_PASSIVE: u32 = 2;
+pub const IOPOL_THROTTLE: u32 = 3;
+pub const IOPOL_UTILITY: u32 = 4;
+pub const IOPOL_STANDARD: u32 = 5;
+pub const IOPOL_APPLICATION: u32 = 5;
+pub const IOPOL_NORMAL: u32 = 1;
+pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
+pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
+pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
+pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
+pub const WCOREFLAG: u32 = 128;
+pub const _WSTOPPED: u32 = 127;
 pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
-pub const __ldiv_t_defined: u32 = 1;
-pub const __lldiv_t_defined: u32 = 1;
-pub const RAND_MAX: u32 = 2147483647;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const _SYS_TYPES_H: u32 = 1;
-pub const __clock_t_defined: u32 = 1;
-pub const __clockid_t_defined: u32 = 1;
-pub const __time_t_defined: u32 = 1;
-pub const __timer_t_defined: u32 = 1;
-pub const _BITS_STDINT_INTN_H: u32 = 1;
-pub const __BIT_TYPES_DEFINED__: u32 = 1;
-pub const _ENDIAN_H: u32 = 1;
-pub const _BITS_ENDIAN_H: u32 = 1;
-pub const __LITTLE_ENDIAN: u32 = 1234;
-pub const __BIG_ENDIAN: u32 = 4321;
-pub const __PDP_ENDIAN: u32 = 3412;
-pub const _BITS_ENDIANNESS_H: u32 = 1;
-pub const __BYTE_ORDER: u32 = 1234;
-pub const __FLOAT_WORD_ORDER: u32 = 1234;
+pub const WSTOPPED: u32 = 8;
+pub const WCONTINUED: u32 = 16;
+pub const WNOWAIT: u32 = 32;
+pub const WAIT_ANY: i32 = -1;
+pub const WAIT_MYPGRP: u32 = 0;
+pub const _QUAD_HIGHWORD: u32 = 1;
+pub const _QUAD_LOWWORD: u32 = 0;
+pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
+pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
+pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
+pub const __DARWIN_BYTE_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const _BITS_BYTESWAP_H: u32 = 1;
-pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
-pub const _SYS_SELECT_H: u32 = 1;
-pub const __sigset_t_defined: u32 = 1;
-pub const __timeval_defined: u32 = 1;
-pub const _STRUCT_TIMESPEC: u32 = 1;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const RAND_MAX: u32 = 2147483647;
+pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const __DARWIN_FD_SETSIZE: u32 = 1024;
+pub const __DARWIN_NBBY: u32 = 8;
+pub const NBBY: u32 = 8;
 pub const FD_SETSIZE: u32 = 1024;
-pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
-pub const _THREAD_SHARED_TYPES_H: u32 = 1;
-pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
-pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
-pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
-pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
-pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
-pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
-pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
-pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
-pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
-pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
-pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
-pub const __have_pthread_attr_t: u32 = 1;
-pub const _ALLOCA_H: u32 = 1;
-pub const _STRING_H: u32 = 1;
-pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
-pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
-pub const _STRINGS_H: u32 = 1;
-pub const _STDINT_H: u32 = 1;
-pub const _BITS_WCHAR_H: u32 = 1;
-pub const _BITS_STDINT_UINTN_H: u32 = 1;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i64 = -9223372036854775808;
-pub const INT_FAST32_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u64 = 9223372036854775807;
-pub const INT_FAST32_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: i32 = -1;
-pub const UINT_FAST32_MAX: i32 = -1;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const UINTPTR_MAX: i32 = -1;
-pub const PTRDIFF_MIN: i64 = -9223372036854775808;
-pub const PTRDIFF_MAX: u64 = 9223372036854775807;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const SIZE_MAX: i32 = -1;
-pub const WINT_MIN: u32 = 0;
-pub const WINT_MAX: u32 = 4294967295;
-pub const _ERRNO_H: u32 = 1;
-pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -572,7 +878,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EAGAIN: u32 = 11;
+pub const EDEADLK: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -596,147 +902,88 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EDEADLK: u32 = 35;
-pub const ENAMETOOLONG: u32 = 36;
-pub const ENOLCK: u32 = 37;
-pub const ENOSYS: u32 = 38;
-pub const ENOTEMPTY: u32 = 39;
-pub const ELOOP: u32 = 40;
-pub const EWOULDBLOCK: u32 = 11;
-pub const ENOMSG: u32 = 42;
-pub const EIDRM: u32 = 43;
-pub const ECHRNG: u32 = 44;
-pub const EL2NSYNC: u32 = 45;
-pub const EL3HLT: u32 = 46;
-pub const EL3RST: u32 = 47;
-pub const ELNRNG: u32 = 48;
-pub const EUNATCH: u32 = 49;
-pub const ENOCSI: u32 = 50;
-pub const EL2HLT: u32 = 51;
-pub const EBADE: u32 = 52;
-pub const EBADR: u32 = 53;
-pub const EXFULL: u32 = 54;
-pub const ENOANO: u32 = 55;
-pub const EBADRQC: u32 = 56;
-pub const EBADSLT: u32 = 57;
-pub const EDEADLOCK: u32 = 35;
-pub const EBFONT: u32 = 59;
-pub const ENOSTR: u32 = 60;
-pub const ENODATA: u32 = 61;
-pub const ETIME: u32 = 62;
-pub const ENOSR: u32 = 63;
-pub const ENONET: u32 = 64;
-pub const ENOPKG: u32 = 65;
-pub const EREMOTE: u32 = 66;
-pub const ENOLINK: u32 = 67;
-pub const EADV: u32 = 68;
-pub const ESRMNT: u32 = 69;
-pub const ECOMM: u32 = 70;
-pub const EPROTO: u32 = 71;
-pub const EMULTIHOP: u32 = 72;
-pub const EDOTDOT: u32 = 73;
-pub const EBADMSG: u32 = 74;
-pub const EOVERFLOW: u32 = 75;
-pub const ENOTUNIQ: u32 = 76;
-pub const EBADFD: u32 = 77;
-pub const EREMCHG: u32 = 78;
-pub const ELIBACC: u32 = 79;
-pub const ELIBBAD: u32 = 80;
-pub const ELIBSCN: u32 = 81;
-pub const ELIBMAX: u32 = 82;
-pub const ELIBEXEC: u32 = 83;
-pub const EILSEQ: u32 = 84;
-pub const ERESTART: u32 = 85;
-pub const ESTRPIPE: u32 = 86;
-pub const EUSERS: u32 = 87;
-pub const ENOTSOCK: u32 = 88;
-pub const EDESTADDRREQ: u32 = 89;
-pub const EMSGSIZE: u32 = 90;
-pub const EPROTOTYPE: u32 = 91;
-pub const ENOPROTOOPT: u32 = 92;
-pub const EPROTONOSUPPORT: u32 = 93;
-pub const ESOCKTNOSUPPORT: u32 = 94;
-pub const EOPNOTSUPP: u32 = 95;
-pub const EPFNOSUPPORT: u32 = 96;
-pub const EAFNOSUPPORT: u32 = 97;
-pub const EADDRINUSE: u32 = 98;
-pub const EADDRNOTAVAIL: u32 = 99;
-pub const ENETDOWN: u32 = 100;
-pub const ENETUNREACH: u32 = 101;
-pub const ENETRESET: u32 = 102;
-pub const ECONNABORTED: u32 = 103;
-pub const ECONNRESET: u32 = 104;
-pub const ENOBUFS: u32 = 105;
-pub const EISCONN: u32 = 106;
-pub const ENOTCONN: u32 = 107;
-pub const ESHUTDOWN: u32 = 108;
-pub const ETOOMANYREFS: u32 = 109;
-pub const ETIMEDOUT: u32 = 110;
-pub const ECONNREFUSED: u32 = 111;
-pub const EHOSTDOWN: u32 = 112;
-pub const EHOSTUNREACH: u32 = 113;
-pub const EALREADY: u32 = 114;
-pub const EINPROGRESS: u32 = 115;
-pub const ESTALE: u32 = 116;
-pub const EUCLEAN: u32 = 117;
-pub const ENOTNAM: u32 = 118;
-pub const ENAVAIL: u32 = 119;
-pub const EISNAM: u32 = 120;
-pub const EREMOTEIO: u32 = 121;
-pub const EDQUOT: u32 = 122;
-pub const ENOMEDIUM: u32 = 123;
-pub const EMEDIUMTYPE: u32 = 124;
-pub const ECANCELED: u32 = 125;
-pub const ENOKEY: u32 = 126;
-pub const EKEYEXPIRED: u32 = 127;
-pub const EKEYREVOKED: u32 = 128;
-pub const EKEYREJECTED: u32 = 129;
-pub const EOWNERDEAD: u32 = 130;
-pub const ENOTRECOVERABLE: u32 = 131;
-pub const ERFKILL: u32 = 132;
-pub const EHWPOISON: u32 = 133;
-pub const ENOTSUP: u32 = 95;
-pub const _LOCALE_H: u32 = 1;
-pub const _BITS_LOCALE_H: u32 = 1;
-pub const __LC_CTYPE: u32 = 0;
-pub const __LC_NUMERIC: u32 = 1;
-pub const __LC_TIME: u32 = 2;
-pub const __LC_COLLATE: u32 = 3;
-pub const __LC_MONETARY: u32 = 4;
-pub const __LC_MESSAGES: u32 = 5;
-pub const __LC_ALL: u32 = 6;
-pub const __LC_PAPER: u32 = 7;
-pub const __LC_NAME: u32 = 8;
-pub const __LC_ADDRESS: u32 = 9;
-pub const __LC_TELEPHONE: u32 = 10;
-pub const __LC_MEASUREMENT: u32 = 11;
-pub const __LC_IDENTIFICATION: u32 = 12;
-pub const LC_CTYPE: u32 = 0;
-pub const LC_NUMERIC: u32 = 1;
-pub const LC_TIME: u32 = 2;
-pub const LC_COLLATE: u32 = 3;
-pub const LC_MONETARY: u32 = 4;
-pub const LC_MESSAGES: u32 = 5;
-pub const LC_ALL: u32 = 6;
-pub const LC_PAPER: u32 = 7;
-pub const LC_NAME: u32 = 8;
-pub const LC_ADDRESS: u32 = 9;
-pub const LC_TELEPHONE: u32 = 10;
-pub const LC_MEASUREMENT: u32 = 11;
-pub const LC_IDENTIFICATION: u32 = 12;
-pub const LC_CTYPE_MASK: u32 = 1;
-pub const LC_NUMERIC_MASK: u32 = 2;
-pub const LC_TIME_MASK: u32 = 4;
-pub const LC_COLLATE_MASK: u32 = 8;
-pub const LC_MONETARY_MASK: u32 = 16;
-pub const LC_MESSAGES_MASK: u32 = 32;
-pub const LC_PAPER_MASK: u32 = 128;
-pub const LC_NAME_MASK: u32 = 256;
-pub const LC_ADDRESS_MASK: u32 = 512;
-pub const LC_TELEPHONE_MASK: u32 = 1024;
-pub const LC_MEASUREMENT_MASK: u32 = 2048;
-pub const LC_IDENTIFICATION_MASK: u32 = 4096;
-pub const LC_ALL_MASK: u32 = 8127;
+pub const EAGAIN: u32 = 35;
+pub const EWOULDBLOCK: u32 = 35;
+pub const EINPROGRESS: u32 = 36;
+pub const EALREADY: u32 = 37;
+pub const ENOTSOCK: u32 = 38;
+pub const EDESTADDRREQ: u32 = 39;
+pub const EMSGSIZE: u32 = 40;
+pub const EPROTOTYPE: u32 = 41;
+pub const ENOPROTOOPT: u32 = 42;
+pub const EPROTONOSUPPORT: u32 = 43;
+pub const ESOCKTNOSUPPORT: u32 = 44;
+pub const ENOTSUP: u32 = 45;
+pub const EPFNOSUPPORT: u32 = 46;
+pub const EAFNOSUPPORT: u32 = 47;
+pub const EADDRINUSE: u32 = 48;
+pub const EADDRNOTAVAIL: u32 = 49;
+pub const ENETDOWN: u32 = 50;
+pub const ENETUNREACH: u32 = 51;
+pub const ENETRESET: u32 = 52;
+pub const ECONNABORTED: u32 = 53;
+pub const ECONNRESET: u32 = 54;
+pub const ENOBUFS: u32 = 55;
+pub const EISCONN: u32 = 56;
+pub const ENOTCONN: u32 = 57;
+pub const ESHUTDOWN: u32 = 58;
+pub const ETOOMANYREFS: u32 = 59;
+pub const ETIMEDOUT: u32 = 60;
+pub const ECONNREFUSED: u32 = 61;
+pub const ELOOP: u32 = 62;
+pub const ENAMETOOLONG: u32 = 63;
+pub const EHOSTDOWN: u32 = 64;
+pub const EHOSTUNREACH: u32 = 65;
+pub const ENOTEMPTY: u32 = 66;
+pub const EPROCLIM: u32 = 67;
+pub const EUSERS: u32 = 68;
+pub const EDQUOT: u32 = 69;
+pub const ESTALE: u32 = 70;
+pub const EREMOTE: u32 = 71;
+pub const EBADRPC: u32 = 72;
+pub const ERPCMISMATCH: u32 = 73;
+pub const EPROGUNAVAIL: u32 = 74;
+pub const EPROGMISMATCH: u32 = 75;
+pub const EPROCUNAVAIL: u32 = 76;
+pub const ENOLCK: u32 = 77;
+pub const ENOSYS: u32 = 78;
+pub const EFTYPE: u32 = 79;
+pub const EAUTH: u32 = 80;
+pub const ENEEDAUTH: u32 = 81;
+pub const EPWROFF: u32 = 82;
+pub const EDEVERR: u32 = 83;
+pub const EOVERFLOW: u32 = 84;
+pub const EBADEXEC: u32 = 85;
+pub const EBADARCH: u32 = 86;
+pub const ESHLIBVERS: u32 = 87;
+pub const EBADMACHO: u32 = 88;
+pub const ECANCELED: u32 = 89;
+pub const EIDRM: u32 = 90;
+pub const ENOMSG: u32 = 91;
+pub const EILSEQ: u32 = 92;
+pub const ENOATTR: u32 = 93;
+pub const EBADMSG: u32 = 94;
+pub const EMULTIHOP: u32 = 95;
+pub const ENODATA: u32 = 96;
+pub const ENOLINK: u32 = 97;
+pub const ENOSR: u32 = 98;
+pub const ENOSTR: u32 = 99;
+pub const EPROTO: u32 = 100;
+pub const ETIME: u32 = 101;
+pub const EOPNOTSUPP: u32 = 102;
+pub const ENOPOLICY: u32 = 103;
+pub const ENOTRECOVERABLE: u32 = 104;
+pub const EOWNERDEAD: u32 = 105;
+pub const EQFULL: u32 = 106;
+pub const ELAST: u32 = 106;
+pub const LC_ALL: u32 = 0;
+pub const LC_COLLATE: u32 = 1;
+pub const LC_CTYPE: u32 = 2;
+pub const LC_MONETARY: u32 = 3;
+pub const LC_NUMERIC: u32 = 4;
+pub const LC_TIME: u32 = 5;
+pub const LC_MESSAGES: u32 = 6;
+pub const _LC_LAST: u32 = 7;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
@@ -766,355 +1013,375 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &'static [u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &'static [u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &'static [u8; 2usize] = b"w\0";
-pub const _CTYPE_H: u32 = 1;
-pub const _NETDB_H: u32 = 1;
-pub const _NETINET_IN_H: u32 = 1;
-pub const _SYS_SOCKET_H: u32 = 1;
-pub const __iovec_defined: u32 = 1;
+pub const _CACHED_RUNES: u32 = 256;
+pub const _CRMASK: i32 = -256;
+pub const _RUNE_MAGIC_A: &'static [u8; 9usize] = b"RuneMagA\0";
+pub const _CTYPE_A: u32 = 256;
+pub const _CTYPE_C: u32 = 512;
+pub const _CTYPE_D: u32 = 1024;
+pub const _CTYPE_G: u32 = 2048;
+pub const _CTYPE_L: u32 = 4096;
+pub const _CTYPE_P: u32 = 8192;
+pub const _CTYPE_S: u32 = 16384;
+pub const _CTYPE_U: u32 = 32768;
+pub const _CTYPE_X: u32 = 65536;
+pub const _CTYPE_B: u32 = 131072;
+pub const _CTYPE_R: u32 = 262144;
+pub const _CTYPE_I: u32 = 524288;
+pub const _CTYPE_T: u32 = 1048576;
+pub const _CTYPE_Q: u32 = 2097152;
+pub const _CTYPE_SW0: u32 = 536870912;
+pub const _CTYPE_SW1: u32 = 1073741824;
+pub const _CTYPE_SW2: u32 = 2147483648;
+pub const _CTYPE_SW3: u32 = 3221225472;
+pub const _CTYPE_SWM: u32 = 3758096384;
+pub const _CTYPE_SWS: u32 = 30;
+pub const KEV_INET_SUBCLASS: u32 = 1;
+pub const KEV_INET_NEW_ADDR: u32 = 1;
+pub const KEV_INET_CHANGED_ADDR: u32 = 2;
+pub const KEV_INET_ADDR_DELETED: u32 = 3;
+pub const KEV_INET_SIFDSTADDR: u32 = 4;
+pub const KEV_INET_SIFBRDADDR: u32 = 5;
+pub const KEV_INET_SIFNETMASK: u32 = 6;
+pub const KEV_INET_ARPCOLLISION: u32 = 7;
+pub const KEV_INET_PORTINUSE: u32 = 8;
+pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
+pub const KEV_INET_ARPRTRALIVE: u32 = 10;
+pub const KEV_DL_SUBCLASS: u32 = 2;
+pub const KEV_DL_SIFFLAGS: u32 = 1;
+pub const KEV_DL_SIFMETRICS: u32 = 2;
+pub const KEV_DL_SIFMTU: u32 = 3;
+pub const KEV_DL_SIFPHYS: u32 = 4;
+pub const KEV_DL_SIFMEDIA: u32 = 5;
+pub const KEV_DL_SIFGENERIC: u32 = 6;
+pub const KEV_DL_ADDMULTI: u32 = 7;
+pub const KEV_DL_DELMULTI: u32 = 8;
+pub const KEV_DL_IF_ATTACHED: u32 = 9;
+pub const KEV_DL_IF_DETACHING: u32 = 10;
+pub const KEV_DL_IF_DETACHED: u32 = 11;
+pub const KEV_DL_LINK_OFF: u32 = 12;
+pub const KEV_DL_LINK_ON: u32 = 13;
+pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
+pub const KEV_DL_PROTO_DETACHED: u32 = 15;
+pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
+pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
+pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
+pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
+pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
+pub const KEV_DL_NODE_PRESENCE: u32 = 21;
+pub const KEV_DL_NODE_ABSENCE: u32 = 22;
+pub const KEV_DL_MASTER_ELECTED: u32 = 23;
+pub const KEV_DL_ISSUES: u32 = 24;
+pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
+pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
+pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
+pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
+pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
+pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
+pub const KEV_INET6_SUBCLASS: u32 = 6;
+pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
+pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
+pub const KEV_INET6_ADDR_DELETED: u32 = 3;
+pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
+pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
+pub const KEV_INET6_DEFROUTER: u32 = 6;
+pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
+pub const SOCK_STREAM: u32 = 1;
+pub const SOCK_DGRAM: u32 = 2;
+pub const SOCK_RAW: u32 = 3;
+pub const SOCK_RDM: u32 = 4;
+pub const SOCK_SEQPACKET: u32 = 5;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_ACCEPTCONN: u32 = 2;
+pub const SO_REUSEADDR: u32 = 4;
+pub const SO_KEEPALIVE: u32 = 8;
+pub const SO_DONTROUTE: u32 = 16;
+pub const SO_BROADCAST: u32 = 32;
+pub const SO_USELOOPBACK: u32 = 64;
+pub const SO_LINGER: u32 = 128;
+pub const SO_OOBINLINE: u32 = 256;
+pub const SO_REUSEPORT: u32 = 512;
+pub const SO_TIMESTAMP: u32 = 1024;
+pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
+pub const SO_DONTTRUNC: u32 = 8192;
+pub const SO_WANTMORE: u32 = 16384;
+pub const SO_WANTOOBFLAG: u32 = 32768;
+pub const SO_SNDBUF: u32 = 4097;
+pub const SO_RCVBUF: u32 = 4098;
+pub const SO_SNDLOWAT: u32 = 4099;
+pub const SO_RCVLOWAT: u32 = 4100;
+pub const SO_SNDTIMEO: u32 = 4101;
+pub const SO_RCVTIMEO: u32 = 4102;
+pub const SO_ERROR: u32 = 4103;
+pub const SO_TYPE: u32 = 4104;
+pub const SO_LABEL: u32 = 4112;
+pub const SO_PEERLABEL: u32 = 4113;
+pub const SO_NREAD: u32 = 4128;
+pub const SO_NKE: u32 = 4129;
+pub const SO_NOSIGPIPE: u32 = 4130;
+pub const SO_NOADDRERR: u32 = 4131;
+pub const SO_NWRITE: u32 = 4132;
+pub const SO_REUSESHAREUID: u32 = 4133;
+pub const SO_NOTIFYCONFLICT: u32 = 4134;
+pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
+pub const SO_LINGER_SEC: u32 = 4224;
+pub const SO_RANDOMPORT: u32 = 4226;
+pub const SO_NP_EXTENSIONS: u32 = 4227;
+pub const SO_NUMRCVPKT: u32 = 4370;
+pub const SO_NET_SERVICE_TYPE: u32 = 4374;
+pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
+pub const NET_SERVICE_TYPE_BE: u32 = 0;
+pub const NET_SERVICE_TYPE_BK: u32 = 1;
+pub const NET_SERVICE_TYPE_SIG: u32 = 2;
+pub const NET_SERVICE_TYPE_VI: u32 = 3;
+pub const NET_SERVICE_TYPE_VO: u32 = 4;
+pub const NET_SERVICE_TYPE_RV: u32 = 5;
+pub const NET_SERVICE_TYPE_AV: u32 = 6;
+pub const NET_SERVICE_TYPE_OAM: u32 = 7;
+pub const NET_SERVICE_TYPE_RD: u32 = 8;
+pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
+pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
+pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
+pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
+pub const SAE_ASSOCID_ANY: u32 = 0;
+pub const SAE_CONNID_ANY: u32 = 0;
+pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
+pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
+pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
+pub const SONPX_SETOPTSHUT: u32 = 1;
+pub const SOL_SOCKET: u32 = 65535;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_UNIX: u32 = 1;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_IMPLINK: u32 = 3;
+pub const AF_PUP: u32 = 4;
+pub const AF_CHAOS: u32 = 5;
+pub const AF_NS: u32 = 6;
+pub const AF_ISO: u32 = 7;
+pub const AF_OSI: u32 = 7;
+pub const AF_ECMA: u32 = 8;
+pub const AF_DATAKIT: u32 = 9;
+pub const AF_CCITT: u32 = 10;
+pub const AF_SNA: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_DLI: u32 = 13;
+pub const AF_LAT: u32 = 14;
+pub const AF_HYLINK: u32 = 15;
+pub const AF_APPLETALK: u32 = 16;
+pub const AF_ROUTE: u32 = 17;
+pub const AF_LINK: u32 = 18;
+pub const pseudo_AF_XTP: u32 = 19;
+pub const AF_COIP: u32 = 20;
+pub const AF_CNT: u32 = 21;
+pub const pseudo_AF_RTIP: u32 = 22;
+pub const AF_IPX: u32 = 23;
+pub const AF_SIP: u32 = 24;
+pub const pseudo_AF_PIP: u32 = 25;
+pub const AF_NDRV: u32 = 27;
+pub const AF_ISDN: u32 = 28;
+pub const AF_E164: u32 = 28;
+pub const pseudo_AF_KEY: u32 = 29;
+pub const AF_INET6: u32 = 30;
+pub const AF_NATM: u32 = 31;
+pub const AF_SYSTEM: u32 = 32;
+pub const AF_NETBIOS: u32 = 33;
+pub const AF_PPP: u32 = 34;
+pub const pseudo_AF_HDRCMPLT: u32 = 35;
+pub const AF_RESERVED_36: u32 = 36;
+pub const AF_IEEE80211: u32 = 37;
+pub const AF_UTUN: u32 = 38;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_MAX: u32 = 41;
+pub const SOCK_MAXADDRLEN: u32 = 255;
+pub const _SS_MAXSIZE: u32 = 128;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
-pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_AX25: u32 = 3;
-pub const PF_IPX: u32 = 4;
-pub const PF_APPLETALK: u32 = 5;
-pub const PF_NETROM: u32 = 6;
-pub const PF_BRIDGE: u32 = 7;
-pub const PF_ATMPVC: u32 = 8;
-pub const PF_X25: u32 = 9;
-pub const PF_INET6: u32 = 10;
-pub const PF_ROSE: u32 = 11;
+pub const PF_IMPLINK: u32 = 3;
+pub const PF_PUP: u32 = 4;
+pub const PF_CHAOS: u32 = 5;
+pub const PF_NS: u32 = 6;
+pub const PF_ISO: u32 = 7;
+pub const PF_OSI: u32 = 7;
+pub const PF_ECMA: u32 = 8;
+pub const PF_DATAKIT: u32 = 9;
+pub const PF_CCITT: u32 = 10;
+pub const PF_SNA: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_NETBEUI: u32 = 13;
-pub const PF_SECURITY: u32 = 14;
-pub const PF_KEY: u32 = 15;
-pub const PF_NETLINK: u32 = 16;
-pub const PF_ROUTE: u32 = 16;
-pub const PF_PACKET: u32 = 17;
-pub const PF_ASH: u32 = 18;
-pub const PF_ECONET: u32 = 19;
-pub const PF_ATMSVC: u32 = 20;
-pub const PF_RDS: u32 = 21;
-pub const PF_SNA: u32 = 22;
-pub const PF_IRDA: u32 = 23;
-pub const PF_PPPOX: u32 = 24;
-pub const PF_WANPIPE: u32 = 25;
-pub const PF_LLC: u32 = 26;
-pub const PF_IB: u32 = 27;
-pub const PF_MPLS: u32 = 28;
-pub const PF_CAN: u32 = 29;
-pub const PF_TIPC: u32 = 30;
-pub const PF_BLUETOOTH: u32 = 31;
-pub const PF_IUCV: u32 = 32;
-pub const PF_RXRPC: u32 = 33;
-pub const PF_ISDN: u32 = 34;
-pub const PF_PHONET: u32 = 35;
-pub const PF_IEEE802154: u32 = 36;
-pub const PF_CAIF: u32 = 37;
-pub const PF_ALG: u32 = 38;
-pub const PF_NFC: u32 = 39;
+pub const PF_DLI: u32 = 13;
+pub const PF_LAT: u32 = 14;
+pub const PF_HYLINK: u32 = 15;
+pub const PF_APPLETALK: u32 = 16;
+pub const PF_ROUTE: u32 = 17;
+pub const PF_LINK: u32 = 18;
+pub const PF_XTP: u32 = 19;
+pub const PF_COIP: u32 = 20;
+pub const PF_CNT: u32 = 21;
+pub const PF_SIP: u32 = 24;
+pub const PF_IPX: u32 = 23;
+pub const PF_RTIP: u32 = 22;
+pub const PF_PIP: u32 = 25;
+pub const PF_NDRV: u32 = 27;
+pub const PF_ISDN: u32 = 28;
+pub const PF_KEY: u32 = 29;
+pub const PF_INET6: u32 = 30;
+pub const PF_NATM: u32 = 31;
+pub const PF_SYSTEM: u32 = 32;
+pub const PF_NETBIOS: u32 = 33;
+pub const PF_PPP: u32 = 34;
+pub const PF_RESERVED_36: u32 = 36;
+pub const PF_UTUN: u32 = 38;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_KCM: u32 = 41;
-pub const PF_QIPCRTR: u32 = 42;
-pub const PF_SMC: u32 = 43;
-pub const PF_XDP: u32 = 44;
-pub const PF_MAX: u32 = 45;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_UNIX: u32 = 1;
-pub const AF_FILE: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_AX25: u32 = 3;
-pub const AF_IPX: u32 = 4;
-pub const AF_APPLETALK: u32 = 5;
-pub const AF_NETROM: u32 = 6;
-pub const AF_BRIDGE: u32 = 7;
-pub const AF_ATMPVC: u32 = 8;
-pub const AF_X25: u32 = 9;
-pub const AF_INET6: u32 = 10;
-pub const AF_ROSE: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_NETBEUI: u32 = 13;
-pub const AF_SECURITY: u32 = 14;
-pub const AF_KEY: u32 = 15;
-pub const AF_NETLINK: u32 = 16;
-pub const AF_ROUTE: u32 = 16;
-pub const AF_PACKET: u32 = 17;
-pub const AF_ASH: u32 = 18;
-pub const AF_ECONET: u32 = 19;
-pub const AF_ATMSVC: u32 = 20;
-pub const AF_RDS: u32 = 21;
-pub const AF_SNA: u32 = 22;
-pub const AF_IRDA: u32 = 23;
-pub const AF_PPPOX: u32 = 24;
-pub const AF_WANPIPE: u32 = 25;
-pub const AF_LLC: u32 = 26;
-pub const AF_IB: u32 = 27;
-pub const AF_MPLS: u32 = 28;
-pub const AF_CAN: u32 = 29;
-pub const AF_TIPC: u32 = 30;
-pub const AF_BLUETOOTH: u32 = 31;
-pub const AF_IUCV: u32 = 32;
-pub const AF_RXRPC: u32 = 33;
-pub const AF_ISDN: u32 = 34;
-pub const AF_PHONET: u32 = 35;
-pub const AF_IEEE802154: u32 = 36;
-pub const AF_CAIF: u32 = 37;
-pub const AF_ALG: u32 = 38;
-pub const AF_NFC: u32 = 39;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_KCM: u32 = 41;
-pub const AF_QIPCRTR: u32 = 42;
-pub const AF_SMC: u32 = 43;
-pub const AF_XDP: u32 = 44;
-pub const AF_MAX: u32 = 45;
-pub const SOL_RAW: u32 = 255;
-pub const SOL_DECNET: u32 = 261;
-pub const SOL_X25: u32 = 262;
-pub const SOL_PACKET: u32 = 263;
-pub const SOL_ATM: u32 = 264;
-pub const SOL_AAL: u32 = 265;
-pub const SOL_IRDA: u32 = 266;
-pub const SOL_NETBEUI: u32 = 267;
-pub const SOL_LLC: u32 = 268;
-pub const SOL_DCCP: u32 = 269;
-pub const SOL_NETLINK: u32 = 270;
-pub const SOL_TIPC: u32 = 271;
-pub const SOL_RXRPC: u32 = 272;
-pub const SOL_PPPOL2TP: u32 = 273;
-pub const SOL_BLUETOOTH: u32 = 274;
-pub const SOL_PNPIPE: u32 = 275;
-pub const SOL_RDS: u32 = 276;
-pub const SOL_IUCV: u32 = 277;
-pub const SOL_CAIF: u32 = 278;
-pub const SOL_ALG: u32 = 279;
-pub const SOL_NFC: u32 = 280;
-pub const SOL_KCM: u32 = 281;
-pub const SOL_TLS: u32 = 282;
-pub const SOL_XDP: u32 = 283;
-pub const SOMAXCONN: u32 = 4096;
-pub const _BITS_SOCKADDR_H: u32 = 1;
-pub const _SS_SIZE: u32 = 128;
-pub const __BITS_PER_LONG: u32 = 64;
-pub const FIOSETOWN: u32 = 35073;
-pub const SIOCSPGRP: u32 = 35074;
-pub const FIOGETOWN: u32 = 35075;
-pub const SIOCGPGRP: u32 = 35076;
-pub const SIOCATMARK: u32 = 35077;
-pub const SIOCGSTAMP_OLD: u32 = 35078;
-pub const SIOCGSTAMPNS_OLD: u32 = 35079;
-pub const SOL_SOCKET: u32 = 1;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_REUSEADDR: u32 = 2;
-pub const SO_TYPE: u32 = 3;
-pub const SO_ERROR: u32 = 4;
-pub const SO_DONTROUTE: u32 = 5;
-pub const SO_BROADCAST: u32 = 6;
-pub const SO_SNDBUF: u32 = 7;
-pub const SO_RCVBUF: u32 = 8;
-pub const SO_SNDBUFFORCE: u32 = 32;
-pub const SO_RCVBUFFORCE: u32 = 33;
-pub const SO_KEEPALIVE: u32 = 9;
-pub const SO_OOBINLINE: u32 = 10;
-pub const SO_NO_CHECK: u32 = 11;
-pub const SO_PRIORITY: u32 = 12;
-pub const SO_LINGER: u32 = 13;
-pub const SO_BSDCOMPAT: u32 = 14;
-pub const SO_REUSEPORT: u32 = 15;
-pub const SO_PASSCRED: u32 = 16;
-pub const SO_PEERCRED: u32 = 17;
-pub const SO_RCVLOWAT: u32 = 18;
-pub const SO_SNDLOWAT: u32 = 19;
-pub const SO_RCVTIMEO_OLD: u32 = 20;
-pub const SO_SNDTIMEO_OLD: u32 = 21;
-pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
-pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
-pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
-pub const SO_BINDTODEVICE: u32 = 25;
-pub const SO_ATTACH_FILTER: u32 = 26;
-pub const SO_DETACH_FILTER: u32 = 27;
-pub const SO_GET_FILTER: u32 = 26;
-pub const SO_PEERNAME: u32 = 28;
-pub const SO_ACCEPTCONN: u32 = 30;
-pub const SO_PEERSEC: u32 = 31;
-pub const SO_PASSSEC: u32 = 34;
-pub const SO_MARK: u32 = 36;
-pub const SO_PROTOCOL: u32 = 38;
-pub const SO_DOMAIN: u32 = 39;
-pub const SO_RXQ_OVFL: u32 = 40;
-pub const SO_WIFI_STATUS: u32 = 41;
-pub const SCM_WIFI_STATUS: u32 = 41;
-pub const SO_PEEK_OFF: u32 = 42;
-pub const SO_NOFCS: u32 = 43;
-pub const SO_LOCK_FILTER: u32 = 44;
-pub const SO_SELECT_ERR_QUEUE: u32 = 45;
-pub const SO_BUSY_POLL: u32 = 46;
-pub const SO_MAX_PACING_RATE: u32 = 47;
-pub const SO_BPF_EXTENSIONS: u32 = 48;
-pub const SO_INCOMING_CPU: u32 = 49;
-pub const SO_ATTACH_BPF: u32 = 50;
-pub const SO_DETACH_BPF: u32 = 27;
-pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
-pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
-pub const SO_CNX_ADVICE: u32 = 53;
-pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
-pub const SO_MEMINFO: u32 = 55;
-pub const SO_INCOMING_NAPI_ID: u32 = 56;
-pub const SO_COOKIE: u32 = 57;
-pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
-pub const SO_PEERGROUPS: u32 = 59;
-pub const SO_ZEROCOPY: u32 = 60;
-pub const SO_TXTIME: u32 = 61;
-pub const SCM_TXTIME: u32 = 61;
-pub const SO_BINDTOIFINDEX: u32 = 62;
-pub const SO_TIMESTAMP_OLD: u32 = 29;
-pub const SO_TIMESTAMPNS_OLD: u32 = 35;
-pub const SO_TIMESTAMPING_OLD: u32 = 37;
-pub const SO_TIMESTAMP_NEW: u32 = 63;
-pub const SO_TIMESTAMPNS_NEW: u32 = 64;
-pub const SO_TIMESTAMPING_NEW: u32 = 65;
-pub const SO_RCVTIMEO_NEW: u32 = 66;
-pub const SO_SNDTIMEO_NEW: u32 = 67;
-pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_TIMESTAMP: u32 = 29;
-pub const SO_TIMESTAMPNS: u32 = 35;
-pub const SO_TIMESTAMPING: u32 = 37;
-pub const SO_RCVTIMEO: u32 = 20;
-pub const SO_SNDTIMEO: u32 = 21;
-pub const SCM_TIMESTAMP: u32 = 29;
-pub const SCM_TIMESTAMPNS: u32 = 35;
-pub const SCM_TIMESTAMPING: u32 = 37;
-pub const __osockaddr_defined: u32 = 1;
-pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
-pub const IP_OPTIONS: u32 = 4;
-pub const IP_HDRINCL: u32 = 3;
-pub const IP_TOS: u32 = 1;
-pub const IP_TTL: u32 = 2;
-pub const IP_RECVOPTS: u32 = 6;
-pub const IP_RETOPTS: u32 = 7;
-pub const IP_MULTICAST_IF: u32 = 32;
-pub const IP_MULTICAST_TTL: u32 = 33;
-pub const IP_MULTICAST_LOOP: u32 = 34;
-pub const IP_ADD_MEMBERSHIP: u32 = 35;
-pub const IP_DROP_MEMBERSHIP: u32 = 36;
-pub const IP_UNBLOCK_SOURCE: u32 = 37;
-pub const IP_BLOCK_SOURCE: u32 = 38;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
-pub const IP_MSFILTER: u32 = 41;
-pub const MCAST_JOIN_GROUP: u32 = 42;
-pub const MCAST_BLOCK_SOURCE: u32 = 43;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
-pub const MCAST_LEAVE_GROUP: u32 = 45;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
-pub const MCAST_MSFILTER: u32 = 48;
-pub const IP_MULTICAST_ALL: u32 = 49;
-pub const IP_UNICAST_IF: u32 = 50;
-pub const MCAST_EXCLUDE: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const IP_ROUTER_ALERT: u32 = 5;
-pub const IP_PKTINFO: u32 = 8;
-pub const IP_PKTOPTIONS: u32 = 9;
-pub const IP_PMTUDISC: u32 = 10;
-pub const IP_MTU_DISCOVER: u32 = 10;
-pub const IP_RECVERR: u32 = 11;
-pub const IP_RECVTTL: u32 = 12;
-pub const IP_RECVTOS: u32 = 13;
-pub const IP_MTU: u32 = 14;
-pub const IP_FREEBIND: u32 = 15;
-pub const IP_IPSEC_POLICY: u32 = 16;
-pub const IP_XFRM_POLICY: u32 = 17;
-pub const IP_PASSSEC: u32 = 18;
-pub const IP_TRANSPARENT: u32 = 19;
-pub const IP_ORIGDSTADDR: u32 = 20;
-pub const IP_RECVORIGDSTADDR: u32 = 20;
-pub const IP_MINTTL: u32 = 21;
-pub const IP_NODEFRAG: u32 = 22;
-pub const IP_CHECKSUM: u32 = 23;
-pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
-pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_PMTUDISC_DONT: u32 = 0;
-pub const IP_PMTUDISC_WANT: u32 = 1;
-pub const IP_PMTUDISC_DO: u32 = 2;
-pub const IP_PMTUDISC_PROBE: u32 = 3;
-pub const IP_PMTUDISC_INTERFACE: u32 = 4;
-pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const SOL_IP: u32 = 0;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MAX_MEMBERSHIPS: u32 = 20;
-pub const IPV6_ADDRFORM: u32 = 1;
-pub const IPV6_2292PKTINFO: u32 = 2;
-pub const IPV6_2292HOPOPTS: u32 = 3;
-pub const IPV6_2292DSTOPTS: u32 = 4;
-pub const IPV6_2292RTHDR: u32 = 5;
-pub const IPV6_2292PKTOPTIONS: u32 = 6;
-pub const IPV6_CHECKSUM: u32 = 7;
-pub const IPV6_2292HOPLIMIT: u32 = 8;
-pub const IPV6_NEXTHOP: u32 = 9;
-pub const IPV6_AUTHHDR: u32 = 10;
-pub const IPV6_UNICAST_HOPS: u32 = 16;
-pub const IPV6_MULTICAST_IF: u32 = 17;
-pub const IPV6_MULTICAST_HOPS: u32 = 18;
-pub const IPV6_MULTICAST_LOOP: u32 = 19;
-pub const IPV6_JOIN_GROUP: u32 = 20;
-pub const IPV6_LEAVE_GROUP: u32 = 21;
-pub const IPV6_ROUTER_ALERT: u32 = 22;
-pub const IPV6_MTU_DISCOVER: u32 = 23;
-pub const IPV6_MTU: u32 = 24;
-pub const IPV6_RECVERR: u32 = 25;
-pub const IPV6_V6ONLY: u32 = 26;
-pub const IPV6_JOIN_ANYCAST: u32 = 27;
-pub const IPV6_LEAVE_ANYCAST: u32 = 28;
-pub const IPV6_MULTICAST_ALL: u32 = 29;
-pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_IPSEC_POLICY: u32 = 34;
-pub const IPV6_XFRM_POLICY: u32 = 35;
-pub const IPV6_HDRINCL: u32 = 36;
-pub const IPV6_RECVPKTINFO: u32 = 49;
-pub const IPV6_PKTINFO: u32 = 50;
-pub const IPV6_RECVHOPLIMIT: u32 = 51;
-pub const IPV6_HOPLIMIT: u32 = 52;
-pub const IPV6_RECVHOPOPTS: u32 = 53;
-pub const IPV6_HOPOPTS: u32 = 54;
-pub const IPV6_RTHDRDSTOPTS: u32 = 55;
-pub const IPV6_RECVRTHDR: u32 = 56;
-pub const IPV6_RTHDR: u32 = 57;
-pub const IPV6_RECVDSTOPTS: u32 = 58;
-pub const IPV6_DSTOPTS: u32 = 59;
-pub const IPV6_RECVPATHMTU: u32 = 60;
-pub const IPV6_PATHMTU: u32 = 61;
-pub const IPV6_DONTFRAG: u32 = 62;
-pub const IPV6_RECVTCLASS: u32 = 66;
-pub const IPV6_TCLASS: u32 = 67;
-pub const IPV6_AUTOFLOWLABEL: u32 = 70;
-pub const IPV6_ADDR_PREFERENCES: u32 = 72;
-pub const IPV6_MINHOPCOUNT: u32 = 73;
-pub const IPV6_ORIGDSTADDR: u32 = 74;
-pub const IPV6_RECVORIGDSTADDR: u32 = 74;
-pub const IPV6_TRANSPARENT: u32 = 75;
-pub const IPV6_UNICAST_IF: u32 = 76;
-pub const IPV6_RECVFRAGSIZE: u32 = 77;
-pub const IPV6_FREEBIND: u32 = 78;
-pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
-pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
-pub const IPV6_RXHOPOPTS: u32 = 54;
-pub const IPV6_RXDSTOPTS: u32 = 59;
-pub const IPV6_PMTUDISC_DONT: u32 = 0;
-pub const IPV6_PMTUDISC_WANT: u32 = 1;
-pub const IPV6_PMTUDISC_DO: u32 = 2;
-pub const IPV6_PMTUDISC_PROBE: u32 = 3;
-pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
-pub const IPV6_PMTUDISC_OMIT: u32 = 5;
-pub const SOL_IPV6: u32 = 41;
-pub const SOL_ICMPV6: u32 = 58;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
+pub const PF_MAX: u32 = 41;
+pub const NET_MAXID: u32 = 41;
+pub const NET_RT_DUMP: u32 = 1;
+pub const NET_RT_FLAGS: u32 = 2;
+pub const NET_RT_IFLIST: u32 = 3;
+pub const NET_RT_STAT: u32 = 4;
+pub const NET_RT_TRASH: u32 = 5;
+pub const NET_RT_IFLIST2: u32 = 6;
+pub const NET_RT_DUMP2: u32 = 7;
+pub const NET_RT_FLAGS_PRIV: u32 = 10;
+pub const NET_RT_MAXID: u32 = 11;
+pub const SOMAXCONN: u32 = 128;
+pub const MSG_OOB: u32 = 1;
+pub const MSG_PEEK: u32 = 2;
+pub const MSG_DONTROUTE: u32 = 4;
+pub const MSG_EOR: u32 = 8;
+pub const MSG_TRUNC: u32 = 16;
+pub const MSG_CTRUNC: u32 = 32;
+pub const MSG_WAITALL: u32 = 64;
+pub const MSG_DONTWAIT: u32 = 128;
+pub const MSG_EOF: u32 = 256;
+pub const MSG_WAITSTREAM: u32 = 512;
+pub const MSG_FLUSH: u32 = 1024;
+pub const MSG_HOLD: u32 = 2048;
+pub const MSG_SEND: u32 = 4096;
+pub const MSG_HAVEMORE: u32 = 8192;
+pub const MSG_RCVMORE: u32 = 16384;
+pub const MSG_NEEDSA: u32 = 65536;
+pub const MSG_NOSIGNAL: u32 = 524288;
+pub const SCM_RIGHTS: u32 = 1;
+pub const SCM_TIMESTAMP: u32 = 2;
+pub const SCM_CREDS: u32 = 3;
+pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
+pub const SHUT_RD: u32 = 0;
+pub const SHUT_WR: u32 = 1;
+pub const SHUT_RDWR: u32 = 2;
+pub const IPPROTO_IP: u32 = 0;
+pub const IPPROTO_HOPOPTS: u32 = 0;
+pub const IPPROTO_ICMP: u32 = 1;
+pub const IPPROTO_IGMP: u32 = 2;
+pub const IPPROTO_GGP: u32 = 3;
+pub const IPPROTO_IPV4: u32 = 4;
+pub const IPPROTO_IPIP: u32 = 4;
+pub const IPPROTO_TCP: u32 = 6;
+pub const IPPROTO_ST: u32 = 7;
+pub const IPPROTO_EGP: u32 = 8;
+pub const IPPROTO_PIGP: u32 = 9;
+pub const IPPROTO_RCCMON: u32 = 10;
+pub const IPPROTO_NVPII: u32 = 11;
+pub const IPPROTO_PUP: u32 = 12;
+pub const IPPROTO_ARGUS: u32 = 13;
+pub const IPPROTO_EMCON: u32 = 14;
+pub const IPPROTO_XNET: u32 = 15;
+pub const IPPROTO_CHAOS: u32 = 16;
+pub const IPPROTO_UDP: u32 = 17;
+pub const IPPROTO_MUX: u32 = 18;
+pub const IPPROTO_MEAS: u32 = 19;
+pub const IPPROTO_HMP: u32 = 20;
+pub const IPPROTO_PRM: u32 = 21;
+pub const IPPROTO_IDP: u32 = 22;
+pub const IPPROTO_TRUNK1: u32 = 23;
+pub const IPPROTO_TRUNK2: u32 = 24;
+pub const IPPROTO_LEAF1: u32 = 25;
+pub const IPPROTO_LEAF2: u32 = 26;
+pub const IPPROTO_RDP: u32 = 27;
+pub const IPPROTO_IRTP: u32 = 28;
+pub const IPPROTO_TP: u32 = 29;
+pub const IPPROTO_BLT: u32 = 30;
+pub const IPPROTO_NSP: u32 = 31;
+pub const IPPROTO_INP: u32 = 32;
+pub const IPPROTO_SEP: u32 = 33;
+pub const IPPROTO_3PC: u32 = 34;
+pub const IPPROTO_IDPR: u32 = 35;
+pub const IPPROTO_XTP: u32 = 36;
+pub const IPPROTO_DDP: u32 = 37;
+pub const IPPROTO_CMTP: u32 = 38;
+pub const IPPROTO_TPXX: u32 = 39;
+pub const IPPROTO_IL: u32 = 40;
+pub const IPPROTO_IPV6: u32 = 41;
+pub const IPPROTO_SDRP: u32 = 42;
+pub const IPPROTO_ROUTING: u32 = 43;
+pub const IPPROTO_FRAGMENT: u32 = 44;
+pub const IPPROTO_IDRP: u32 = 45;
+pub const IPPROTO_RSVP: u32 = 46;
+pub const IPPROTO_GRE: u32 = 47;
+pub const IPPROTO_MHRP: u32 = 48;
+pub const IPPROTO_BHA: u32 = 49;
+pub const IPPROTO_ESP: u32 = 50;
+pub const IPPROTO_AH: u32 = 51;
+pub const IPPROTO_INLSP: u32 = 52;
+pub const IPPROTO_SWIPE: u32 = 53;
+pub const IPPROTO_NHRP: u32 = 54;
+pub const IPPROTO_ICMPV6: u32 = 58;
+pub const IPPROTO_NONE: u32 = 59;
+pub const IPPROTO_DSTOPTS: u32 = 60;
+pub const IPPROTO_AHIP: u32 = 61;
+pub const IPPROTO_CFTP: u32 = 62;
+pub const IPPROTO_HELLO: u32 = 63;
+pub const IPPROTO_SATEXPAK: u32 = 64;
+pub const IPPROTO_KRYPTOLAN: u32 = 65;
+pub const IPPROTO_RVD: u32 = 66;
+pub const IPPROTO_IPPC: u32 = 67;
+pub const IPPROTO_ADFS: u32 = 68;
+pub const IPPROTO_SATMON: u32 = 69;
+pub const IPPROTO_VISA: u32 = 70;
+pub const IPPROTO_IPCV: u32 = 71;
+pub const IPPROTO_CPNX: u32 = 72;
+pub const IPPROTO_CPHB: u32 = 73;
+pub const IPPROTO_WSN: u32 = 74;
+pub const IPPROTO_PVP: u32 = 75;
+pub const IPPROTO_BRSATMON: u32 = 76;
+pub const IPPROTO_ND: u32 = 77;
+pub const IPPROTO_WBMON: u32 = 78;
+pub const IPPROTO_WBEXPAK: u32 = 79;
+pub const IPPROTO_EON: u32 = 80;
+pub const IPPROTO_VMTP: u32 = 81;
+pub const IPPROTO_SVMTP: u32 = 82;
+pub const IPPROTO_VINES: u32 = 83;
+pub const IPPROTO_TTP: u32 = 84;
+pub const IPPROTO_IGP: u32 = 85;
+pub const IPPROTO_DGP: u32 = 86;
+pub const IPPROTO_TCF: u32 = 87;
+pub const IPPROTO_IGRP: u32 = 88;
+pub const IPPROTO_OSPFIGP: u32 = 89;
+pub const IPPROTO_SRPC: u32 = 90;
+pub const IPPROTO_LARP: u32 = 91;
+pub const IPPROTO_MTP: u32 = 92;
+pub const IPPROTO_AX25: u32 = 93;
+pub const IPPROTO_IPEIP: u32 = 94;
+pub const IPPROTO_MICP: u32 = 95;
+pub const IPPROTO_SCCSP: u32 = 96;
+pub const IPPROTO_ETHERIP: u32 = 97;
+pub const IPPROTO_ENCAP: u32 = 98;
+pub const IPPROTO_APES: u32 = 99;
+pub const IPPROTO_GMTP: u32 = 100;
+pub const IPPROTO_PIM: u32 = 103;
+pub const IPPROTO_IPCOMP: u32 = 108;
+pub const IPPROTO_PGM: u32 = 113;
+pub const IPPROTO_SCTP: u32 = 132;
+pub const IPPROTO_DIVERT: u32 = 254;
+pub const IPPROTO_RAW: u32 = 255;
+pub const IPPROTO_MAX: u32 = 256;
+pub const IPPROTO_DONE: u32 = 257;
+pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
+pub const IPPORT_USERRESERVED: u32 = 5000;
+pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
+pub const IPPORT_HILASTAUTO: u32 = 65535;
+pub const IPPORT_RESERVEDSTART: u32 = 600;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1126,66 +1393,279 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
+pub const IN_CLASSD_NET: u32 = 4026531840;
+pub const IN_CLASSD_NSHIFT: u32 = 28;
+pub const IN_CLASSD_HOST: u32 = 268435455;
+pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
+pub const IP_OPTIONS: u32 = 1;
+pub const IP_HDRINCL: u32 = 2;
+pub const IP_TOS: u32 = 3;
+pub const IP_TTL: u32 = 4;
+pub const IP_RECVOPTS: u32 = 5;
+pub const IP_RECVRETOPTS: u32 = 6;
+pub const IP_RECVDSTADDR: u32 = 7;
+pub const IP_RETOPTS: u32 = 8;
+pub const IP_MULTICAST_IF: u32 = 9;
+pub const IP_MULTICAST_TTL: u32 = 10;
+pub const IP_MULTICAST_LOOP: u32 = 11;
+pub const IP_ADD_MEMBERSHIP: u32 = 12;
+pub const IP_DROP_MEMBERSHIP: u32 = 13;
+pub const IP_MULTICAST_VIF: u32 = 14;
+pub const IP_RSVP_ON: u32 = 15;
+pub const IP_RSVP_OFF: u32 = 16;
+pub const IP_RSVP_VIF_ON: u32 = 17;
+pub const IP_RSVP_VIF_OFF: u32 = 18;
+pub const IP_PORTRANGE: u32 = 19;
+pub const IP_RECVIF: u32 = 20;
+pub const IP_IPSEC_POLICY: u32 = 21;
+pub const IP_FAITH: u32 = 22;
+pub const IP_STRIPHDR: u32 = 23;
+pub const IP_RECVTTL: u32 = 24;
+pub const IP_BOUND_IF: u32 = 25;
+pub const IP_PKTINFO: u32 = 26;
+pub const IP_RECVPKTINFO: u32 = 26;
+pub const IP_RECVTOS: u32 = 27;
+pub const IP_DONTFRAG: u32 = 28;
+pub const IP_FW_ADD: u32 = 40;
+pub const IP_FW_DEL: u32 = 41;
+pub const IP_FW_FLUSH: u32 = 42;
+pub const IP_FW_ZERO: u32 = 43;
+pub const IP_FW_GET: u32 = 44;
+pub const IP_FW_RESETLOG: u32 = 45;
+pub const IP_OLD_FW_ADD: u32 = 50;
+pub const IP_OLD_FW_DEL: u32 = 51;
+pub const IP_OLD_FW_FLUSH: u32 = 52;
+pub const IP_OLD_FW_ZERO: u32 = 53;
+pub const IP_OLD_FW_GET: u32 = 54;
+pub const IP_NAT__XXX: u32 = 55;
+pub const IP_OLD_FW_RESETLOG: u32 = 56;
+pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
+pub const IP_DUMMYNET_DEL: u32 = 61;
+pub const IP_DUMMYNET_FLUSH: u32 = 62;
+pub const IP_DUMMYNET_GET: u32 = 64;
+pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
+pub const IP_MULTICAST_IFINDEX: u32 = 66;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
+pub const IP_BLOCK_SOURCE: u32 = 72;
+pub const IP_UNBLOCK_SOURCE: u32 = 73;
+pub const IP_MSFILTER: u32 = 74;
+pub const MCAST_JOIN_GROUP: u32 = 80;
+pub const MCAST_LEAVE_GROUP: u32 = 81;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
+pub const MCAST_BLOCK_SOURCE: u32 = 84;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MIN_MEMBERSHIPS: u32 = 31;
+pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
+pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
+pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
+pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
+pub const MCAST_UNDEFINED: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const MCAST_EXCLUDE: u32 = 2;
+pub const IP_PORTRANGE_DEFAULT: u32 = 0;
+pub const IP_PORTRANGE_HIGH: u32 = 1;
+pub const IP_PORTRANGE_LOW: u32 = 2;
+pub const IPPROTO_MAXID: u32 = 52;
+pub const IPCTL_FORWARDING: u32 = 1;
+pub const IPCTL_SENDREDIRECTS: u32 = 2;
+pub const IPCTL_DEFTTL: u32 = 3;
+pub const IPCTL_RTEXPIRE: u32 = 5;
+pub const IPCTL_RTMINEXPIRE: u32 = 6;
+pub const IPCTL_RTMAXCACHE: u32 = 7;
+pub const IPCTL_SOURCEROUTE: u32 = 8;
+pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
+pub const IPCTL_INTRQMAXLEN: u32 = 10;
+pub const IPCTL_INTRQDROPS: u32 = 11;
+pub const IPCTL_STATS: u32 = 12;
+pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
+pub const IPCTL_FASTFORWARDING: u32 = 14;
+pub const IPCTL_KEEPFAITH: u32 = 15;
+pub const IPCTL_GIF_TTL: u32 = 16;
+pub const IPCTL_MAXID: u32 = 17;
+pub const __KAME_VERSION: &'static [u8; 18usize] = b"2009/apple-darwin\0";
+pub const IPV6PORT_RESERVED: u32 = 1024;
+pub const IPV6PORT_ANONMIN: u32 = 49152;
+pub const IPV6PORT_ANONMAX: u32 = 65535;
+pub const IPV6PORT_RESERVEDMIN: u32 = 600;
+pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const _RPC_NETDB_H: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
+pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
+pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
+pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
+pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
+pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
+pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
+pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
+pub const IPV6_UNICAST_HOPS: u32 = 4;
+pub const IPV6_MULTICAST_IF: u32 = 9;
+pub const IPV6_MULTICAST_HOPS: u32 = 10;
+pub const IPV6_MULTICAST_LOOP: u32 = 11;
+pub const IPV6_JOIN_GROUP: u32 = 12;
+pub const IPV6_LEAVE_GROUP: u32 = 13;
+pub const IPV6_PORTRANGE: u32 = 14;
+pub const ICMP6_FILTER: u32 = 18;
+pub const IPV6_2292PKTINFO: u32 = 19;
+pub const IPV6_2292HOPLIMIT: u32 = 20;
+pub const IPV6_2292NEXTHOP: u32 = 21;
+pub const IPV6_2292HOPOPTS: u32 = 22;
+pub const IPV6_2292DSTOPTS: u32 = 23;
+pub const IPV6_2292RTHDR: u32 = 24;
+pub const IPV6_2292PKTOPTIONS: u32 = 25;
+pub const IPV6_CHECKSUM: u32 = 26;
+pub const IPV6_V6ONLY: u32 = 27;
+pub const IPV6_BINDV6ONLY: u32 = 27;
+pub const IPV6_IPSEC_POLICY: u32 = 28;
+pub const IPV6_FAITH: u32 = 29;
+pub const IPV6_FW_ADD: u32 = 30;
+pub const IPV6_FW_DEL: u32 = 31;
+pub const IPV6_FW_FLUSH: u32 = 32;
+pub const IPV6_FW_ZERO: u32 = 33;
+pub const IPV6_FW_GET: u32 = 34;
+pub const IPV6_RECVTCLASS: u32 = 35;
+pub const IPV6_TCLASS: u32 = 36;
+pub const IPV6_BOUND_IF: u32 = 125;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
+pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
+pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
+pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
+pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
+pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
+pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
+pub const IPV6_PORTRANGE_HIGH: u32 = 1;
+pub const IPV6_PORTRANGE_LOW: u32 = 2;
+pub const IPV6PROTO_MAXID: u32 = 104;
+pub const IPV6CTL_FORWARDING: u32 = 1;
+pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
+pub const IPV6CTL_DEFHLIM: u32 = 3;
+pub const IPV6CTL_FORWSRCRT: u32 = 5;
+pub const IPV6CTL_STATS: u32 = 6;
+pub const IPV6CTL_MRTSTATS: u32 = 7;
+pub const IPV6CTL_MRTPROTO: u32 = 8;
+pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
+pub const IPV6CTL_SOURCECHECK: u32 = 10;
+pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
+pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
+pub const IPV6CTL_KEEPFAITH: u32 = 13;
+pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
+pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
+pub const IPV6CTL_DAD_COUNT: u32 = 16;
+pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
+pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
+pub const IPV6CTL_GIF_HLIM: u32 = 19;
+pub const IPV6CTL_KAME_VERSION: u32 = 20;
+pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
+pub const IPV6CTL_RR_PRUNE: u32 = 22;
+pub const IPV6CTL_V6ONLY: u32 = 24;
+pub const IPV6CTL_RTEXPIRE: u32 = 25;
+pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
+pub const IPV6CTL_RTMAXCACHE: u32 = 27;
+pub const IPV6CTL_USETEMPADDR: u32 = 32;
+pub const IPV6CTL_TEMPPLTIME: u32 = 33;
+pub const IPV6CTL_TEMPVLTIME: u32 = 34;
+pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
+pub const IPV6CTL_RIP6STATS: u32 = 36;
+pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
+pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
+pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
+pub const IPV6CTL_MAXFRAGS: u32 = 41;
+pub const IPV6CTL_MCAST_PMTU: u32 = 44;
+pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
+pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
+pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
+pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
+pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
+pub const IPV6CTL_MAXID: u32 = 51;
 pub const _PATH_HEQUIV: &'static [u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &'static [u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &'static [u8; 14usize] = b"/etc/networks\0";
-pub const _PATH_NSSWITCH_CONF: &'static [u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &'static [u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &'static [u8; 14usize] = b"/etc/services\0";
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
+pub const EAI_ADDRFAMILY: u32 = 1;
+pub const EAI_AGAIN: u32 = 2;
+pub const EAI_BADFLAGS: u32 = 3;
+pub const EAI_FAIL: u32 = 4;
+pub const EAI_FAMILY: u32 = 5;
+pub const EAI_MEMORY: u32 = 6;
+pub const EAI_NODATA: u32 = 7;
+pub const EAI_NONAME: u32 = 8;
+pub const EAI_SERVICE: u32 = 9;
+pub const EAI_SOCKTYPE: u32 = 10;
+pub const EAI_SYSTEM: u32 = 11;
+pub const EAI_BADHINTS: u32 = 12;
+pub const EAI_PROTOCOL: u32 = 13;
+pub const EAI_OVERFLOW: u32 = 14;
+pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_V4MAPPED: u32 = 8;
-pub const AI_ALL: u32 = 16;
-pub const AI_ADDRCONFIG: u32 = 32;
-pub const AI_NUMERICSERV: u32 = 1024;
-pub const EAI_BADFLAGS: i32 = -1;
-pub const EAI_NONAME: i32 = -2;
-pub const EAI_AGAIN: i32 = -3;
-pub const EAI_FAIL: i32 = -4;
-pub const EAI_FAMILY: i32 = -6;
-pub const EAI_SOCKTYPE: i32 = -7;
-pub const EAI_SERVICE: i32 = -8;
-pub const EAI_MEMORY: i32 = -10;
-pub const EAI_SYSTEM: i32 = -11;
-pub const EAI_OVERFLOW: i32 = -12;
+pub const AI_NUMERICSERV: u32 = 4096;
+pub const AI_ALL: u32 = 256;
+pub const AI_V4MAPPED_CFG: u32 = 512;
+pub const AI_ADDRCONFIG: u32 = 1024;
+pub const AI_V4MAPPED: u32 = 2048;
+pub const AI_DEFAULT: u32 = 1536;
+pub const AI_UNUSABLE: u32 = 268435456;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NUMERICHOST: u32 = 1;
-pub const NI_NUMERICSERV: u32 = 2;
-pub const NI_NOFQDN: u32 = 4;
-pub const NI_NAMEREQD: u32 = 8;
+pub const NI_NOFQDN: u32 = 1;
+pub const NI_NUMERICHOST: u32 = 2;
+pub const NI_NAMEREQD: u32 = 4;
+pub const NI_NUMERICSERV: u32 = 8;
+pub const NI_NUMERICSCOPE: u32 = 256;
 pub const NI_DGRAM: u32 = 16;
-pub const _PWD_H: u32 = 1;
-pub const NSS_BUFLEN_PASSWD: u32 = 1024;
+pub const NI_WITHSCOPEID: u32 = 32;
+pub const SCOPE_DELIMITER: u8 = 37u8;
+pub const _PATH_PWD: &'static [u8; 5usize] = b"/etc\0";
+pub const _PATH_PASSWD: &'static [u8; 12usize] = b"/etc/passwd\0";
+pub const _PASSWD: &'static [u8; 7usize] = b"passwd\0";
+pub const _PATH_MASTERPASSWD: &'static [u8; 19usize] = b"/etc/master.passwd\0";
+pub const _PATH_MASTERPASSWD_LOCK: &'static [u8; 10usize] = b"/etc/ptmp\0";
+pub const _MASTERPASSWD: &'static [u8; 14usize] = b"master.passwd\0";
+pub const _PATH_MP_DB: &'static [u8; 12usize] = b"/etc/pwd.db\0";
+pub const _MP_DB: &'static [u8; 7usize] = b"pwd.db\0";
+pub const _PATH_SMP_DB: &'static [u8; 13usize] = b"/etc/spwd.db\0";
+pub const _SMP_DB: &'static [u8; 8usize] = b"spwd.db\0";
+pub const _PATH_PWD_MKDB: &'static [u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
+pub const _PW_KEYBYNAME: u8 = 49u8;
+pub const _PW_KEYBYNUM: u8 = 50u8;
+pub const _PW_KEYBYUID: u8 = 51u8;
+pub const _PASSWORD_EFMT1: u8 = 95u8;
+pub const _PASSWORD_LEN: u32 = 128;
+pub const _PASSWORD_NOUID: u32 = 1;
+pub const _PASSWORD_NOGID: u32 = 2;
+pub const _PASSWORD_NOCHG: u32 = 4;
+pub const _PASSWORD_NOEXP: u32 = 8;
+pub const _PASSWORD_WARNDAYS: u32 = 14;
+pub const _PASSWORD_CHGNOW: i32 = -1;
 pub const PGINVALID_SOCKET: i32 = -1;
 pub const PG_BACKEND_VERSIONSTR: &'static [u8; 29usize] = b"postgres (PostgreSQL) 11.11\n\0";
 pub const EXE: &'static [u8; 1usize] = b"\0";
 pub const DEVNULL: &'static [u8; 10usize] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
-pub const _MATH_H: u32 = 1;
-pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
-pub const __FP_LOGB0_IS_MIN: u32 = 1;
-pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
+pub const FP_SUPERNORMAL: u32 = 6;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
-pub const __MATH_DECLARING_DOUBLE: u32 = 1;
-pub const __MATH_DECLARING_FLOATN: u32 = 0;
-pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
-pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1199,8 +1679,13 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const _SETJMP_H: u32 = 1;
-pub const _BITS_SETJMP_H: u32 = 1;
+pub const DOMAIN: u32 = 1;
+pub const SING: u32 = 2;
+pub const OVERFLOW: u32 = 3;
+pub const UNDERFLOW: u32 = 4;
+pub const TLOSS: u32 = 5;
+pub const PLOSS: u32 = 6;
+pub const _JBLEN: u32 = 37;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1318,84 +1803,121 @@ pub const LP_DEAD: u32 = 3;
 pub const OffsetNumberMask: u32 = 65535;
 pub const SpecTokenOffsetNumber: u32 = 65534;
 pub const MovedPartitionsOffsetNumber: u32 = 65533;
-pub const _LIBC_LIMITS_H_: u32 = 1;
-pub const MB_LEN_MAX: u32 = 16;
-pub const _BITS_POSIX1_LIM_H: u32 = 1;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
+pub const __DARWIN_CLK_TCK: u32 = 100;
+pub const CHAR_BIT: u32 = 8;
+pub const MB_LEN_MAX: u32 = 6;
+pub const CLK_TCK: u32 = 100;
+pub const SCHAR_MAX: u32 = 127;
+pub const SCHAR_MIN: i32 = -128;
+pub const UCHAR_MAX: u32 = 255;
+pub const CHAR_MAX: u32 = 127;
+pub const CHAR_MIN: i32 = -128;
+pub const USHRT_MAX: u32 = 65535;
+pub const SHRT_MAX: u32 = 32767;
+pub const SHRT_MIN: i32 = -32768;
+pub const UINT_MAX: u32 = 4294967295;
+pub const INT_MAX: u32 = 2147483647;
+pub const INT_MIN: i32 = -2147483648;
+pub const ULONG_MAX: i32 = -1;
+pub const LONG_MAX: u64 = 9223372036854775807;
+pub const LONG_MIN: i64 = -9223372036854775808;
+pub const ULLONG_MAX: i32 = -1;
+pub const LLONG_MAX: u64 = 9223372036854775807;
+pub const LLONG_MIN: i64 = -9223372036854775808;
+pub const LONG_BIT: u32 = 64;
+pub const SSIZE_MAX: u64 = 9223372036854775807;
+pub const WORD_BIT: u32 = 32;
+pub const SIZE_T_MAX: i32 = -1;
+pub const UQUAD_MAX: i32 = -1;
+pub const QUAD_MAX: u64 = 9223372036854775807;
+pub const QUAD_MIN: i64 = -9223372036854775808;
+pub const ARG_MAX: u32 = 1048576;
+pub const CHILD_MAX: u32 = 266;
+pub const GID_MAX: u32 = 2147483647;
+pub const LINK_MAX: u32 = 32767;
+pub const MAX_CANON: u32 = 1024;
+pub const MAX_INPUT: u32 = 1024;
+pub const NAME_MAX: u32 = 255;
+pub const NGROUPS_MAX: u32 = 16;
+pub const UID_MAX: u32 = 2147483647;
+pub const OPEN_MAX: u32 = 10240;
+pub const PATH_MAX: u32 = 1024;
+pub const PIPE_BUF: u32 = 512;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const CHARCLASS_NAME_MAX: u32 = 14;
+pub const COLL_WEIGHTS_MAX: u32 = 2;
+pub const EQUIV_CLASS_MAX: u32 = 2;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 255;
+pub const NZERO: u32 = 20;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_RTSIG_MAX: u32 = 8;
-pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
-pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
-pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
 pub const _POSIX_SSIZE_MAX: u32 = 32767;
 pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_SYMLINK_MAX: u32 = 255;
-pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_TTY_NAME_MAX: u32 = 9;
 pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const NR_OPEN: u32 = 1024;
-pub const NGROUPS_MAX: u32 = 65536;
-pub const ARG_MAX: u32 = 131072;
-pub const LINK_MAX: u32 = 127;
-pub const MAX_CANON: u32 = 255;
-pub const MAX_INPUT: u32 = 255;
-pub const NAME_MAX: u32 = 255;
-pub const PATH_MAX: u32 = 4096;
-pub const PIPE_BUF: u32 = 4096;
-pub const XATTR_NAME_MAX: u32 = 255;
-pub const XATTR_SIZE_MAX: u32 = 65536;
-pub const XATTR_LIST_MAX: u32 = 65536;
-pub const RTSIG_MAX: u32 = 32;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const PTHREAD_KEYS_MAX: u32 = 1024;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const AIO_PRIO_DELTA_MAX: u32 = 20;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const DELAYTIMER_MAX: u32 = 2147483647;
-pub const TTY_NAME_MAX: u32 = 32;
-pub const LOGIN_NAME_MAX: u32 = 256;
-pub const HOST_NAME_MAX: u32 = 64;
-pub const MQ_PRIO_MAX: u32 = 32768;
-pub const SEM_VALUE_MAX: u32 = 2147483647;
-pub const _BITS_POSIX2_LIM_H: u32 = 1;
 pub const _POSIX2_BC_BASE_MAX: u32 = 99;
 pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
 pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
 pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
+pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
 pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
 pub const _POSIX2_LINE_MAX: u32 = 2048;
 pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RTSIG_MAX: u32 = 8;
+pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
+pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
+pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_KEYS_MAX: u32 = 512;
+pub const PTHREAD_STACK_MIN: u32 = 8192;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
+pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SYMLINK_MAX: u32 = 255;
+pub const _POSIX_SYMLOOP_MAX: u32 = 8;
+pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
+pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
+pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
+pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TTY_NAME_MAX: u32 = 9;
 pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const COLL_WEIGHTS_MAX: u32 = 255;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const CHARCLASS_NAME_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 32767;
+pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
+pub const OFF_MIN: i64 = -9223372036854775808;
+pub const OFF_MAX: u64 = 9223372036854775807;
+pub const PASS_MAX: u32 = 128;
+pub const NL_ARGMAX: u32 = 9;
+pub const NL_LANGMAX: u32 = 14;
+pub const NL_MSGMAX: u32 = 32767;
+pub const NL_NMAX: u32 = 1;
+pub const NL_SETMAX: u32 = 255;
+pub const NL_TEXTMAX: u32 = 2048;
+pub const _XOPEN_IOV_MAX: u32 = 16;
+pub const IOV_MAX: u32 = 1024;
+pub const _XOPEN_NAME_MAX: u32 = 255;
+pub const _XOPEN_PATH_MAX: u32 = 1024;
 pub const DSM_IMPL_NONE: u32 = 0;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
@@ -1423,139 +1945,153 @@ pub const AccessExclusiveLock: u32 = 8;
 pub const BITS_PER_BITMAPWORD: u32 = 32;
 pub const RELCACHE_INIT_FILENAME: &'static [u8; 17usize] = b"pg_internal.init\0";
 pub const FIELDNO_HEAPTUPLEDATA_DATA: u32 = 3;
-pub const _FCNTL_H: u32 = 1;
-pub const __O_LARGEFILE: u32 = 0;
-pub const F_GETLK64: u32 = 5;
-pub const F_SETLK64: u32 = 6;
-pub const F_SETLKW64: u32 = 7;
-pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_CREAT: u32 = 64;
-pub const O_EXCL: u32 = 128;
-pub const O_NOCTTY: u32 = 256;
-pub const O_TRUNC: u32 = 512;
-pub const O_APPEND: u32 = 1024;
-pub const O_NONBLOCK: u32 = 2048;
-pub const O_NDELAY: u32 = 2048;
-pub const O_SYNC: u32 = 1052672;
-pub const O_FSYNC: u32 = 1052672;
-pub const O_ASYNC: u32 = 8192;
-pub const __O_DIRECTORY: u32 = 65536;
-pub const __O_NOFOLLOW: u32 = 131072;
-pub const __O_CLOEXEC: u32 = 524288;
-pub const __O_DIRECT: u32 = 16384;
-pub const __O_NOATIME: u32 = 262144;
-pub const __O_PATH: u32 = 2097152;
-pub const __O_DSYNC: u32 = 4096;
-pub const __O_TMPFILE: u32 = 4259840;
-pub const F_GETLK: u32 = 5;
-pub const F_SETLK: u32 = 6;
-pub const F_SETLKW: u32 = 7;
-pub const O_DIRECTORY: u32 = 65536;
-pub const O_NOFOLLOW: u32 = 131072;
-pub const O_CLOEXEC: u32 = 524288;
-pub const O_DSYNC: u32 = 4096;
-pub const O_RSYNC: u32 = 1052672;
+pub const O_ACCMODE: u32 = 3;
+pub const FREAD: u32 = 1;
+pub const FWRITE: u32 = 2;
+pub const O_NONBLOCK: u32 = 4;
+pub const O_APPEND: u32 = 8;
+pub const O_SYNC: u32 = 128;
+pub const O_SHLOCK: u32 = 16;
+pub const O_EXLOCK: u32 = 32;
+pub const O_ASYNC: u32 = 64;
+pub const O_FSYNC: u32 = 128;
+pub const O_NOFOLLOW: u32 = 256;
+pub const O_CREAT: u32 = 512;
+pub const O_TRUNC: u32 = 1024;
+pub const O_EXCL: u32 = 2048;
+pub const O_EVTONLY: u32 = 32768;
+pub const O_NOCTTY: u32 = 131072;
+pub const O_DIRECTORY: u32 = 1048576;
+pub const O_SYMLINK: u32 = 2097152;
+pub const O_DSYNC: u32 = 4194304;
+pub const O_CLOEXEC: u32 = 16777216;
+pub const O_NOFOLLOW_ANY: u32 = 536870912;
+pub const AT_FDCWD: i32 = -2;
+pub const AT_EACCESS: u32 = 16;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
+pub const AT_SYMLINK_FOLLOW: u32 = 64;
+pub const AT_REMOVEDIR: u32 = 128;
+pub const AT_REALDEV: u32 = 512;
+pub const AT_FDONLY: u32 = 1024;
+pub const O_DP_GETRAWENCRYPTED: u32 = 1;
+pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
+pub const FAPPEND: u32 = 8;
+pub const FASYNC: u32 = 64;
+pub const FFSYNC: u32 = 128;
+pub const FFDSYNC: u32 = 4194304;
+pub const FNONBLOCK: u32 = 4;
+pub const FNDELAY: u32 = 4;
+pub const O_NDELAY: u32 = 4;
+pub const CPF_OVERWRITE: u32 = 1;
+pub const CPF_IGNORE_MODE: u32 = 2;
+pub const CPF_MASK: u32 = 3;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const __F_SETOWN: u32 = 8;
-pub const __F_GETOWN: u32 = 9;
-pub const F_SETOWN: u32 = 8;
-pub const F_GETOWN: u32 = 9;
-pub const __F_SETSIG: u32 = 10;
-pub const __F_GETSIG: u32 = 11;
-pub const __F_SETOWN_EX: u32 = 15;
-pub const __F_GETOWN_EX: u32 = 16;
-pub const F_DUPFD_CLOEXEC: u32 = 1030;
+pub const F_GETOWN: u32 = 5;
+pub const F_SETOWN: u32 = 6;
+pub const F_GETLK: u32 = 7;
+pub const F_SETLK: u32 = 8;
+pub const F_SETLKW: u32 = 9;
+pub const F_SETLKWTIMEOUT: u32 = 10;
+pub const F_FLUSH_DATA: u32 = 40;
+pub const F_CHKCLEAN: u32 = 41;
+pub const F_PREALLOCATE: u32 = 42;
+pub const F_SETSIZE: u32 = 43;
+pub const F_RDADVISE: u32 = 44;
+pub const F_RDAHEAD: u32 = 45;
+pub const F_NOCACHE: u32 = 48;
+pub const F_LOG2PHYS: u32 = 49;
+pub const F_GETPATH: u32 = 50;
+pub const F_FULLFSYNC: u32 = 51;
+pub const F_PATHPKG_CHECK: u32 = 52;
+pub const F_FREEZE_FS: u32 = 53;
+pub const F_THAW_FS: u32 = 54;
+pub const F_GLOBAL_NOCACHE: u32 = 55;
+pub const F_ADDSIGS: u32 = 59;
+pub const F_ADDFILESIGS: u32 = 61;
+pub const F_NODIRECT: u32 = 62;
+pub const F_GETPROTECTIONCLASS: u32 = 63;
+pub const F_SETPROTECTIONCLASS: u32 = 64;
+pub const F_LOG2PHYS_EXT: u32 = 65;
+pub const F_GETLKPID: u32 = 66;
+pub const F_SETBACKINGSTORE: u32 = 70;
+pub const F_GETPATH_MTMINFO: u32 = 71;
+pub const F_GETCODEDIR: u32 = 72;
+pub const F_SETNOSIGPIPE: u32 = 73;
+pub const F_GETNOSIGPIPE: u32 = 74;
+pub const F_TRANSCODEKEY: u32 = 75;
+pub const F_SINGLE_WRITER: u32 = 76;
+pub const F_GETPROTECTIONLEVEL: u32 = 77;
+pub const F_FINDSIGS: u32 = 78;
+pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
+pub const F_BARRIERFSYNC: u32 = 85;
+pub const F_ADDFILESIGS_RETURN: u32 = 97;
+pub const F_CHECK_LV: u32 = 98;
+pub const F_PUNCHHOLE: u32 = 99;
+pub const F_TRIM_ACTIVE_FILE: u32 = 100;
+pub const F_SPECULATIVE_READ: u32 = 101;
+pub const F_GETPATH_NOFIRMLINK: u32 = 102;
+pub const F_ADDFILESIGS_INFO: u32 = 103;
+pub const F_ADDFILESUPPL: u32 = 104;
+pub const F_GETSIGSINFO: u32 = 105;
+pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
+pub const F_DUPFD_CLOEXEC: u32 = 67;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 0;
-pub const F_WRLCK: u32 = 1;
+pub const F_RDLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_EXLCK: u32 = 4;
-pub const F_SHLCK: u32 = 8;
+pub const F_WRLCK: u32 = 3;
+pub const SEEK_HOLE: u32 = 3;
+pub const SEEK_DATA: u32 = 4;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_IFWHT: u32 = 57344;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXG: u32 = 56;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXO: u32 = 7;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_ISTXT: u32 = 512;
+pub const S_IREAD: u32 = 256;
+pub const S_IWRITE: u32 = 128;
+pub const S_IEXEC: u32 = 64;
+pub const F_ALLOCATECONTIG: u32 = 2;
+pub const F_ALLOCATEALL: u32 = 4;
+pub const F_PEOFPOSMODE: u32 = 3;
+pub const F_VOLPOSMODE: u32 = 4;
+pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
+pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const FAPPEND: u32 = 1024;
-pub const FFSYNC: u32 = 1052672;
-pub const FASYNC: u32 = 8192;
-pub const FNONBLOCK: u32 = 2048;
-pub const FNDELAY: u32 = 2048;
-pub const __POSIX_FADV_DONTNEED: u32 = 4;
-pub const __POSIX_FADV_NOREUSE: u32 = 5;
-pub const POSIX_FADV_NORMAL: u32 = 0;
-pub const POSIX_FADV_RANDOM: u32 = 1;
-pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
-pub const POSIX_FADV_WILLNEED: u32 = 3;
-pub const POSIX_FADV_DONTNEED: u32 = 4;
-pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const _BITS_STAT_H: u32 = 1;
-pub const _STAT_VER_KERNEL: u32 = 0;
-pub const _STAT_VER_LINUX: u32 = 1;
-pub const _MKNOD_VER_LINUX: u32 = 0;
-pub const _STAT_VER: u32 = 1;
-pub const __S_IFMT: u32 = 61440;
-pub const __S_IFDIR: u32 = 16384;
-pub const __S_IFCHR: u32 = 8192;
-pub const __S_IFBLK: u32 = 24576;
-pub const __S_IFREG: u32 = 32768;
-pub const __S_IFIFO: u32 = 4096;
-pub const __S_IFLNK: u32 = 40960;
-pub const __S_IFSOCK: u32 = 49152;
-pub const __S_ISUID: u32 = 2048;
-pub const __S_ISGID: u32 = 1024;
-pub const __S_ISVTX: u32 = 512;
-pub const __S_IREAD: u32 = 256;
-pub const __S_IWRITE: u32 = 128;
-pub const __S_IEXEC: u32 = 64;
-pub const UTIME_NOW: u32 = 1073741823;
-pub const UTIME_OMIT: u32 = 1073741822;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXG: u32 = 56;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_IRWXO: u32 = 7;
-pub const R_OK: u32 = 4;
-pub const W_OK: u32 = 2;
-pub const X_OK: u32 = 1;
-pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
-pub const F_ULOCK: u32 = 0;
-pub const F_LOCK: u32 = 1;
-pub const F_TLOCK: u32 = 2;
-pub const F_TEST: u32 = 3;
+pub const O_POPUP: u32 = 2147483648;
+pub const O_ALERT: u32 = 536870912;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 1052672;
-pub const OPEN_DATASYNC_FLAG: u32 = 4096;
+pub const OPEN_SYNC_FLAG: u32 = 128;
+pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
 pub const MAX_TIMESTAMP_PRECISION: u32 = 6;
 pub const MAX_INTERVAL_PRECISION: u32 = 6;
 pub const TS_PREC_INV: f64 = 1000000.0;
@@ -1601,24 +2137,8 @@ pub const HEAP_INSERT_SKIP_FSM: u32 = 2;
 pub const HEAP_INSERT_FROZEN: u32 = 4;
 pub const HEAP_INSERT_SPECULATIVE: u32 = 8;
 pub const HEAP_INSERT_NO_LOGICAL: u32 = 16;
-pub const _TIME_H: u32 = 1;
-pub const _BITS_TIME_H: u32 = 1;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_TAI: u32 = 11;
-pub const TIMER_ABSTIME: u32 = 1;
-pub const __struct_tm_defined: u32 = 1;
-pub const __itimerspec_defined: u32 = 1;
+pub const CLOCKS_PER_SEC: u32 = 1000000;
 pub const TIME_UTC: u32 = 1;
-pub const PG_INSTR_CLOCK: u32 = 1;
 pub const PARAM_FLAG_CONST: u32 = 1;
 pub const HASH_PARTITION: u32 = 1;
 pub const HASH_SEGMENT: u32 = 2;
@@ -1635,9 +2155,25 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const _DIRENT_H: u32 = 1;
-pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
+pub const __DARWIN_MAXNAMLEN: u32 = 255;
+pub const __DARWIN_MAXPATHLEN: u32 = 1024;
 pub const MAXNAMLEN: u32 = 255;
+pub const DT_UNKNOWN: u32 = 0;
+pub const DT_FIFO: u32 = 1;
+pub const DT_CHR: u32 = 2;
+pub const DT_DIR: u32 = 4;
+pub const DT_BLK: u32 = 6;
+pub const DT_REG: u32 = 8;
+pub const DT_LNK: u32 = 10;
+pub const DT_SOCK: u32 = 12;
+pub const DT_WHT: u32 = 14;
+pub const DIRBLKSIZ: u32 = 1024;
+pub const DTF_HIDEW: u32 = 1;
+pub const DTF_NODUP: u32 = 2;
+pub const DTF_REWIND: u32 = 4;
+pub const __DTF_READALL: u32 = 8;
+pub const __DTF_SKIPREAD: u32 = 16;
+pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const DEFAULT_SPINS_PER_DELAY: u32 = 100;
@@ -1731,6 +2267,7 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
+pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const GROUPING_CAN_USE_SORT: u32 = 1;
 pub const GROUPING_CAN_USE_HASH: u32 = 2;
@@ -1753,85 +2290,6 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
-pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGILL: u32 = 4;
-pub const SIGABRT: u32 = 6;
-pub const SIGFPE: u32 = 8;
-pub const SIGSEGV: u32 = 11;
-pub const SIGTERM: u32 = 15;
-pub const SIGHUP: u32 = 1;
-pub const SIGQUIT: u32 = 3;
-pub const SIGTRAP: u32 = 5;
-pub const SIGKILL: u32 = 9;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGXCPU: u32 = 24;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
-pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
-pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
-pub const __sig_atomic_t_defined: u32 = 1;
-pub const __siginfo_t_defined: u32 = 1;
-pub const __SI_MAX_SIZE: u32 = 128;
-pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
-pub const __SI_ERRNO_THEN_CODE: u32 = 1;
-pub const __SI_HAVE_SIGSYS: u32 = 1;
-pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
-pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
-pub const __sigevent_t_defined: u32 = 1;
-pub const __SIGEV_MAX_SIZE: u32 = 64;
-pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
-pub const _BITS_SIGACTION_H: u32 = 1;
-pub const SA_NOCLDSTOP: u32 = 1;
-pub const SA_NOCLDWAIT: u32 = 2;
-pub const SA_SIGINFO: u32 = 4;
-pub const SA_ONSTACK: u32 = 134217728;
-pub const SA_RESTART: u32 = 268435456;
-pub const SA_NODEFER: u32 = 1073741824;
-pub const SA_RESETHAND: u32 = 2147483648;
-pub const SA_INTERRUPT: u32 = 536870912;
-pub const SA_NOMASK: u32 = 1073741824;
-pub const SA_ONESHOT: u32 = 2147483648;
-pub const SA_STACK: u32 = 134217728;
-pub const SIG_BLOCK: u32 = 0;
-pub const SIG_UNBLOCK: u32 = 1;
-pub const SIG_SETMASK: u32 = 2;
-pub const _BITS_SIGCONTEXT_H: u32 = 1;
-pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
-pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
-pub const __stack_t_defined: u32 = 1;
-pub const _SYS_UCONTEXT_H: u32 = 1;
-pub const __NGREG: u32 = 23;
-pub const NGREG: u32 = 23;
-pub const _BITS_SIGSTACK_H: u32 = 1;
-pub const MINSIGSTKSZ: u32 = 2048;
-pub const SIGSTKSZ: u32 = 8192;
-pub const _BITS_SS_FLAGS_H: u32 = 1;
-pub const __sigstack_defined: u32 = 1;
-pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -1850,7 +2308,13 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const _SYS_UN_H: u32 = 1;
+pub const SOL_LOCAL: u32 = 0;
+pub const LOCAL_PEERCRED: u32 = 1;
+pub const LOCAL_PEERPID: u32 = 2;
+pub const LOCAL_PEEREPID: u32 = 3;
+pub const LOCAL_PEERUUID: u32 = 4;
+pub const LOCAL_PEEREUUID: u32 = 5;
+pub const LOCAL_PEERTOKEN: u32 = 6;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -2753,6 +3217,7 @@ pub const PROCARRAY_FLAGS_DEFAULT: u32 = 16;
 pub const PROCARRAY_FLAGS_VACUUM: u32 = 18;
 pub const PROCARRAY_FLAGS_ANALYZE: u32 = 20;
 pub const PROCARRAY_FLAGS_VACUUM_ANALYZE: u32 = 22;
+pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &'static [u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -2875,195 +3340,428 @@ pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
 pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
-pub type va_list = __builtin_va_list;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type __u_char = ::std::os::raw::c_uchar;
-pub type __u_short = ::std::os::raw::c_ushort;
-pub type __u_int = ::std::os::raw::c_uint;
-pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_long;
-pub type __uint64_t = ::std::os::raw::c_ulong;
-pub type __int_least8_t = __int8_t;
-pub type __uint_least8_t = __uint8_t;
-pub type __int_least16_t = __int16_t;
-pub type __uint_least16_t = __uint16_t;
-pub type __int_least32_t = __int32_t;
-pub type __uint_least32_t = __uint32_t;
-pub type __int_least64_t = __int64_t;
-pub type __uint_least64_t = __uint64_t;
-pub type __quad_t = ::std::os::raw::c_long;
-pub type __u_quad_t = ::std::os::raw::c_ulong;
-pub type __intmax_t = ::std::os::raw::c_long;
-pub type __uintmax_t = ::std::os::raw::c_ulong;
-pub type __dev_t = ::std::os::raw::c_ulong;
-pub type __uid_t = ::std::os::raw::c_uint;
-pub type __gid_t = ::std::os::raw::c_uint;
-pub type __ino_t = ::std::os::raw::c_ulong;
-pub type __ino64_t = ::std::os::raw::c_ulong;
-pub type __mode_t = ::std::os::raw::c_uint;
-pub type __nlink_t = ::std::os::raw::c_ulong;
-pub type __off_t = ::std::os::raw::c_long;
-pub type __off64_t = ::std::os::raw::c_long;
-pub type __pid_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __fsid_t {
-    pub __val: [::std::os::raw::c_int; 2usize],
-}
-pub type __clock_t = ::std::os::raw::c_long;
-pub type __rlim_t = ::std::os::raw::c_ulong;
-pub type __rlim64_t = ::std::os::raw::c_ulong;
-pub type __id_t = ::std::os::raw::c_uint;
-pub type __time_t = ::std::os::raw::c_long;
-pub type __useconds_t = ::std::os::raw::c_uint;
-pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
-pub type __daddr_t = ::std::os::raw::c_int;
-pub type __key_t = ::std::os::raw::c_int;
-pub type __clockid_t = ::std::os::raw::c_int;
-pub type __timer_t = *mut ::std::os::raw::c_void;
-pub type __blksize_t = ::std::os::raw::c_long;
-pub type __blkcnt_t = ::std::os::raw::c_long;
-pub type __blkcnt64_t = ::std::os::raw::c_long;
-pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
-pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsword_t = ::std::os::raw::c_long;
-pub type __ssize_t = ::std::os::raw::c_long;
-pub type __syscall_slong_t = ::std::os::raw::c_long;
-pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
-pub type __loff_t = __off64_t;
-pub type __caddr_t = *mut ::std::os::raw::c_char;
-pub type __intptr_t = ::std::os::raw::c_long;
-pub type __socklen_t = ::std::os::raw::c_uint;
-pub type __sig_atomic_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_longlong;
+pub type __uint64_t = ::std::os::raw::c_ulonglong;
+pub type __darwin_intptr_t = ::std::os::raw::c_long;
+pub type __darwin_natural_t = ::std::os::raw::c_uint;
+pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct __mbstate_t {
-    pub __count: ::std::os::raw::c_int,
-    pub __value: __mbstate_t__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __mbstate_t__bindgen_ty_1 {
-    pub __wch: ::std::os::raw::c_uint,
-    pub __wchb: [::std::os::raw::c_char; 4usize],
-    _bindgen_union_align: u32,
-}
-impl Default for __mbstate_t__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+pub union __mbstate_t {
+    pub __mbstate8: [::std::os::raw::c_char; 128usize],
+    pub _mbstateL: ::std::os::raw::c_longlong,
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub type __darwin_mbstate_t = __mbstate_t;
+pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
+pub type __darwin_size_t = ::std::os::raw::c_ulong;
+pub type __darwin_va_list = __builtin_va_list;
+pub type __darwin_wchar_t = ::std::os::raw::c_int;
+pub type __darwin_rune_t = __darwin_wchar_t;
+pub type __darwin_wint_t = ::std::os::raw::c_int;
+pub type __darwin_clock_t = ::std::os::raw::c_ulong;
+pub type __darwin_socklen_t = __uint32_t;
+pub type __darwin_ssize_t = ::std::os::raw::c_long;
+pub type __darwin_time_t = ::std::os::raw::c_long;
+pub type __darwin_blkcnt_t = __int64_t;
+pub type __darwin_blksize_t = __int32_t;
+pub type __darwin_dev_t = __int32_t;
+pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_gid_t = __uint32_t;
+pub type __darwin_id_t = __uint32_t;
+pub type __darwin_ino64_t = __uint64_t;
+pub type __darwin_ino_t = __darwin_ino64_t;
+pub type __darwin_mach_port_name_t = __darwin_natural_t;
+pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
+pub type __darwin_mode_t = __uint16_t;
+pub type __darwin_off_t = __int64_t;
+pub type __darwin_pid_t = __int32_t;
+pub type __darwin_sigset_t = __uint32_t;
+pub type __darwin_suseconds_t = __int32_t;
+pub type __darwin_uid_t = __uint32_t;
+pub type __darwin_useconds_t = __uint32_t;
+pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
+pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_pthread_handler_rec {
+    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+    pub __arg: *mut ::std::os::raw::c_void,
+    pub __next: *mut __darwin_pthread_handler_rec,
+}
+impl Default for __darwin_pthread_handler_rec {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _G_fpos_t {
-    pub __pos: __off_t,
-    pub __state: __mbstate_t,
+pub struct _opaque_pthread_attr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
 }
-impl Default for _G_fpos_t {
+impl Default for _opaque_pthread_attr_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _G_fpos64_t {
-    pub __pos: __off64_t,
-    pub __state: __mbstate_t,
+pub struct _opaque_pthread_cond_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 40usize],
 }
-impl Default for _G_fpos64_t {
+impl Default for _opaque_pthread_cond_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __fpos64_t = _G_fpos64_t;
-pub type __FILE = _IO_FILE;
-pub type FILE = _IO_FILE;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_condattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_mutex_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
-    _unused: [u8; 0],
-}
-pub type _IO_lock_t = ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_FILE {
-    pub _flags: ::std::os::raw::c_int,
-    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    pub _IO_read_end: *mut ::std::os::raw::c_char,
-    pub _IO_read_base: *mut ::std::os::raw::c_char,
-    pub _IO_write_base: *mut ::std::os::raw::c_char,
-    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    pub _IO_write_end: *mut ::std::os::raw::c_char,
-    pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    pub _IO_save_base: *mut ::std::os::raw::c_char,
-    pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    pub _IO_save_end: *mut ::std::os::raw::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::std::os::raw::c_int,
-    pub _flags2: ::std::os::raw::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::std::os::raw::c_ushort,
-    pub _vtable_offset: ::std::os::raw::c_schar,
-    pub _shortbuf: [::std::os::raw::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::std::os::raw::c_void,
-    pub __pad5: usize,
-    pub _mode: ::std::os::raw::c_int,
-    pub _unused2: [::std::os::raw::c_char; 20usize],
-}
-impl Default for _IO_FILE {
+impl Default for _opaque_pthread_mutex_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type off_t = __off_t;
-pub type fpos_t = __fpos_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_mutexattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_once_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_rwlock_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 192usize],
+}
+impl Default for _opaque_pthread_rwlock_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_rwlockattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 16usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
+    pub __opaque: [::std::os::raw::c_char; 8176usize],
+}
+impl Default for _opaque_pthread_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
+pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
+pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
+pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
+pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
+pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
+pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
+pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
+pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
+pub type __darwin_pthread_t = *mut _opaque_pthread_t;
+pub type __darwin_nl_item = ::std::os::raw::c_int;
+pub type __darwin_wctrans_t = ::std::os::raw::c_int;
+pub type __darwin_wctype_t = __uint32_t;
+pub type u_int8_t = ::std::os::raw::c_uchar;
+pub type u_int16_t = ::std::os::raw::c_ushort;
+pub type u_int32_t = ::std::os::raw::c_uint;
+pub type u_int64_t = ::std::os::raw::c_ulonglong;
+pub type register_t = i64;
+pub type user_addr_t = u_int64_t;
+pub type user_size_t = u_int64_t;
+pub type user_ssize_t = i64;
+pub type user_long_t = i64;
+pub type user_ulong_t = u_int64_t;
+pub type user_time_t = i64;
+pub type user_off_t = i64;
+pub type syscall_arg_t = u_int64_t;
+pub type va_list = __darwin_va_list;
 #[pg_guard]
 extern "C" {
-    pub static mut stdin: *mut FILE;
+    pub fn renameat(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut stdout: *mut FILE;
+    pub fn renamex_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut stderr: *mut FILE;
+    pub fn renameatx_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fpos_t = __darwin_off_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sbuf {
+    pub _base: *mut ::std::os::raw::c_uchar,
+    pub _size: ::std::os::raw::c_int,
+}
+impl Default for __sbuf {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sFILEX {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sFILE {
+    pub _p: *mut ::std::os::raw::c_uchar,
+    pub _r: ::std::os::raw::c_int,
+    pub _w: ::std::os::raw::c_int,
+    pub _flags: ::std::os::raw::c_short,
+    pub _file: ::std::os::raw::c_short,
+    pub _bf: __sbuf,
+    pub _lbfsize: ::std::os::raw::c_int,
+    pub _cookie: *mut ::std::os::raw::c_void,
+    pub _close: ::std::option::Option<
+        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+    >,
+    pub _read: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: *mut ::std::os::raw::c_char,
+            arg3: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub _seek: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: fpos_t,
+            arg3: ::std::os::raw::c_int,
+        ) -> fpos_t,
+    >,
+    pub _write: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: *const ::std::os::raw::c_char,
+            arg3: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub _ub: __sbuf,
+    pub _extra: *mut __sFILEX,
+    pub _ur: ::std::os::raw::c_int,
+    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
+    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
+    pub _lb: __sbuf,
+    pub _blksize: ::std::os::raw::c_int,
+    pub _offset: fpos_t,
+}
+impl Default for __sFILE {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type FILE = __sFILE;
+#[pg_guard]
+extern "C" {
+    pub static mut __stdinp: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub static mut __stdoutp: *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __stderrp: *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr(arg1: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgets(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __mode: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fprintf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __nitems: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freopen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut FILE,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fscanf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseek(
+        arg1: *mut FILE,
+        arg2: ::std::os::raw::c_long,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __nitems: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn perror(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3074,11 +3772,39 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn renameat(
-        __oldfd: ::std::os::raw::c_int,
-        __old: *const ::std::os::raw::c_char,
-        __newfd: ::std::os::raw::c_int,
-        __new: *const ::std::os::raw::c_char,
+    pub fn rewind(arg1: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setvbuf(
+        arg1: *mut FILE,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sprintf(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sscanf(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3087,275 +3813,89 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tempnam(
-        __dir: *const ::std::os::raw::c_char,
-        __pfx: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freopen(
-        __filename: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
-        __stream: *mut FILE,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
-        -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmemopen(
-        __s: *mut ::std::os::raw::c_void,
-        __len: usize,
-        __modes: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn open_memstream(
-        __bufloc: *mut *mut ::std::os::raw::c_char,
-        __sizeloc: *mut usize,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setvbuf(
-        __stream: *mut FILE,
-        __buf: *mut ::std::os::raw::c_char,
-        __modes: ::std::os::raw::c_int,
-        __n: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setlinebuf(__stream: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn fprintf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vfprintf(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vprintf(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vsprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn snprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __maxlen: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        ...
+    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn popen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __svfscanf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vsnprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __maxlen: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
+    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vdprintf(
-        __fd: ::std::os::raw::c_int,
-        __fmt: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
+    pub fn flockfile(arg1: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn dprintf(
-        __fd: ::std::os::raw::c_int,
-        __fmt: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fscanf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn funlockfile(arg1: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sscanf(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_fscanf"]
-    pub fn fscanf1(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_scanf"]
-    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_sscanf"]
-    pub fn sscanf1(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vfscanf(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vscanf(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsscanf(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vfscanf"]
-    pub fn vfscanf1(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vscanf"]
-    pub fn vscanf1(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vsscanf"]
-    pub fn vsscanf1(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3363,231 +3903,2080 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgets(
-        __s: *mut ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_int,
-        __stream: *mut FILE,
+    pub fn tempnam(
+        __dir: *const ::std::os::raw::c_char,
+        __prefix: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-#[pg_guard]
-extern "C" {
-    pub fn __getdelim(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getdelim(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getline(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __n: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __n: ::std::os::raw::c_ulong,
-        __s: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread_unlocked(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
-        __n: usize,
-        __stream: *mut FILE,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite_unlocked(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: usize,
-        __n: usize,
-        __stream: *mut FILE,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fseek(
-        __stream: *mut FILE,
-        __off: ::std::os::raw::c_long,
-        __whence: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rewind(__stream: *mut FILE);
-}
+pub type off_t = __darwin_off_t;
 #[pg_guard]
 extern "C" {
     pub fn fseeko(
         __stream: *mut FILE,
-        __off: __off_t,
+        __offset: off_t,
         __whence: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> __off_t;
+    pub fn ftello(__stream: *mut FILE) -> off_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+    pub fn snprintf(
+        __str: *mut ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+    pub fn vfscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr(__stream: *mut FILE);
+    pub fn vscanf(
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vsnprintf(
+        __str: *mut ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vsscanf(
+        __str: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr_unlocked(__stream: *mut FILE);
+    pub fn dprintf(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vdprintf(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getdelim(
+        __linep: *mut *mut ::std::os::raw::c_char,
+        __linecapp: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn perror(__s: *const ::std::os::raw::c_char);
+    pub fn getline(
+        __linep: *mut *mut ::std::os::raw::c_char,
+        __linecapp: *mut usize,
+        __stream: *mut FILE,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn popen(
-        __command: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
+    pub fn fmemopen(
+        __buf: *mut ::std::os::raw::c_void,
+        __size: usize,
+        __mode: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn open_memstream(
+        __bufp: *mut *mut ::std::os::raw::c_char,
+        __sizep: *mut usize,
+    ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub static sys_nerr: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn flockfile(__stream: *mut FILE);
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn asprintf(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn funlockfile(__stream: *mut FILE);
+    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn fmtcheck(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *const ::std::os::raw::c_char;
 }
-pub type wchar_t = ::std::os::raw::c_int;
+#[pg_guard]
+extern "C" {
+    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuffer(
+        arg1: *mut FILE,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vasprintf(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn zopen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn funopen(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *mut ::std::os::raw::c_char,
+                arg3: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int,
+        >,
+        arg3: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_char,
+                arg3: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int,
+        >,
+        arg4: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: fpos_t,
+                arg3: ::std::os::raw::c_int,
+            ) -> fpos_t,
+        >,
+        arg5: ::std::option::Option<
+            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+        >,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __snprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+        arg5: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __vsprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __vsnprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+        arg5: *const ::std::os::raw::c_char,
+        arg6: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type pid_t = __darwin_pid_t;
+pub type id_t = __darwin_id_t;
+pub type sig_atomic_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_i386_thread_state {
+    pub __eax: ::std::os::raw::c_uint,
+    pub __ebx: ::std::os::raw::c_uint,
+    pub __ecx: ::std::os::raw::c_uint,
+    pub __edx: ::std::os::raw::c_uint,
+    pub __edi: ::std::os::raw::c_uint,
+    pub __esi: ::std::os::raw::c_uint,
+    pub __ebp: ::std::os::raw::c_uint,
+    pub __esp: ::std::os::raw::c_uint,
+    pub __ss: ::std::os::raw::c_uint,
+    pub __eflags: ::std::os::raw::c_uint,
+    pub __eip: ::std::os::raw::c_uint,
+    pub __cs: ::std::os::raw::c_uint,
+    pub __ds: ::std::os::raw::c_uint,
+    pub __es: ::std::os::raw::c_uint,
+    pub __fs: ::std::os::raw::c_uint,
+    pub __gs: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_fp_control {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+}
+impl __darwin_fp_control {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __pc: ::std::os::raw::c_ushort,
+        __rc: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 2u8, {
+            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
+            __pc as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 2u8, {
+            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
+            __rc as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_control_t = __darwin_fp_control;
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_fp_status {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+}
+impl __darwin_fp_status {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(6usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(9usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
+    }
+    #[inline]
+    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(11usize, 3u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(14usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(15usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __stkflt: ::std::os::raw::c_ushort,
+        __errsumm: ::std::os::raw::c_ushort,
+        __c0: ::std::os::raw::c_ushort,
+        __c1: ::std::os::raw::c_ushort,
+        __c2: ::std::os::raw::c_ushort,
+        __tos: ::std::os::raw::c_ushort,
+        __c3: ::std::os::raw::c_ushort,
+        __busy: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(6usize, 1u8, {
+            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
+            __stkflt as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
+            __errsumm as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 1u8, {
+            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
+            __c0 as u64
+        });
+        __bindgen_bitfield_unit.set(9usize, 1u8, {
+            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
+            __c1 as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 1u8, {
+            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
+            __c2 as u64
+        });
+        __bindgen_bitfield_unit.set(11usize, 3u8, {
+            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
+            __tos as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 1u8, {
+            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
+            __c3 as u64
+        });
+        __bindgen_bitfield_unit.set(15usize, 1u8, {
+            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
+            __busy as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_status_t = __darwin_fp_status;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_mmst_reg {
+    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
+    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_xmm_reg {
+    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_ymm_reg {
+    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_zmm_reg {
+    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
+}
+impl Default for __darwin_zmm_reg {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_opmask_reg {
+    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_float_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+impl Default for __darwin_i386_float_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_avx_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+}
+impl Default for __darwin_i386_avx_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_avx512_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+}
+impl Default for __darwin_i386_avx512_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_i386_exception_state {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_debug_state32 {
+    pub __dr0: ::std::os::raw::c_uint,
+    pub __dr1: ::std::os::raw::c_uint,
+    pub __dr2: ::std::os::raw::c_uint,
+    pub __dr3: ::std::os::raw::c_uint,
+    pub __dr4: ::std::os::raw::c_uint,
+    pub __dr5: ::std::os::raw::c_uint,
+    pub __dr6: ::std::os::raw::c_uint,
+    pub __dr7: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __x86_instruction_state {
+    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
+    pub __insn_offset: ::std::os::raw::c_int,
+    pub __out_of_synch: ::std::os::raw::c_int,
+    pub __insn_bytes: [__uint8_t; 2380usize],
+    pub __insn_cacheline: [__uint8_t; 64usize],
+}
+impl Default for __x86_instruction_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __last_branch_record {
+    pub __from_ip: __uint64_t,
+    pub __to_ip: __uint64_t,
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __bindgen_padding_0: u32,
+}
+impl __last_branch_record {
+    #[inline]
+    pub fn __mispredict(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___mispredict(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tsx_abort(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __in_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___in_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set___cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(19usize, 13u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __mispredict: __uint32_t,
+        __tsx_abort: __uint32_t,
+        __in_tsx: __uint32_t,
+        __cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
+            __mispredict as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
+            __tsx_abort as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
+            __in_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 16u8, {
+            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
+            __cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(19usize, 13u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __last_branch_state {
+    pub __lbr_count: ::std::os::raw::c_int,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __lbrs: [__last_branch_record; 32usize],
+}
+impl __last_branch_state {
+    #[inline]
+    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 30u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __lbr_supported_tsx: __uint32_t,
+        __lbr_supported_cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
+            __lbr_supported_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __lbr_supported_cycle_count: u32 =
+                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
+            __lbr_supported_cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 30u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __x86_pagein_state {
+    pub __pagein_error: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_thread_state64 {
+    pub __rax: __uint64_t,
+    pub __rbx: __uint64_t,
+    pub __rcx: __uint64_t,
+    pub __rdx: __uint64_t,
+    pub __rdi: __uint64_t,
+    pub __rsi: __uint64_t,
+    pub __rbp: __uint64_t,
+    pub __rsp: __uint64_t,
+    pub __r8: __uint64_t,
+    pub __r9: __uint64_t,
+    pub __r10: __uint64_t,
+    pub __r11: __uint64_t,
+    pub __r12: __uint64_t,
+    pub __r13: __uint64_t,
+    pub __r14: __uint64_t,
+    pub __r15: __uint64_t,
+    pub __rip: __uint64_t,
+    pub __rflags: __uint64_t,
+    pub __cs: __uint64_t,
+    pub __fs: __uint64_t,
+    pub __gs: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_thread_full_state64 {
+    pub __ss64: __darwin_x86_thread_state64,
+    pub __ds: __uint64_t,
+    pub __es: __uint64_t,
+    pub __ss: __uint64_t,
+    pub __gsbase: __uint64_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_float_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+impl Default for __darwin_x86_float_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_avx_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+}
+impl Default for __darwin_x86_avx_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_avx512_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+    pub __fpu_zmmh8: __darwin_ymm_reg,
+    pub __fpu_zmmh9: __darwin_ymm_reg,
+    pub __fpu_zmmh10: __darwin_ymm_reg,
+    pub __fpu_zmmh11: __darwin_ymm_reg,
+    pub __fpu_zmmh12: __darwin_ymm_reg,
+    pub __fpu_zmmh13: __darwin_ymm_reg,
+    pub __fpu_zmmh14: __darwin_ymm_reg,
+    pub __fpu_zmmh15: __darwin_ymm_reg,
+    pub __fpu_zmm16: __darwin_zmm_reg,
+    pub __fpu_zmm17: __darwin_zmm_reg,
+    pub __fpu_zmm18: __darwin_zmm_reg,
+    pub __fpu_zmm19: __darwin_zmm_reg,
+    pub __fpu_zmm20: __darwin_zmm_reg,
+    pub __fpu_zmm21: __darwin_zmm_reg,
+    pub __fpu_zmm22: __darwin_zmm_reg,
+    pub __fpu_zmm23: __darwin_zmm_reg,
+    pub __fpu_zmm24: __darwin_zmm_reg,
+    pub __fpu_zmm25: __darwin_zmm_reg,
+    pub __fpu_zmm26: __darwin_zmm_reg,
+    pub __fpu_zmm27: __darwin_zmm_reg,
+    pub __fpu_zmm28: __darwin_zmm_reg,
+    pub __fpu_zmm29: __darwin_zmm_reg,
+    pub __fpu_zmm30: __darwin_zmm_reg,
+    pub __fpu_zmm31: __darwin_zmm_reg,
+}
+impl Default for __darwin_x86_avx512_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_exception_state64 {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_debug_state64 {
+    pub __dr0: __uint64_t,
+    pub __dr1: __uint64_t,
+    pub __dr2: __uint64_t,
+    pub __dr3: __uint64_t,
+    pub __dr4: __uint64_t,
+    pub __dr5: __uint64_t,
+    pub __dr6: __uint64_t,
+    pub __dr7: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_cpmu_state64 {
+    pub __ctrs: [__uint64_t; 16usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_float_state,
+}
+impl Default for __darwin_mcontext32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx_state,
+}
+impl Default for __darwin_mcontext_avx32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx512_state,
+}
+impl Default for __darwin_mcontext_avx512_32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+impl Default for __darwin_mcontext64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+impl Default for __darwin_mcontext64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+impl Default for __darwin_mcontext_avx64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+impl Default for __darwin_mcontext_avx64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+impl Default for __darwin_mcontext_avx512_64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+impl Default for __darwin_mcontext_avx512_64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type mcontext_t = *mut __darwin_mcontext64;
+pub type pthread_attr_t = __darwin_pthread_attr_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_sigaltstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_size: __darwin_size_t,
+    pub ss_flags: ::std::os::raw::c_int,
+}
+impl Default for __darwin_sigaltstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type stack_t = __darwin_sigaltstack;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_ucontext {
+    pub uc_onstack: ::std::os::raw::c_int,
+    pub uc_sigmask: __darwin_sigset_t,
+    pub uc_stack: __darwin_sigaltstack,
+    pub uc_link: *mut __darwin_ucontext,
+    pub uc_mcsize: __darwin_size_t,
+    pub uc_mcontext: *mut __darwin_mcontext64,
+}
+impl Default for __darwin_ucontext {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type ucontext_t = __darwin_ucontext;
+pub type sigset_t = __darwin_sigset_t;
+pub type uid_t = __darwin_uid_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
+}
+impl Default for sigval {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_value: sigval,
+    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
+    pub sigev_notify_attributes: *mut pthread_attr_t,
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __siginfo {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub si_pid: pid_t,
+    pub si_uid: uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_value: sigval,
+    pub si_band: ::std::os::raw::c_long,
+    pub __pad: [::std::os::raw::c_ulong; 7usize],
+}
+impl Default for __siginfo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type siginfo_t = __siginfo;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __sigaction_u {
+    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub __sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut __siginfo,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for __sigaction_u {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __sigaction {
+    pub __sigaction_u: __sigaction_u,
+    pub sa_tramp: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: ::std::os::raw::c_int,
+            arg3: ::std::os::raw::c_int,
+            arg4: *mut siginfo_t,
+            arg5: *mut ::std::os::raw::c_void,
+        ),
+    >,
+    pub sa_mask: sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+}
+impl Default for __sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_u: __sigaction_u,
+    pub sa_mask: sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sigvec {
+    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub sv_mask: ::std::os::raw::c_int,
+    pub sv_flags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_char,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn signal(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+        ),
+    >;
+}
+pub type int_least8_t = i8;
+pub type int_least16_t = i16;
+pub type int_least32_t = i32;
+pub type int_least64_t = i64;
+pub type uint_least8_t = u8;
+pub type uint_least16_t = u16;
+pub type uint_least32_t = u32;
+pub type uint_least64_t = u64;
+pub type int_fast8_t = i8;
+pub type int_fast16_t = i16;
+pub type int_fast32_t = i32;
+pub type int_fast64_t = i64;
+pub type uint_fast8_t = u8;
+pub type uint_fast16_t = u16;
+pub type uint_fast32_t = u32;
+pub type uint_fast64_t = u64;
+pub type intmax_t = ::std::os::raw::c_long;
+pub type uintmax_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __darwin_time_t,
+    pub tv_usec: __darwin_suseconds_t,
+}
+pub type rlim_t = __uint64_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage {
+    pub ru_utime: timeval,
+    pub ru_stime: timeval,
+    pub ru_maxrss: ::std::os::raw::c_long,
+    pub ru_ixrss: ::std::os::raw::c_long,
+    pub ru_idrss: ::std::os::raw::c_long,
+    pub ru_isrss: ::std::os::raw::c_long,
+    pub ru_minflt: ::std::os::raw::c_long,
+    pub ru_majflt: ::std::os::raw::c_long,
+    pub ru_nswap: ::std::os::raw::c_long,
+    pub ru_inblock: ::std::os::raw::c_long,
+    pub ru_oublock: ::std::os::raw::c_long,
+    pub ru_msgsnd: ::std::os::raw::c_long,
+    pub ru_msgrcv: ::std::os::raw::c_long,
+    pub ru_nsignals: ::std::os::raw::c_long,
+    pub ru_nvcsw: ::std::os::raw::c_long,
+    pub ru_nivcsw: ::std::os::raw::c_long,
+}
+pub type rusage_info_t = *mut ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v0 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v1 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v2 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v3 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v4 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v5 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+    pub ri_flags: u64,
+}
+pub type rusage_info_current = rusage_info_v5;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rlimit {
+    pub rlim_cur: rlim_t,
+    pub rlim_max: rlim_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct proc_rlimit_control_wakeupmon {
+    pub wm_flags: u32,
+    pub wm_rate: i32,
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getiopolicy_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setpriority(
+        arg1: ::std::os::raw::c_int,
+        arg2: id_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setiopolicy_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union wait {
+    pub w_status: ::std::os::raw::c_int,
+    pub w_T: wait__bindgen_ty_1,
+    pub w_S: wait__bindgen_ty_2,
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct wait__bindgen_ty_1 {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+impl wait__bindgen_ty_1 {
+    #[inline]
+    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 7u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        w_Termsig: ::std::os::raw::c_uint,
+        w_Coredump: ::std::os::raw::c_uint,
+        w_Retcode: ::std::os::raw::c_uint,
+        w_Filler: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 7u8, {
+            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
+            w_Termsig as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
+            w_Coredump as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 8u8, {
+            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
+            w_Retcode as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
+            w_Filler as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct wait__bindgen_ty_2 {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+impl wait__bindgen_ty_2 {
+    #[inline]
+    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        w_Stopval: ::std::os::raw::c_uint,
+        w_Stopsig: ::std::os::raw::c_uint,
+        w_Filler: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 8u8, {
+            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
+            w_Stopval as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 8u8, {
+            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
+            w_Stopsig as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
+            w_Filler as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+impl Default for wait {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn waitpid(
+        arg1: pid_t,
+        arg2: *mut ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn waitid(
+        arg1: idtype_t,
+        arg2: id_t,
+        arg3: *mut siginfo_t,
+        arg4: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait3(
+        arg1: *mut ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut rusage,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait4(
+        arg1: pid_t,
+        arg2: *mut ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut rusage,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+}
+pub type ct_rune_t = __darwin_ct_rune_t;
+pub type rune_t = __darwin_rune_t;
+pub type wchar_t = __darwin_wchar_t;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -3608,595 +5997,7 @@ pub struct lldiv_t {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_get_mb_cur_max() -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtod(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtof(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtold(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtol(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoul(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoq(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtouq(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoll(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoull(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-pub type u_char = __u_char;
-pub type u_short = __u_short;
-pub type u_int = __u_int;
-pub type u_long = __u_long;
-pub type quad_t = __quad_t;
-pub type u_quad_t = __u_quad_t;
-pub type fsid_t = __fsid_t;
-pub type loff_t = __loff_t;
-pub type ino_t = __ino_t;
-pub type dev_t = __dev_t;
-pub type gid_t = __gid_t;
-pub type mode_t = __mode_t;
-pub type nlink_t = __nlink_t;
-pub type uid_t = __uid_t;
-pub type pid_t = __pid_t;
-pub type id_t = __id_t;
-pub type daddr_t = __daddr_t;
-pub type caddr_t = __caddr_t;
-pub type key_t = __key_t;
-pub type clock_t = __clock_t;
-pub type clockid_t = __clockid_t;
-pub type time_t = __time_t;
-pub type timer_t = __timer_t;
-pub type ulong = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_int8_t = __uint8_t;
-pub type u_int16_t = __uint16_t;
-pub type u_int32_t = __uint32_t;
-pub type u_int64_t = __uint64_t;
-pub type register_t = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sigset_t {
-    pub __val: [::std::os::raw::c_ulong; 16usize],
-}
-pub type sigset_t = __sigset_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __time_t,
-    pub tv_usec: __suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __time_t,
-    pub tv_nsec: __syscall_slong_t,
-}
-pub type suseconds_t = __suseconds_t;
-pub type __fd_mask = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub __fds_bits: [__fd_mask; 16usize],
-}
-pub type fd_mask = __fd_mask;
-#[pg_guard]
-extern "C" {
-    pub fn select(
-        __nfds: ::std::os::raw::c_int,
-        __readfds: *mut fd_set,
-        __writefds: *mut fd_set,
-        __exceptfds: *mut fd_set,
-        __timeout: *mut timeval,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pselect(
-        __nfds: ::std::os::raw::c_int,
-        __readfds: *mut fd_set,
-        __writefds: *mut fd_set,
-        __exceptfds: *mut fd_set,
-        __timeout: *const timespec,
-        __sigmask: *const __sigset_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type blksize_t = __blksize_t;
-pub type blkcnt_t = __blkcnt_t;
-pub type fsblkcnt_t = __fsblkcnt_t;
-pub type fsfilcnt_t = __fsfilcnt_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_internal_list {
-    pub __prev: *mut __pthread_internal_list,
-    pub __next: *mut __pthread_internal_list,
-}
-impl Default for __pthread_internal_list {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __pthread_list_t = __pthread_internal_list;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_internal_slist {
-    pub __next: *mut __pthread_internal_slist,
-}
-impl Default for __pthread_internal_slist {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __pthread_slist_t = __pthread_internal_slist;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_mutex_s {
-    pub __lock: ::std::os::raw::c_int,
-    pub __count: ::std::os::raw::c_uint,
-    pub __owner: ::std::os::raw::c_int,
-    pub __nusers: ::std::os::raw::c_uint,
-    pub __kind: ::std::os::raw::c_int,
-    pub __spins: ::std::os::raw::c_short,
-    pub __elision: ::std::os::raw::c_short,
-    pub __list: __pthread_list_t,
-}
-impl Default for __pthread_mutex_s {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_rwlock_arch_t {
-    pub __readers: ::std::os::raw::c_uint,
-    pub __writers: ::std::os::raw::c_uint,
-    pub __wrphase_futex: ::std::os::raw::c_uint,
-    pub __writers_futex: ::std::os::raw::c_uint,
-    pub __pad3: ::std::os::raw::c_uint,
-    pub __pad4: ::std::os::raw::c_uint,
-    pub __cur_writer: ::std::os::raw::c_int,
-    pub __shared: ::std::os::raw::c_int,
-    pub __rwelision: ::std::os::raw::c_schar,
-    pub __pad1: [::std::os::raw::c_uchar; 7usize],
-    pub __pad2: ::std::os::raw::c_ulong,
-    pub __flags: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __pthread_cond_s {
-    pub __bindgen_anon_1: __pthread_cond_s__bindgen_ty_1,
-    pub __bindgen_anon_2: __pthread_cond_s__bindgen_ty_2,
-    pub __g_refs: [::std::os::raw::c_uint; 2usize],
-    pub __g_size: [::std::os::raw::c_uint; 2usize],
-    pub __g1_orig_size: ::std::os::raw::c_uint,
-    pub __wrefs: ::std::os::raw::c_uint,
-    pub __g_signals: [::std::os::raw::c_uint; 2usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __pthread_cond_s__bindgen_ty_1 {
-    pub __wseq: ::std::os::raw::c_ulonglong,
-    pub __wseq32: __pthread_cond_s__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_cond_s__bindgen_ty_1__bindgen_ty_1 {
-    pub __low: ::std::os::raw::c_uint,
-    pub __high: ::std::os::raw::c_uint,
-}
-impl Default for __pthread_cond_s__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __pthread_cond_s__bindgen_ty_2 {
-    pub __g1_start: ::std::os::raw::c_ulonglong,
-    pub __g1_start32: __pthread_cond_s__bindgen_ty_2__bindgen_ty_1,
-    _bindgen_union_align: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_cond_s__bindgen_ty_2__bindgen_ty_1 {
-    pub __low: ::std::os::raw::c_uint,
-    pub __high: ::std::os::raw::c_uint,
-}
-impl Default for __pthread_cond_s__bindgen_ty_2 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for __pthread_cond_s {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
-}
-pub type pthread_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_mutexattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_mutexattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_condattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_condattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type pthread_key_t = ::std::os::raw::c_uint;
-pub type pthread_once_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_attr_t {
-    pub __size: [::std::os::raw::c_char; 56usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 7usize],
-}
-impl Default for pthread_attr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_mutex_t {
-    pub __data: __pthread_mutex_s,
-    pub __size: [::std::os::raw::c_char; 40usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 5usize],
-}
-impl Default for pthread_mutex_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_cond_t {
-    pub __data: __pthread_cond_s,
-    pub __size: [::std::os::raw::c_char; 48usize],
-    pub __align: ::std::os::raw::c_longlong,
-    _bindgen_union_align: [u64; 6usize],
-}
-impl Default for pthread_cond_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_rwlock_t {
-    pub __data: __pthread_rwlock_arch_t,
-    pub __size: [::std::os::raw::c_char; 56usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 7usize],
-}
-impl Default for pthread_rwlock_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_rwlockattr_t {
-    pub __size: [::std::os::raw::c_char; 8usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: u64,
-}
-impl Default for pthread_rwlockattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type pthread_spinlock_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_barrier_t {
-    pub __size: [::std::os::raw::c_char; 32usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 4usize],
-}
-impl Default for pthread_barrier_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_barrierattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_barrierattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom(__seed: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn initstate(
-        __seed: ::std::os::raw::c_uint,
-        __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct random_data {
-    pub fptr: *mut i32,
-    pub rptr: *mut i32,
-    pub state: *mut i32,
-    pub rand_type: ::std::os::raw::c_int,
-    pub rand_deg: ::std::os::raw::c_int,
-    pub rand_sep: ::std::os::raw::c_int,
-    pub end_ptr: *mut i32,
-}
-impl Default for random_data {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom_r(
-        __seed: ::std::os::raw::c_uint,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn initstate_r(
-        __seed: ::std::os::raw::c_uint,
-        __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: usize,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate_r(
-        __statebuf: *mut ::std::os::raw::c_char,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand(__seed: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48(__seedval: ::std::os::raw::c_long);
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct drand48_data {
-    pub __x: [::std::os::raw::c_ushort; 3usize],
-    pub __old_x: [::std::os::raw::c_ushort; 3usize],
-    pub __c: ::std::os::raw::c_ushort,
-    pub __init: ::std::os::raw::c_ushort,
-    pub __a: ::std::os::raw::c_ulonglong,
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut f64,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48_r(
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48_r(
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48_r(
-        __seedval: ::std::os::raw::c_long,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48_r(
-        __seed16v: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48_r(
-        __param: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
+    pub static mut __mb_cur_max: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -4205,9 +6006,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn calloc(
-        __nmemb: ::std::os::raw::c_ulong,
+        __count: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4218,23 +6023,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn reallocarray(
-        __ptr: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
-    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -4246,247 +6039,74 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
     pub fn abort();
 }
 #[pg_guard]
 extern "C" {
-    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn at_quick_exit(
-        __func: ::std::option::Option<unsafe extern "C" fn()>,
-    ) -> ::std::os::raw::c_int;
+    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn on_exit(
-        __func: ::std::option::Option<
-            unsafe extern "C" fn(
-                __status: ::std::os::raw::c_int,
-                __arg: *mut ::std::os::raw::c_void,
-            ),
-        >,
-        __arg: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
+    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exit(__status: ::std::os::raw::c_int);
+    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn quick_exit(__status: ::std::os::raw::c_int);
+    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _Exit(__status: ::std::os::raw::c_int);
+    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
 }
-#[pg_guard]
-extern "C" {
-    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __replace: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn clearenv() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemps(
-        __template: *mut ::std::os::raw::c_char,
-        __suffixlen: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn realpath(
-        __name: *const ::std::os::raw::c_char,
-        __resolved: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-pub type __compar_fn_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int,
->;
 #[pg_guard]
 extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-        __compar: __compar_fn_t,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-        __compar: __compar_fn_t,
-    );
+    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn exit(arg1: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
+    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
+    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lldiv(
-        __numer: ::std::os::raw::c_longlong,
-        __denom: ::std::os::raw::c_longlong,
-    ) -> lldiv_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gcvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qecvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qfcvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qgcvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt_r(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt_r(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qecvt_r(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qfcvt_r(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
 }
 #[pg_guard]
 extern "C" {
@@ -4494,70 +6114,594 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
     pub fn mbtowc(
-        __pwc: *mut wchar_t,
-        __s: *const ::std::os::raw::c_char,
-        __n: usize,
+        arg1: *mut wchar_t,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn rand() -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
+    pub fn srand(arg1: ::std::os::raw::c_uint);
 }
 #[pg_guard]
 extern "C" {
-    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn strtod(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtof(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtol(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtold(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoll(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoul(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoull(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _Exit(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gcvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn getsubopt(
-        __optionp: *mut *mut ::std::os::raw::c_char,
-        __tokens: *const *mut ::std::os::raw::c_char,
-        __valuep: *mut *mut ::std::os::raw::c_char,
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const *mut ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
+    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memcpy(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+    pub fn initstate(
+        arg1: ::std::os::raw::c_uint,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ptsname_r(
+        fildes: ::std::os::raw::c_int,
+        buffer: *mut ::std::os::raw::c_char,
+        buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn random() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
+    pub fn realpath(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setenv(
+        __name: *const ::std::os::raw::c_char,
+        __value: *const ::std::os::raw::c_char,
+        __overwrite: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setkey(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48(arg1: ::std::os::raw::c_long);
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom(arg1: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+pub type dev_t = __darwin_dev_t;
+pub type mode_t = __darwin_mode_t;
+#[pg_guard]
+extern "C" {
+    pub fn arc4random() -> u32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_stir();
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bsearch_b(
+        __key: *const ::std::os::raw::c_void,
+        __base: *const ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmove(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+    pub fn cgetcap(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetclose() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetent(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+        arg3: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetfirst(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetmatch(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetnext(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetnum(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetstr(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetustr(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_daemon$1050"]
+    pub fn daemon(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn devname_r(
+        arg1: dev_t,
+        arg2: mode_t,
+        buf: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getbsize(
+        arg1: *mut ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_long,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprogname() -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn heapsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn heapsort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mergesort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mergesort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort_r(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        arg1: *mut ::std::os::raw::c_void,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+                arg3: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn qsort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn qsort_r(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        arg1: *mut ::std::os::raw::c_void,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+                arg3: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn radixsort(
+        __base: *mut *const ::std::os::raw::c_uchar,
+        __nel: ::std::os::raw::c_int,
+        __table: *const ::std::os::raw::c_uchar,
+        __endbyte: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sradixsort(
+        __base: *mut *const ::std::os::raw::c_uchar,
+        __nel: ::std::os::raw::c_int,
+        __table: *const ::std::os::raw::c_uchar,
+        __endbyte: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sranddev();
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandomdev();
+}
+#[pg_guard]
+extern "C" {
+    pub fn reallocf(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memccpy(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __n: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn strtonum(
+        __numstr: *const ::std::os::raw::c_char,
+        __minval: ::std::os::raw::c_longlong,
+        __maxval: ::std::os::raw::c_longlong,
+        __errstrp: *mut *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memset(
-        __s: *mut ::std::os::raw::c_void,
+    pub fn strtoq(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtouq(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut suboptarg: *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -4572,114 +6716,33 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
+    pub fn memcpy(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn memmove(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __len: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn memset(
+        __b: *mut ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __len: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
     pub fn strcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcmp(
-        __s1: *const ::std::os::raw::c_char,
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncmp(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strxfrm(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __locale_struct {
-    pub __locales: [*mut __locale_data; 13usize],
-    pub __ctype_b: *const ::std::os::raw::c_ushort,
-    pub __ctype_tolower: *const ::std::os::raw::c_int,
-    pub __ctype_toupper: *const ::std::os::raw::c_int,
-    pub __names: [*const ::std::os::raw::c_char; 13usize],
-}
-impl Default for __locale_struct {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __locale_t = *mut __locale_struct;
-pub type locale_t = __locale_t;
-#[pg_guard]
-extern "C" {
-    pub fn strcoll_l(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __l: locale_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strxfrm_l(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: usize,
-        __l: locale_t,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strndup(
-        __string: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -4691,69 +6754,31 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strrchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strcmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strcspn(
         __s: *const ::std::os::raw::c_char,
-        __reject: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strspn(
-        __s: *const ::std::os::raw::c_char,
-        __accept: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strpbrk(
-        __s: *const ::std::os::raw::c_char,
-        __accept: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strstr(
-        __haystack: *const ::std::os::raw::c_char,
-        __needle: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtok(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __strtok_r(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-        __save_ptr: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtok_r(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-        __save_ptr: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
@@ -4761,76 +6786,19 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}__xpg_strerror_r"]
-    pub fn strerror_r(
-        __errnum: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strerror_l(
-        __errnum: ::std::os::raw::c_int,
-        __l: locale_t,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcmp(
-        __s1: *const ::std::os::raw::c_void,
-        __s2: *const ::std::os::raw::c_void,
-        __n: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcopy(
-        __src: *const ::std::os::raw::c_void,
-        __dest: *mut ::std::os::raw::c_void,
-        __n: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
-}
-#[pg_guard]
-extern "C" {
-    pub fn index(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rindex(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcasecmp(
-        __s1: *const ::std::os::raw::c_char,
+    pub fn strncat(
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncasecmp(
+    pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
@@ -4838,24 +6806,192 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcasecmp_l(
-        __s1: *const ::std::os::raw::c_char,
+    pub fn strncpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strrchr(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strstr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtok(
+        __str: *mut ::std::os::raw::c_char,
+        __sep: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm(
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-        __loc: locale_t,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtok_r(
+        __str: *mut ::std::os::raw::c_char,
+        __sep: *const ::std::os::raw::c_char,
+        __lasts: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strerror_r(
+        __errnum: ::std::os::raw::c_int,
+        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncasecmp_l(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: usize,
-        __loc: locale_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+    pub fn memccpy(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn stpcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn stpncpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strndup(
+        __s1: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+pub type rsize_t = __darwin_size_t;
+pub type errno_t = ::std::os::raw::c_int;
+#[pg_guard]
+extern "C" {
+    pub fn memset_s(
+        __s: *mut ::std::os::raw::c_void,
+        __smax: rsize_t,
+        __c: ::std::os::raw::c_int,
+        __n: rsize_t,
+    ) -> errno_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memmem(
+        __big: *const ::std::os::raw::c_void,
+        __big_len: usize,
+        __little: *const ::std::os::raw::c_void,
+        __little_len: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern4(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern4: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern8(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern8: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern16(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern16: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcasestr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnstr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+        __len: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dst: *mut ::std::os::raw::c_char,
+        __source: *const ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __source: *const ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
@@ -4866,67 +7002,158 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+    pub fn swab(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: isize,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn __stpcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
+    pub fn timingsafe_bcmp(
+        __b1: *const ::std::os::raw::c_void,
+        __b2: *const ::std::os::raw::c_void,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strsignal_r(
+        __sig: ::std::os::raw::c_int,
+        __strsignalbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcmp(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcopy(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
+}
+#[pg_guard]
+extern "C" {
+    pub fn index(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
+    pub fn rindex(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __stpncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: usize,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn strcasecmp(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
 }
+#[pg_guard]
+extern "C" {
+    pub fn strncasecmp(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+pub type max_align_t = u128;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type u_char = ::std::os::raw::c_uchar;
+pub type u_short = ::std::os::raw::c_ushort;
+pub type u_int = ::std::os::raw::c_uint;
+pub type u_long = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_quad_t = u_int64_t;
+pub type quad_t = i64;
+pub type qaddr_t = *mut quad_t;
+pub type caddr_t = *mut ::std::os::raw::c_char;
+pub type daddr_t = i32;
+pub type fixpt_t = u_int32_t;
+pub type blkcnt_t = __darwin_blkcnt_t;
+pub type blksize_t = __darwin_blksize_t;
+pub type gid_t = __darwin_gid_t;
+pub type in_addr_t = __uint32_t;
+pub type in_port_t = __uint16_t;
+pub type ino_t = __darwin_ino_t;
+pub type ino64_t = __darwin_ino64_t;
+pub type key_t = __int32_t;
+pub type nlink_t = __uint16_t;
+pub type segsz_t = i32;
+pub type swblk_t = i32;
+pub type clock_t = __darwin_clock_t;
+pub type time_t = __darwin_time_t;
+pub type useconds_t = __darwin_useconds_t;
+pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
-#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct max_align_t {
-    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
-    pub __bindgen_padding_0: u64,
-    pub __clang_max_align_nonce2: u128,
+pub struct fd_set {
+    pub fds_bits: [__int32_t; 32usize],
 }
-pub type int_least8_t = __int_least8_t;
-pub type int_least16_t = __int_least16_t;
-pub type int_least32_t = __int_least32_t;
-pub type int_least64_t = __int_least64_t;
-pub type uint_least8_t = __uint_least8_t;
-pub type uint_least16_t = __uint_least16_t;
-pub type uint_least32_t = __uint_least32_t;
-pub type uint_least64_t = __uint_least64_t;
-pub type int_fast8_t = ::std::os::raw::c_schar;
-pub type int_fast16_t = ::std::os::raw::c_long;
-pub type int_fast32_t = ::std::os::raw::c_long;
-pub type int_fast64_t = ::std::os::raw::c_long;
-pub type uint_fast8_t = ::std::os::raw::c_uchar;
-pub type uint_fast16_t = ::std::os::raw::c_ulong;
-pub type uint_fast32_t = ::std::os::raw::c_ulong;
-pub type uint_fast64_t = ::std::os::raw::c_ulong;
-pub type intmax_t = __intmax_t;
-pub type uintmax_t = __uintmax_t;
 #[pg_guard]
 extern "C" {
-    pub fn __errno_location() -> *mut ::std::os::raw::c_int;
+    pub fn __darwin_check_fd_set_overflow(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fd_mask = __int32_t;
+pub type pthread_cond_t = __darwin_pthread_cond_t;
+pub type pthread_condattr_t = __darwin_pthread_condattr_t;
+pub type pthread_mutex_t = __darwin_pthread_mutex_t;
+pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
+pub type pthread_once_t = __darwin_pthread_once_t;
+pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
+pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
+pub type pthread_t = __darwin_pthread_t;
+pub type pthread_key_t = __darwin_pthread_key_t;
+pub type fsblkcnt_t = __darwin_fsblkcnt_t;
+pub type fsfilcnt_t = __darwin_fsfilcnt_t;
+#[pg_guard]
+extern "C" {
+    pub fn __error() -> *mut ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -4950,8 +7177,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_p_sep_by_space: ::std::os::raw::c_char,
     pub int_n_cs_precedes: ::std::os::raw::c_char,
+    pub int_p_sep_by_space: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -4963,34 +7190,14 @@ impl Default for lconv {
 }
 #[pg_guard]
 extern "C" {
-    pub fn setlocale(
-        __category: ::std::os::raw::c_int,
-        __locale: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
     pub fn localeconv() -> *mut lconv;
 }
 #[pg_guard]
 extern "C" {
-    pub fn newlocale(
-        __category_mask: ::std::os::raw::c_int,
-        __locale: *const ::std::os::raw::c_char,
-        __base: locale_t,
-    ) -> locale_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn duplocale(__dataset: locale_t) -> locale_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freelocale(__dataset: locale_t);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uselocale(__dataset: locale_t) -> locale_t;
+    pub fn setlocale(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
 pub type int8 = ::std::os::raw::c_schar;
@@ -5083,7 +7290,6 @@ pub union PGAlignedBlock {
     pub data: [::std::os::raw::c_char; 8192usize],
     pub force_align_d: f64,
     pub force_align_i64: int64,
-    _bindgen_union_align: [u64; 1024usize],
 }
 impl Default for PGAlignedBlock {
     fn default() -> Self {
@@ -5096,174 +7302,121 @@ pub union PGAlignedXLogBlock {
     pub data: [::std::os::raw::c_char; 8192usize],
     pub force_align_d: f64,
     pub force_align_i64: int64,
-    _bindgen_union_align: [u64; 1024usize],
 }
 impl Default for PGAlignedXLogBlock {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub const _ISupper: ::std::os::raw::c_uint = 256;
-pub const _ISlower: ::std::os::raw::c_uint = 512;
-pub const _ISalpha: ::std::os::raw::c_uint = 1024;
-pub const _ISdigit: ::std::os::raw::c_uint = 2048;
-pub const _ISxdigit: ::std::os::raw::c_uint = 4096;
-pub const _ISspace: ::std::os::raw::c_uint = 8192;
-pub const _ISprint: ::std::os::raw::c_uint = 16384;
-pub const _ISgraph: ::std::os::raw::c_uint = 32768;
-pub const _ISblank: ::std::os::raw::c_uint = 1;
-pub const _IScntrl: ::std::os::raw::c_uint = 2;
-pub const _ISpunct: ::std::os::raw::c_uint = 4;
-pub const _ISalnum: ::std::os::raw::c_uint = 8;
-pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
+    pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+pub type wint_t = __darwin_wint_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _RuneEntry {
+    pub __min: __darwin_rune_t,
+    pub __max: __darwin_rune_t,
+    pub __map: __darwin_rune_t,
+    pub __types: *mut __uint32_t,
+}
+impl Default for _RuneEntry {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _RuneRange {
+    pub __nranges: ::std::os::raw::c_int,
+    pub __ranges: *mut _RuneEntry,
+}
+impl Default for _RuneRange {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _RuneCharClass {
+    pub __name: [::std::os::raw::c_char; 14usize],
+    pub __mask: __uint32_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _RuneLocale {
+    pub __magic: [::std::os::raw::c_char; 8usize],
+    pub __encoding: [::std::os::raw::c_char; 32usize],
+    pub __sgetrune: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *const ::std::os::raw::c_char,
+            arg2: __darwin_size_t,
+            arg3: *mut *const ::std::os::raw::c_char,
+        ) -> __darwin_rune_t,
+    >,
+    pub __sputrune: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: __darwin_rune_t,
+            arg2: *mut ::std::os::raw::c_char,
+            arg3: __darwin_size_t,
+            arg4: *mut *mut ::std::os::raw::c_char,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub __invalid_rune: __darwin_rune_t,
+    pub __runetype: [__uint32_t; 256usize],
+    pub __maplower: [__darwin_rune_t; 256usize],
+    pub __mapupper: [__darwin_rune_t; 256usize],
+    pub __runetype_ext: _RuneRange,
+    pub __maplower_ext: _RuneRange,
+    pub __mapupper_ext: _RuneRange,
+    pub __variable: *mut ::std::os::raw::c_void,
+    pub __variable_len: ::std::os::raw::c_int,
+    pub __ncharclasses: ::std::os::raw::c_int,
+    pub __charclasses: *mut _RuneCharClass,
+}
+impl Default for _RuneLocale {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
+    pub static mut _DefaultRuneLocale: _RuneLocale;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
+    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __maskrune(
+        arg1: __darwin_ct_rune_t,
+        arg2: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
-#[pg_guard]
-extern "C" {
-    pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
+pub type socklen_t = __darwin_socklen_t;
+pub type sa_family_t = __uint8_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -5275,131 +7428,23 @@ impl Default for iovec {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type socklen_t = __socklen_t;
-pub const __socket_type_SOCK_STREAM: __socket_type = 1;
-pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
-pub const __socket_type_SOCK_RAW: __socket_type = 3;
-pub const __socket_type_SOCK_RDM: __socket_type = 4;
-pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
-pub const __socket_type_SOCK_DCCP: __socket_type = 6;
-pub const __socket_type_SOCK_PACKET: __socket_type = 10;
-pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
-pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
-pub type __socket_type = ::std::os::raw::c_uint;
-pub type sa_family_t = ::std::os::raw::c_ushort;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr {
-    pub sa_family: sa_family_t,
-    pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_storage {
-    pub ss_family: sa_family_t,
-    pub __ss_padding: [::std::os::raw::c_char; 118usize],
-    pub __ss_align: ::std::os::raw::c_ulong,
-}
-impl Default for sockaddr_storage {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub const MSG_OOB: ::std::os::raw::c_uint = 1;
-pub const MSG_PEEK: ::std::os::raw::c_uint = 2;
-pub const MSG_DONTROUTE: ::std::os::raw::c_uint = 4;
-pub const MSG_CTRUNC: ::std::os::raw::c_uint = 8;
-pub const MSG_PROXY: ::std::os::raw::c_uint = 16;
-pub const MSG_TRUNC: ::std::os::raw::c_uint = 32;
-pub const MSG_DONTWAIT: ::std::os::raw::c_uint = 64;
-pub const MSG_EOR: ::std::os::raw::c_uint = 128;
-pub const MSG_WAITALL: ::std::os::raw::c_uint = 256;
-pub const MSG_FIN: ::std::os::raw::c_uint = 512;
-pub const MSG_SYN: ::std::os::raw::c_uint = 1024;
-pub const MSG_CONFIRM: ::std::os::raw::c_uint = 2048;
-pub const MSG_RST: ::std::os::raw::c_uint = 4096;
-pub const MSG_ERRQUEUE: ::std::os::raw::c_uint = 8192;
-pub const MSG_NOSIGNAL: ::std::os::raw::c_uint = 16384;
-pub const MSG_MORE: ::std::os::raw::c_uint = 32768;
-pub const MSG_WAITFORONE: ::std::os::raw::c_uint = 65536;
-pub const MSG_BATCH: ::std::os::raw::c_uint = 262144;
-pub const MSG_ZEROCOPY: ::std::os::raw::c_uint = 67108864;
-pub const MSG_FASTOPEN: ::std::os::raw::c_uint = 536870912;
-pub const MSG_CMSG_CLOEXEC: ::std::os::raw::c_uint = 1073741824;
-pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
+pub type sae_associd_t = __uint32_t;
+pub type sae_connid_t = __uint32_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct msghdr {
-    pub msg_name: *mut ::std::os::raw::c_void,
-    pub msg_namelen: socklen_t,
-    pub msg_iov: *mut iovec,
-    pub msg_iovlen: usize,
-    pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: usize,
-    pub msg_flags: ::std::os::raw::c_int,
+pub struct sa_endpoints {
+    pub sae_srcif: ::std::os::raw::c_uint,
+    pub sae_srcaddr: *const sockaddr,
+    pub sae_srcaddrlen: socklen_t,
+    pub sae_dstaddr: *const sockaddr,
+    pub sae_dstaddrlen: socklen_t,
 }
-impl Default for msghdr {
+impl Default for sa_endpoints {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct cmsghdr {
-    pub cmsg_len: usize,
-    pub cmsg_level: ::std::os::raw::c_int,
-    pub cmsg_type: ::std::os::raw::c_int,
-    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
-}
-pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
-pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __kernel_fd_set {
-    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
-}
-pub type __kernel_sighandler_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
-pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = __kernel_ulong_t;
-pub type __kernel_ssize_t = __kernel_long_t;
-pub type __kernel_ptrdiff_t = __kernel_long_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __kernel_fsid_t {
-    pub val: [::std::os::raw::c_int; 2usize],
-}
-pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
-pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
-pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type sa_endpoints_t = sa_endpoints;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct linger {
@@ -5408,175 +7453,273 @@ pub struct linger {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct osockaddr {
-    pub sa_family: ::std::os::raw::c_ushort,
-    pub sa_data: [::std::os::raw::c_uchar; 14usize],
+pub struct so_np_extensions {
+    pub npx_flags: u_int32_t,
+    pub npx_mask: u_int32_t,
 }
-pub const SHUT_RD: ::std::os::raw::c_uint = 0;
-pub const SHUT_WR: ::std::os::raw::c_uint = 1;
-pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
-pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr {
+    pub sa_len: __uint8_t,
+    pub sa_family: sa_family_t,
+    pub sa_data: [::std::os::raw::c_char; 14usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockproto {
+    pub sp_family: __uint16_t,
+    pub sp_protocol: __uint16_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_storage {
+    pub ss_len: __uint8_t,
+    pub ss_family: sa_family_t,
+    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
+    pub __ss_align: __int64_t,
+    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+}
+impl Default for sockaddr_storage {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct msghdr {
+    pub msg_name: *mut ::std::os::raw::c_void,
+    pub msg_namelen: socklen_t,
+    pub msg_iov: *mut iovec,
+    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_control: *mut ::std::os::raw::c_void,
+    pub msg_controllen: socklen_t,
+    pub msg_flags: ::std::os::raw::c_int,
+}
+impl Default for msghdr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct cmsghdr {
+    pub cmsg_len: socklen_t,
+    pub cmsg_level: ::std::os::raw::c_int,
+    pub cmsg_type: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sf_hdtr {
+    pub headers: *mut iovec,
+    pub hdr_cnt: ::std::os::raw::c_int,
+    pub trailers: *mut iovec,
+    pub trl_cnt: ::std::os::raw::c_int,
+}
+impl Default for sf_hdtr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[pg_guard]
 extern "C" {
-    pub fn socket(
-        __domain: ::std::os::raw::c_int,
-        __type: ::std::os::raw::c_int,
-        __protocol: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn socketpair(
-        __domain: ::std::os::raw::c_int,
-        __type: ::std::os::raw::c_int,
-        __protocol: ::std::os::raw::c_int,
-        __fds: *mut ::std::os::raw::c_int,
+    pub fn accept(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn bind(
-        __fd: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __len: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockname(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sockaddr,
+        arg3: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn connect(
-        __fd: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __len: socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sockaddr,
+        arg3: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn getpeername(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn send(
-        __fd: ::std::os::raw::c_int,
-        __buf: *const ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-    ) -> isize;
+    pub fn getsockname(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsockopt(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_void,
+        arg5: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn listen(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn recv(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendto(
-        __fd: ::std::os::raw::c_int,
-        __buf: *const ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __addr_len: socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn recvfrom(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __addr_len: *mut socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendmsg(
-        __fd: ::std::os::raw::c_int,
-        __message: *const msghdr,
-        __flags: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+        arg5: *mut sockaddr,
+        arg6: *mut socklen_t,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn recvmsg(
-        __fd: ::std::os::raw::c_int,
-        __message: *mut msghdr,
-        __flags: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut msghdr,
+        arg3: ::std::os::raw::c_int,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getsockopt(
-        __fd: ::std::os::raw::c_int,
-        __level: ::std::os::raw::c_int,
-        __optname: ::std::os::raw::c_int,
-        __optval: *mut ::std::os::raw::c_void,
-        __optlen: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn send(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendmsg(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const msghdr,
+        arg3: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendto(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+        arg5: *const sockaddr,
+        arg6: socklen_t,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn setsockopt(
-        __fd: ::std::os::raw::c_int,
-        __level: ::std::os::raw::c_int,
-        __optname: ::std::os::raw::c_int,
-        __optval: *const ::std::os::raw::c_void,
-        __optlen: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn accept(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __addr_len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_void,
+        arg5: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn shutdown(
-        __fd: ::std::os::raw::c_int,
-        __how: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isfdtype(
-        __fd: ::std::os::raw::c_int,
-        __fdtype: ::std::os::raw::c_int,
+    pub fn socket(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
-pub type in_addr_t = u32;
+#[pg_guard]
+extern "C" {
+    pub fn socketpair(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendfile(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: off_t,
+        arg4: *mut off_t,
+        arg5: *mut sf_hdtr,
+        arg6: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
+}
+#[pg_guard]
+extern "C" {
+    pub fn connectx(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sa_endpoints_t,
+        arg3: sae_associd_t,
+        arg4: ::std::os::raw::c_uint,
+        arg5: *const iovec,
+        arg6: ::std::os::raw::c_uint,
+        arg7: *mut usize,
+        arg8: *mut sae_connid_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn disconnectx(
+        arg1: ::std::os::raw::c_int,
+        arg2: sae_associd_t,
+        arg3: sae_connid_t,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_len: __uint8_t,
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5591,6 +7734,12 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -5598,88 +7747,113 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_sourceaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
+}
+impl Default for group_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
+}
+impl Default for group_source_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct __msfilterreq {
+    pub msfr_ifindex: u32,
+    pub msfr_fmode: u32,
+    pub msfr_nsrcs: u32,
+    pub __msfr_align: u32,
+    pub msfr_group: sockaddr_storage,
+    pub msfr_srcs: *mut sockaddr_storage,
+}
+impl Default for __msfilterreq {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setipv4sourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: in_addr,
+        arg3: in_addr,
+        arg4: u32,
+        arg5: u32,
+        arg6: *mut in_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipv4sourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: in_addr,
+        arg3: in_addr,
+        arg4: *mut u32,
+        arg5: *mut u32,
+        arg6: *mut in_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setsourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: u32,
+        arg3: *mut sockaddr,
+        arg4: socklen_t,
+        arg5: u32,
+        arg6: u32,
+        arg7: *mut sockaddr_storage,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: u32,
+        arg3: *mut sockaddr,
+        arg4: socklen_t,
+        arg5: *mut u32,
+        arg6: *mut u32,
+        arg7: *mut sockaddr_storage,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_int,
+    pub ipi_ifindex: ::std::os::raw::c_uint,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
-pub const IPPROTO_IP: ::std::os::raw::c_uint = 0;
-pub const IPPROTO_ICMP: ::std::os::raw::c_uint = 1;
-pub const IPPROTO_IGMP: ::std::os::raw::c_uint = 2;
-pub const IPPROTO_IPIP: ::std::os::raw::c_uint = 4;
-pub const IPPROTO_TCP: ::std::os::raw::c_uint = 6;
-pub const IPPROTO_EGP: ::std::os::raw::c_uint = 8;
-pub const IPPROTO_PUP: ::std::os::raw::c_uint = 12;
-pub const IPPROTO_UDP: ::std::os::raw::c_uint = 17;
-pub const IPPROTO_IDP: ::std::os::raw::c_uint = 22;
-pub const IPPROTO_TP: ::std::os::raw::c_uint = 29;
-pub const IPPROTO_DCCP: ::std::os::raw::c_uint = 33;
-pub const IPPROTO_IPV6: ::std::os::raw::c_uint = 41;
-pub const IPPROTO_RSVP: ::std::os::raw::c_uint = 46;
-pub const IPPROTO_GRE: ::std::os::raw::c_uint = 47;
-pub const IPPROTO_ESP: ::std::os::raw::c_uint = 50;
-pub const IPPROTO_AH: ::std::os::raw::c_uint = 51;
-pub const IPPROTO_MTP: ::std::os::raw::c_uint = 92;
-pub const IPPROTO_BEETPH: ::std::os::raw::c_uint = 94;
-pub const IPPROTO_ENCAP: ::std::os::raw::c_uint = 98;
-pub const IPPROTO_PIM: ::std::os::raw::c_uint = 103;
-pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
-pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
-pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
-pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
-pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
-pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
-pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
-pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
-pub const IPPROTO_FRAGMENT: ::std::os::raw::c_uint = 44;
-pub const IPPROTO_ICMPV6: ::std::os::raw::c_uint = 58;
-pub const IPPROTO_NONE: ::std::os::raw::c_uint = 59;
-pub const IPPROTO_DSTOPTS: ::std::os::raw::c_uint = 60;
-pub const IPPROTO_MH: ::std::os::raw::c_uint = 135;
-pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
-pub type in_port_t = u16;
-pub const IPPORT_ECHO: ::std::os::raw::c_uint = 7;
-pub const IPPORT_DISCARD: ::std::os::raw::c_uint = 9;
-pub const IPPORT_SYSTAT: ::std::os::raw::c_uint = 11;
-pub const IPPORT_DAYTIME: ::std::os::raw::c_uint = 13;
-pub const IPPORT_NETSTAT: ::std::os::raw::c_uint = 15;
-pub const IPPORT_FTP: ::std::os::raw::c_uint = 21;
-pub const IPPORT_TELNET: ::std::os::raw::c_uint = 23;
-pub const IPPORT_SMTP: ::std::os::raw::c_uint = 25;
-pub const IPPORT_TIMESERVER: ::std::os::raw::c_uint = 37;
-pub const IPPORT_NAMESERVER: ::std::os::raw::c_uint = 42;
-pub const IPPORT_WHOIS: ::std::os::raw::c_uint = 43;
-pub const IPPORT_MTP: ::std::os::raw::c_uint = 57;
-pub const IPPORT_TFTP: ::std::os::raw::c_uint = 69;
-pub const IPPORT_RJE: ::std::os::raw::c_uint = 77;
-pub const IPPORT_FINGER: ::std::os::raw::c_uint = 79;
-pub const IPPORT_TTYLINK: ::std::os::raw::c_uint = 87;
-pub const IPPORT_SUPDUP: ::std::os::raw::c_uint = 95;
-pub const IPPORT_EXECSERVER: ::std::os::raw::c_uint = 512;
-pub const IPPORT_LOGINSERVER: ::std::os::raw::c_uint = 513;
-pub const IPPORT_CMDSERVER: ::std::os::raw::c_uint = 514;
-pub const IPPORT_EFSSERVER: ::std::os::raw::c_uint = 520;
-pub const IPPORT_BIFFUDP: ::std::os::raw::c_uint = 512;
-pub const IPPORT_WHOSERVER: ::std::os::raw::c_uint = 513;
-pub const IPPORT_ROUTESERVER: ::std::os::raw::c_uint = 520;
-pub const IPPORT_RESERVED: ::std::os::raw::c_uint = 1024;
-pub const IPPORT_USERRESERVED: ::std::os::raw::c_uint = 5000;
-pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __in6_u: in6_addr__bindgen_ty_1,
+    pub __u6_addr: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [u8; 16usize],
-    pub __u6_addr16: [u16; 8usize],
-    pub __u6_addr32: [u32; 4usize],
-    _bindgen_union_align: [u32; 4usize],
+    pub __u6_addr8: [__uint8_t; 16usize],
+    pub __u6_addr16: [__uint16_t; 8usize],
+    pub __u6_addr32: [__uint32_t; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -5687,6 +7861,22 @@ impl Default for in6_addr__bindgen_ty_1 {
     }
 }
 impl Default for in6_addr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type in6_addr_t = in6_addr;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_len: __uint8_t,
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: __uint32_t,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: __uint32_t,
+}
+impl Default for sockaddr_in6 {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
@@ -5699,40 +7889,21 @@ extern "C" {
 extern "C" {
     pub static in6addr_loopback: in6_addr;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+#[pg_guard]
+extern "C" {
+    pub static in6addr_nodelocal_allnodes: in6_addr;
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_in6 {
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: u32,
-    pub sin6_addr: in6_addr,
-    pub sin6_scope_id: u32,
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allnodes: in6_addr;
 }
-impl Default for sockaddr_in6 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allrouters: in6_addr;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-    pub imr_sourceaddr: in_addr,
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allv2routers: in6_addr;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5747,165 +7918,234 @@ impl Default for ipv6_mreq {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
+pub struct in6_pktinfo {
+    pub ipi6_addr: in6_addr,
+    pub ipi6_ifindex: ::std::os::raw::c_uint,
 }
-impl Default for group_req {
+impl Default for in6_pktinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
+pub struct ip6_mtuinfo {
+    pub ip6m_addr: sockaddr_in6,
+    pub ip6m_mtu: u32,
 }
-impl Default for group_source_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_msfilter {
-    pub imsf_multiaddr: in_addr,
-    pub imsf_interface: in_addr,
-    pub imsf_fmode: u32,
-    pub imsf_numsrc: u32,
-    pub imsf_slist: [in_addr; 1usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct group_filter {
-    pub gf_interface: u32,
-    pub gf_group: sockaddr_storage,
-    pub gf_fmode: u32,
-    pub gf_numsrc: u32,
-    pub gf_slist: [sockaddr_storage; 1usize],
-}
-impl Default for group_filter {
+impl Default for ip6_mtuinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn ntohl(__netlong: u32) -> u32;
+    pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ntohs(__netshort: u16) -> u16;
+    pub fn inet6_option_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *mut *mut cmsghdr,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn htonl(__hostlong: u32) -> u32;
+    pub fn inet6_option_append(
+        arg1: *mut cmsghdr,
+        arg2: *const __uint8_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn htons(__hostshort: u16) -> u16;
+    pub fn inet6_option_alloc(
+        arg1: *mut cmsghdr,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> *mut __uint8_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_option_next(
+        arg1: *const cmsghdr,
+        arg2: *mut *mut __uint8_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_option_find(
+        arg1: *const cmsghdr,
+        arg2: *mut *mut __uint8_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut cmsghdr;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_add(
+        arg1: *mut cmsghdr,
+        arg2: *const in6_addr,
+        arg3: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_lasthop(
+        arg1: *mut cmsghdr,
+        arg2: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_getaddr(arg1: *mut cmsghdr, arg2: ::std::os::raw::c_int) -> *mut in6_addr;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_getflags(
+        arg1: *const cmsghdr,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_append(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: __uint8_t,
+        arg5: socklen_t,
+        arg6: __uint8_t,
+        arg7: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_finish(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_set_val(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_next(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut __uint8_t,
+        arg5: *mut socklen_t,
+        arg6: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_find(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: __uint8_t,
+        arg5: *mut socklen_t,
+        arg6: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_get_val(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> socklen_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_add(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *const in6_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_reverse(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_getaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut in6_addr;
 }
 #[pg_guard]
 extern "C" {
     pub fn bindresvport(
-        __sockfd: ::std::os::raw::c_int,
-        __sock_in: *mut sockaddr_in,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr_in,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bindresvport6(
-        __sockfd: ::std::os::raw::c_int,
-        __sock_in: *mut sockaddr_in6,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endrpcent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent() -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
+    pub fn bindresvport_sa(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getrpcbynumber_r(
-        __number: ::std::os::raw::c_int,
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent_r(
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn herror(__str: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub static mut h_errno: ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5921,135 +8161,18 @@ impl Default for hostent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn sethostent(__stay_open: ::std::os::raw::c_int);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
 }
-#[pg_guard]
-extern "C" {
-    pub fn endhostent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent() -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr(
-        __addr: *const ::std::os::raw::c_void,
-        __len: __socklen_t,
-        __type: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2(
-        __name: *const ::std::os::raw::c_char,
-        __af: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent_r(
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr_r(
-        __addr: *const ::std::os::raw::c_void,
-        __len: __socklen_t,
-        __type: ::std::os::raw::c_int,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2_r(
-        __name: *const ::std::os::raw::c_char,
-        __af: ::std::os::raw::c_int,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent() -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent_r(
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr_r(
-        __net: u32,
-        __type: ::std::os::raw::c_int,
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+impl Default for netent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6064,63 +8187,6 @@ impl Default for servent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn setservent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endservent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent() -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname(
-        __name: *const ::std::os::raw::c_char,
-        __proto: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport(
-        __port: ::std::os::raw::c_int,
-        __proto: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent_r(
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __proto: *const ::std::os::raw::c_char,
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport_r(
-        __port: ::std::os::raw::c_int,
-        __proto: *const ::std::os::raw::c_char,
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -6133,185 +8199,6 @@ impl Default for protoent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endprotoent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent() -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent_r(
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber_r(
-        __proto: ::std::os::raw::c_int,
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetgrent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetgrent(
-        __hostp: *mut *mut ::std::os::raw::c_char,
-        __userp: *mut *mut ::std::os::raw::c_char,
-        __domainp: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn innetgr(
-        __netgroup: *const ::std::os::raw::c_char,
-        __host: *const ::std::os::raw::c_char,
-        __user: *const ::std::os::raw::c_char,
-        __domain: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetgrent_r(
-        __hostp: *mut *mut ::std::os::raw::c_char,
-        __userp: *mut *mut ::std::os::raw::c_char,
-        __domainp: *mut *mut ::std::os::raw::c_char,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rcmd(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_ushort,
-        __locuser: *const ::std::os::raw::c_char,
-        __remuser: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rcmd_af(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_ushort,
-        __locuser: *const ::std::os::raw::c_char,
-        __remuser: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rexec(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_int,
-        __name: *const ::std::os::raw::c_char,
-        __pass: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rexec_af(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_int,
-        __name: *const ::std::os::raw::c_char,
-        __pass: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ruserok(
-        __rhost: *const ::std::os::raw::c_char,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ruserok_af(
-        __rhost: *const ::std::os::raw::c_char,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iruserok(
-        __raddr: u32,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iruserok_af(
-        __raddr: *const ::std::os::raw::c_void,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rresvport_af(
-        __alport: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct addrinfo {
@@ -6320,8 +8207,8 @@ pub struct addrinfo {
     pub ai_socktype: ::std::os::raw::c_int,
     pub ai_protocol: ::std::os::raw::c_int,
     pub ai_addrlen: socklen_t,
-    pub ai_addr: *mut sockaddr,
     pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_addr: *mut sockaddr,
     pub ai_next: *mut addrinfo,
 }
 impl Default for addrinfo {
@@ -6329,50 +8216,269 @@ impl Default for addrinfo {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn endhostent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endprotoent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endservent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn freeaddrinfo(arg1: *mut addrinfo);
+}
+#[pg_guard]
+extern "C" {
+    pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
 #[pg_guard]
 extern "C" {
     pub fn getaddrinfo(
-        __name: *const ::std::os::raw::c_char,
-        __service: *const ::std::os::raw::c_char,
-        __req: *const addrinfo,
-        __pai: *mut *mut addrinfo,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *const addrinfo,
+        arg4: *mut *mut addrinfo,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn freeaddrinfo(__ai: *mut addrinfo);
+    pub fn gethostbyaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut hostent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent() -> *mut hostent;
 }
 #[pg_guard]
 extern "C" {
     pub fn getnameinfo(
-        __sa: *const sockaddr,
-        __salen: socklen_t,
-        __host: *mut ::std::os::raw::c_char,
-        __hostlen: socklen_t,
-        __serv: *mut ::std::os::raw::c_char,
-        __servlen: socklen_t,
-        __flags: ::std::os::raw::c_int,
+        arg1: *const sockaddr,
+        arg2: socklen_t,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: socklen_t,
+        arg5: *mut ::std::os::raw::c_char,
+        arg6: socklen_t,
+        arg7: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent() -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent() -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent() -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sethostent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprotoent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setservent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn freehostent(arg1: *mut hostent);
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipnodebyaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipnodebyname(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcent() -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setrpcent(stayopen: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endrpcent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn herror(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn innetgr(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *const ::std::os::raw::c_char,
+        arg4: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetgrent(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetgrent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct passwd {
     pub pw_name: *mut ::std::os::raw::c_char,
     pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: __uid_t,
-    pub pw_gid: __gid_t,
+    pub pw_uid: uid_t,
+    pub pw_gid: gid_t,
+    pub pw_change: __darwin_time_t,
+    pub pw_class: *mut ::std::os::raw::c_char,
     pub pw_gecos: *mut ::std::os::raw::c_char,
     pub pw_dir: *mut ::std::os::raw::c_char,
     pub pw_shell: *mut ::std::os::raw::c_char,
+    pub pw_expire: __darwin_time_t,
 }
 impl Default for passwd {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid(arg1: uid_t) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid_r(
+        arg1: uid_t,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam_r(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwent() -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
@@ -6382,63 +8488,86 @@ extern "C" {
 extern "C" {
     pub fn endpwent();
 }
+pub type uuid_t = __darwin_uuid_t;
+pub type uuid_string_t = __darwin_uuid_string_t;
 #[pg_guard]
 extern "C" {
-    pub fn getpwent() -> *mut passwd;
+    pub static UUID_NULL: uuid_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
+    pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
 }
 #[pg_guard]
 extern "C" {
-    pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwent_r(
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_compare(
+        uu1: *mut ::std::os::raw::c_uchar,
+        uu2: *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwuid_r(
-        __uid: __uid_t,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_early_random(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_parse(
+        in_: *mut ::std::os::raw::c_char,
+        uu: *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwnam_r(
-        __name: *const ::std::os::raw::c_char,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
-    ) -> ::std::os::raw::c_int;
+    pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpwent_r(
-        __stream: *mut FILE,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_unparse_lower(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_unparse_upper(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn user_from_uid(arg1: uid_t, arg2: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuuid_r(
+        arg1: *mut ::std::os::raw::c_uchar,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -6703,979 +8832,407 @@ extern "C" {
 extern "C" {
     pub fn pg_srand48(seed: ::std::os::raw::c_long);
 }
-#[pg_guard]
-extern "C" {
-    pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpeereid(
-        sock: ::std::os::raw::c_int,
-        uid: *mut uid_t,
-        gid: *mut gid_t,
-    ) -> ::std::os::raw::c_int;
-}
 pub type float_t = f32;
 pub type double_t = f64;
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __math_errhandling() -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
+    pub fn acosf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
+    pub fn acos(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
+    pub fn acosl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acos(__x: f64) -> f64;
+    pub fn asinf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __acos(__x: f64) -> f64;
+    pub fn asin(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asin(__x: f64) -> f64;
+    pub fn asinl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __asin(__x: f64) -> f64;
+    pub fn atanf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan(__x: f64) -> f64;
+    pub fn atan(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atan(__x: f64) -> f64;
+    pub fn atanl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2(__y: f64, __x: f64) -> f64;
+    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atan2(__y: f64, __x: f64) -> f64;
+    pub fn atan2(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cos(__x: f64) -> f64;
+    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cos(__x: f64) -> f64;
+    pub fn cosf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sin(__x: f64) -> f64;
+    pub fn cos(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sin(__x: f64) -> f64;
+    pub fn cosl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tan(__x: f64) -> f64;
+    pub fn sinf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tan(__x: f64) -> f64;
+    pub fn sin(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosh(__x: f64) -> f64;
+    pub fn sinl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cosh(__x: f64) -> f64;
+    pub fn tanf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinh(__x: f64) -> f64;
+    pub fn tan(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sinh(__x: f64) -> f64;
+    pub fn tanl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanh(__x: f64) -> f64;
+    pub fn acoshf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tanh(__x: f64) -> f64;
+    pub fn acosh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosh(__x: f64) -> f64;
+    pub fn acoshl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __acosh(__x: f64) -> f64;
+    pub fn asinhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinh(__x: f64) -> f64;
+    pub fn asinh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __asinh(__x: f64) -> f64;
+    pub fn asinhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanh(__x: f64) -> f64;
+    pub fn atanhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atanh(__x: f64) -> f64;
+    pub fn atanh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp(__x: f64) -> f64;
+    pub fn atanhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __exp(__x: f64) -> f64;
+    pub fn coshf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
+    pub fn cosh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
+    pub fn coshl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
+    pub fn sinhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
+    pub fn sinh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log(__x: f64) -> f64;
+    pub fn sinhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log(__x: f64) -> f64;
+    pub fn tanhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10(__x: f64) -> f64;
+    pub fn tanh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log10(__x: f64) -> f64;
+    pub fn tanhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
+    pub fn expf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
+    pub fn exp(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1(__x: f64) -> f64;
+    pub fn expl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __expm1(__x: f64) -> f64;
+    pub fn exp2f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1p(__x: f64) -> f64;
+    pub fn exp2(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log1p(__x: f64) -> f64;
+    pub fn exp2l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logb(__x: f64) -> f64;
+    pub fn expm1f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __logb(__x: f64) -> f64;
+    pub fn expm1(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2(__x: f64) -> f64;
+    pub fn expm1l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __exp2(__x: f64) -> f64;
+    pub fn logf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2(__x: f64) -> f64;
+    pub fn log(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log2(__x: f64) -> f64;
+    pub fn logl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pow(__x: f64, __y: f64) -> f64;
+    pub fn log10f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __pow(__x: f64, __y: f64) -> f64;
+    pub fn log10(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sqrt(__x: f64) -> f64;
+    pub fn log10l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sqrt(__x: f64) -> f64;
+    pub fn log2f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn hypot(__x: f64, __y: f64) -> f64;
+    pub fn log2(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __hypot(__x: f64, __y: f64) -> f64;
+    pub fn log2l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cbrt(__x: f64) -> f64;
+    pub fn log1pf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cbrt(__x: f64) -> f64;
+    pub fn log1p(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ceil(__x: f64) -> f64;
+    pub fn log1pl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ceil(__x: f64) -> f64;
+    pub fn logbf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fabs(__x: f64) -> f64;
+    pub fn logb(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fabs(__x: f64) -> f64;
+    pub fn logbl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn floor(__x: f64) -> f64;
+    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __floor(__x: f64) -> f64;
+    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmod(__x: f64, __y: f64) -> f64;
+    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmod(__x: f64, __y: f64) -> f64;
+    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
+    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
+    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn drem(__x: f64, __y: f64) -> f64;
+    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __drem(__x: f64, __y: f64) -> f64;
+    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn significand(__x: f64) -> f64;
+    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __significand(__x: f64) -> f64;
+    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn copysign(__x: f64, __y: f64) -> f64;
+    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __copysign(__x: f64, __y: f64) -> f64;
+    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
+    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
+    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
+    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn j0(arg1: f64) -> f64;
+    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __j0(arg1: f64) -> f64;
+    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn j1(arg1: f64) -> f64;
+    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __j1(arg1: f64) -> f64;
+    pub fn fabsf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn fabs(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn fabsl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn y0(arg1: f64) -> f64;
+    pub fn cbrtf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __y0(arg1: f64) -> f64;
+    pub fn cbrt(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn y1(arg1: f64) -> f64;
+    pub fn cbrtl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __y1(arg1: f64) -> f64;
+    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn hypot(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn erf(arg1: f64) -> f64;
+    pub fn powf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erf(arg1: f64) -> f64;
+    pub fn pow(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
+    pub fn powl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfc(arg1: f64) -> f64;
+    pub fn sqrtf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
+    pub fn sqrt(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __gamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __rint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafter(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nextafter(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttoward(__x: f64, __y: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainder(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remainder(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nearbyint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn round(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __round(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn trunc(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __trunc(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdim(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fdim(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmax(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmax(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmin(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmin(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalb(__x: f64, __n: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalb(__x: f64, __n: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atan2f(__y: f32, __x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atan2f(__y: f32, __x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn coshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __coshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acoshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acoshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log10f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log10f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expm1f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expm1f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log1pf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log1pf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logbf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logbf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn exp2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __powf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sqrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __hypotf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cbrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceilf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ceilf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fabsf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __floorf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmodf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dremf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __dremf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn significandf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __significandf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __copysignf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+    pub fn sqrtl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
@@ -7683,583 +9240,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erff(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __gammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __rintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remainderf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nearbyintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __roundf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __truncf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdimf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fdimf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fminf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbf(__x: f32, __n: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbf(__x: f32, __n: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atan2l(__y: u128, __x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atan2l(__y: u128, __x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn coshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __coshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acoshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acoshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log10l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log10l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expm1l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expm1l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log1pl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log1pl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logbl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logbl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn exp2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __powl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sqrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __hypotl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cbrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceill(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ceill(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fabsl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __floorl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmodl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dreml(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __dreml(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn significandl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __significandl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __copysignl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+    pub fn erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8267,7 +9248,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfl(arg1: u128) -> u128;
+    pub fn erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8275,7 +9260,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfcl(arg1: u128) -> u128;
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8283,7 +9272,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgammal(arg1: u128) -> u128;
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8291,209 +9284,401 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tgammal(arg1: u128) -> u128;
+    pub fn ceilf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gammal(arg1: u128) -> u128;
+    pub fn ceil(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __gammal(arg1: u128) -> u128;
+    pub fn ceill(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+    pub fn floorf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+    pub fn floor(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rintl(__x: u128) -> u128;
+    pub fn floorl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __rintl(__x: u128) -> u128;
+    pub fn nearbyintf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+    pub fn nearbyint(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+    pub fn nearbyintl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+    pub fn rintf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+    pub fn rint(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remainderl(__x: u128, __y: u128) -> u128;
+    pub fn rintl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+    pub fn roundf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+    pub fn round(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+    pub fn roundl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nearbyintl(__x: u128) -> u128;
+    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nearbyintl(__x: u128) -> u128;
+    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn roundl(__x: u128) -> u128;
+    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __roundl(__x: u128) -> u128;
+    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn truncl(__x: u128) -> u128;
+    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __truncl(__x: u128) -> u128;
+    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn truncf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn trunc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn truncl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn fmod(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn remainder(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fdiml(__x: u128, __y: u128) -> u128;
+    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fminl(__x: u128, __y: u128) -> u128;
+    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fminl(__x: u128, __y: u128) -> u128;
+    pub fn copysign(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbl(__x: u128, __n: u128) -> u128;
+    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdim(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmax(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmin(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __inff() -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __inf() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __infl() -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nan() -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp10f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp10(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cospif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cospi(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinpif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinpi(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanpif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanpi(arg1: f64) -> f64;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __float2 {
+    pub __sinval: f32,
+    pub __cosval: f32,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __double2 {
+    pub __sinval: f64,
+    pub __cosval: f64,
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincosf_stret(arg1: f32) -> __float2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincos_stret(arg1: f64) -> __double2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincospif_stret(arg1: f32) -> __float2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincospi_stret(arg1: f64) -> __double2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalb(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-pub const FP_NAN: ::std::os::raw::c_uint = 0;
-pub const FP_INFINITE: ::std::os::raw::c_uint = 1;
-pub const FP_ZERO: ::std::os::raw::c_uint = 2;
-pub const FP_SUBNORMAL: ::std::os::raw::c_uint = 3;
-pub const FP_NORMAL: ::std::os::raw::c_uint = 4;
-pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drem(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significand(arg1: f64) -> f64;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct exception {
+    pub type_: ::std::os::raw::c_int,
+    pub name: *mut ::std::os::raw::c_char,
+    pub arg1: f64,
+    pub arg2: f64,
+    pub retval: f64,
+}
+impl Default for exception {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
@@ -8623,39 +9808,28 @@ extern "C" {
         include_command_not_found: bool,
     ) -> bool;
 }
-pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __jmp_buf_tag {
-    pub __jmpbuf: __jmp_buf,
-    pub __mask_was_saved: ::std::os::raw::c_int,
-    pub __saved_mask: __sigset_t,
-}
-pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type jmp_buf = [::std::os::raw::c_int; 37usize];
+pub type sigjmp_buf = [::std::os::raw::c_int; 38usize];
 #[pg_guard]
 extern "C" {
-    pub fn setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
+    pub fn setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sigsetjmp(
-        __env: *mut __jmp_buf_tag,
-        __savemask: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn _setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
+    pub fn _setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
+    pub fn _longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn _longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
+    pub fn longjmperror();
 }
-pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
     pub fn errstart(
@@ -10334,7 +11508,6 @@ pub union ListCell__bindgen_ty_1 {
     pub ptr_value: *mut ::std::os::raw::c_void,
     pub int_value: ::std::os::raw::c_int,
     pub oid_value: Oid,
-    _bindgen_union_align: u64,
 }
 impl Default for ListCell__bindgen_ty_1 {
     fn default() -> Self {
@@ -11596,83 +12769,239 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
+    pub l_start: off_t,
+    pub l_len: off_t,
+    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
-    pub l_start: __off_t,
-    pub l_len: __off_t,
-    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct stat {
-    pub st_dev: __dev_t,
-    pub st_ino: __ino_t,
-    pub st_nlink: __nlink_t,
-    pub st_mode: __mode_t,
-    pub st_uid: __uid_t,
-    pub st_gid: __gid_t,
-    pub __pad0: ::std::os::raw::c_int,
-    pub st_rdev: __dev_t,
-    pub st_size: __off_t,
-    pub st_blksize: __blksize_t,
-    pub st_blocks: __blkcnt_t,
-    pub st_atim: timespec,
-    pub st_mtim: timespec,
-    pub st_ctim: timespec,
-    pub __glibc_reserved: [__syscall_slong_t; 3usize],
+pub struct timespec {
+    pub tv_sec: __darwin_time_t,
+    pub tv_nsec: ::std::os::raw::c_long,
 }
-#[pg_guard]
-extern "C" {
-    pub fn fcntl(
-        __fd: ::std::os::raw::c_int,
-        __cmd: ::std::os::raw::c_int,
-        ...
-    ) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct flocktimeout {
+    pub fl: flock,
+    pub timeout: timespec,
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct radvisory {
+    pub ra_offset: off_t,
+    pub ra_count: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsignatures {
+    pub fs_file_start: off_t,
+    pub fs_blob_start: *mut ::std::os::raw::c_void,
+    pub fs_blob_size: usize,
+    pub fs_fsignatures_size: usize,
+    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
+    pub fs_hash_type: ::std::os::raw::c_int,
+}
+impl Default for fsignatures {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fsignatures_t = fsignatures;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fsupplement {
+    pub fs_file_start: off_t,
+    pub fs_blob_start: off_t,
+    pub fs_blob_size: usize,
+    pub fs_orig_fd: ::std::os::raw::c_int,
+}
+pub type fsupplement_t = fsupplement;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fchecklv {
+    pub lv_file_start: off_t,
+    pub lv_error_message_size: usize,
+    pub lv_error_message: *mut ::std::os::raw::c_void,
+}
+impl Default for fchecklv {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fchecklv_t = fchecklv;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fgetsigsinfo {
+    pub fg_file_start: off_t,
+    pub fg_info_request: ::std::os::raw::c_int,
+    pub fg_sig_is_platform: ::std::os::raw::c_int,
+}
+pub type fgetsigsinfo_t = fgetsigsinfo;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fstore {
+    pub fst_flags: ::std::os::raw::c_uint,
+    pub fst_posmode: ::std::os::raw::c_int,
+    pub fst_offset: off_t,
+    pub fst_length: off_t,
+    pub fst_bytesalloc: off_t,
+}
+pub type fstore_t = fstore;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fpunchhole {
+    pub fp_flags: ::std::os::raw::c_uint,
+    pub reserved: ::std::os::raw::c_uint,
+    pub fp_offset: off_t,
+    pub fp_length: off_t,
+}
+pub type fpunchhole_t = fpunchhole;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ftrimactivefile {
+    pub fta_offset: off_t,
+    pub fta_length: off_t,
+}
+pub type ftrimactivefile_t = ftrimactivefile;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fspecread {
+    pub fsr_flags: ::std::os::raw::c_uint,
+    pub reserved: ::std::os::raw::c_uint,
+    pub fsr_offset: off_t,
+    pub fsr_length: off_t,
+}
+pub type fspecread_t = fspecread;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fbootstraptransfer {
+    pub fbt_offset: off_t,
+    pub fbt_length: usize,
+    pub fbt_buffer: *mut ::std::os::raw::c_void,
+}
+impl Default for fbootstraptransfer {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fbootstraptransfer_t = fbootstraptransfer;
+#[repr(C, packed(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct log2phys {
+    pub l2p_flags: ::std::os::raw::c_uint,
+    pub l2p_contigbytes: off_t,
+    pub l2p_devoffset: off_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _filesec {
+    _unused: [u8; 0],
+}
+pub type filesec_t = *mut _filesec;
+pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
+pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
+pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
+pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
+pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
+pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
+pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
+pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
+pub type filesec_property_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn open(
-        __file: *const ::std::os::raw::c_char,
-        __oflag: ::std::os::raw::c_int,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn openat(
-        __fd: ::std::os::raw::c_int,
-        __file: *const ::std::os::raw::c_char,
-        __oflag: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn creat(__file: *const ::std::os::raw::c_char, __mode: mode_t) -> ::std::os::raw::c_int;
+    pub fn creat(arg1: *const ::std::os::raw::c_char, arg2: mode_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lockf(
-        __fd: ::std::os::raw::c_int,
-        __cmd: ::std::os::raw::c_int,
-        __len: off_t,
+    pub fn fcntl(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix_fadvise(
-        __fd: ::std::os::raw::c_int,
-        __offset: off_t,
-        __len: off_t,
-        __advise: ::std::os::raw::c_int,
+    pub fn openx_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: filesec_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix_fallocate(
-        __fd: ::std::os::raw::c_int,
-        __offset: off_t,
-        __len: off_t,
+    pub fn open_dprotected_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flock(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_init() -> filesec_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_free(arg1: filesec_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_get_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_query_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_set_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_unset_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
     ) -> ::std::os::raw::c_int;
 }
 pub type XLogRecPtr = uint64;
@@ -13537,115 +14866,20 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *const ::std::os::raw::c_char,
+    pub tm_zone: *mut ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct itimerspec {
-    pub it_interval: timespec,
-    pub it_value: timespec,
+#[pg_guard]
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock() -> clock_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn time(__timer: *mut time_t) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktime(__tp: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strftime(
-        __s: *mut ::std::os::raw::c_char,
-        __maxsize: usize,
-        __format: *const ::std::os::raw::c_char,
-        __tp: *const tm,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strftime_l(
-        __s: *mut ::std::os::raw::c_char,
-        __maxsize: usize,
-        __format: *const ::std::os::raw::c_char,
-        __tp: *const tm,
-        __loc: locale_t,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime(__timer: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime(__timer: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime_r(
-        __tp: *const tm,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctime_r(
-        __timer: *const time_t,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __daylight: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __timezone: ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
-}
-#[pg_guard]
-extern "C" {
-    pub fn tzset();
-}
-#[pg_guard]
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
+    pub static mut getdate_err: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -13653,23 +14887,120 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn timegm(__tp: *mut tm) -> time_t;
+    pub static mut daylight: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timelocal(__tp: *mut tm) -> time_t;
+    pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn clock() -> clock_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nanosleep(
-        __requested_time: *const timespec,
-        __remaining: *mut timespec,
-    ) -> ::std::os::raw::c_int;
+    pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
 }
+#[pg_guard]
+extern "C" {
+    pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime(arg1: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime(arg1: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktime(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strftime(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: *const ::std::os::raw::c_char,
+        arg4: *const tm,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strptime(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut tm,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn time(arg1: *mut time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tzset();
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime_r(
+        arg1: *const tm,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ctime_r(
+        arg1: *const time_t,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn posix2time(arg1: time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tzsetwall();
+}
+#[pg_guard]
+extern "C" {
+    pub fn time2posix(arg1: time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timelocal(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timegm(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanosleep(__rqtp: *const timespec, __rmtp: *mut timespec) -> ::std::os::raw::c_int;
+}
+pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
+pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
+pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
+pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
+pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
+pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
+pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
+pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
+pub type clockid_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn clock_getres(__clock_id: clockid_t, __res: *mut timespec) -> ::std::os::raw::c_int;
@@ -13680,56 +15011,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
+}
+#[pg_guard]
+extern "C" {
     pub fn clock_settime(__clock_id: clockid_t, __tp: *const timespec) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock_nanosleep(
-        __clock_id: clockid_t,
-        __flags: ::std::os::raw::c_int,
-        __req: *const timespec,
-        __rem: *mut timespec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn clock_getcpuclockid(__pid: pid_t, __clock_id: *mut clockid_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_create(
-        __clock_id: clockid_t,
-        __evp: *mut sigevent,
-        __timerid: *mut timer_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_settime(
-        __timerid: timer_t,
-        __flags: ::std::os::raw::c_int,
-        __value: *const itimerspec,
-        __ovalue: *mut itimerspec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_gettime(__timerid: timer_t, __value: *mut itimerspec) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timespec_get(
-        __ts: *mut timespec,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn timespec_get(ts: *mut timespec, base: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type instr_time = timespec;
 #[repr(C)]
@@ -14958,82 +16248,104 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __ino_t,
-    pub d_off: __off_t,
-    pub d_reclen: ::std::os::raw::c_ushort,
-    pub d_type: ::std::os::raw::c_uchar,
-    pub d_name: [::std::os::raw::c_char; 256usize],
+    pub d_ino: __uint64_t,
+    pub d_seekoff: __uint64_t,
+    pub d_reclen: __uint16_t,
+    pub d_namlen: __uint16_t,
+    pub d_type: __uint8_t,
+    pub d_name: [::std::os::raw::c_char; 1024usize],
 }
 impl Default for dirent {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub const DT_UNKNOWN: ::std::os::raw::c_uint = 0;
-pub const DT_FIFO: ::std::os::raw::c_uint = 1;
-pub const DT_CHR: ::std::os::raw::c_uint = 2;
-pub const DT_DIR: ::std::os::raw::c_uint = 4;
-pub const DT_BLK: ::std::os::raw::c_uint = 6;
-pub const DT_REG: ::std::os::raw::c_uint = 8;
-pub const DT_LNK: ::std::os::raw::c_uint = 10;
-pub const DT_SOCK: ::std::os::raw::c_uint = 12;
-pub const DT_WHT: ::std::os::raw::c_uint = 14;
-pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __dirstream {
+pub struct _telldir {
     _unused: [u8; 0],
 }
-pub type DIR = __dirstream;
-#[pg_guard]
-extern "C" {
-    pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct DIR {
+    pub __dd_fd: ::std::os::raw::c_int,
+    pub __dd_loc: ::std::os::raw::c_long,
+    pub __dd_size: ::std::os::raw::c_long,
+    pub __dd_buf: *mut ::std::os::raw::c_char,
+    pub __dd_len: ::std::os::raw::c_int,
+    pub __dd_seek: ::std::os::raw::c_long,
+    pub __padding: ::std::os::raw::c_long,
+    pub __dd_flags: ::std::os::raw::c_int,
+    pub __dd_lock: __darwin_pthread_mutex_t,
+    pub __dd_td: *mut _telldir,
+}
+impl Default for DIR {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
-    pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
+    pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_opendir$INODE64"]
+    pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+    #[link_name = "\u{1}_readdir$INODE64"]
+    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_readdir_r$INODE64"]
     pub fn readdir_r(
-        __dirp: *mut DIR,
-        __entry: *mut dirent,
-        __result: *mut *mut dirent,
+        arg1: *mut DIR,
+        arg2: *mut dirent,
+        arg3: *mut *mut dirent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rewinddir(__dirp: *mut DIR);
+    #[link_name = "\u{1}_rewinddir$INODE64"]
+    pub fn rewinddir(arg1: *mut DIR);
 }
 #[pg_guard]
 extern "C" {
-    pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
+    #[link_name = "\u{1}_seekdir$INODE64"]
+    pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
 }
 #[pg_guard]
 extern "C" {
-    pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
+    #[link_name = "\u{1}_telldir$INODE64"]
+    pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_fdopendir$INODE64"]
+    pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_alphasort$INODE64"]
+    pub fn alphasort(arg1: *mut *const dirent, arg2: *mut *const dirent) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_scandir$INODE64"]
     pub fn scandir(
-        __dir: *const ::std::os::raw::c_char,
-        __namelist: *mut *mut *mut dirent,
-        __selector: ::std::option::Option<
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut *mut dirent,
+        arg3: ::std::option::Option<
             unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
         >,
-        __cmp: ::std::option::Option<
+        arg4: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut *const dirent,
                 arg2: *mut *const dirent,
@@ -15043,16 +16355,29 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn alphasort(__e1: *mut *const dirent, __e2: *mut *const dirent) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_scandir_b$INODE64"]
+    pub fn scandir_b(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut *mut dirent,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
     pub fn getdirentries(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-        __basep: *mut __off_t,
-    ) -> __ssize_t;
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}___opendir2$INODE64"]
+    pub fn __opendir2(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int)
+        -> *mut DIR;
 }
 pub type File = ::std::os::raw::c_int;
 #[pg_guard]
@@ -17771,7 +19096,6 @@ pub struct Value {
 pub union Value_ValUnion {
     pub ival: ::std::os::raw::c_int,
     pub str_: *mut ::std::os::raw::c_char,
-    _bindgen_union_align: u64,
 }
 impl Default for Value_ValUnion {
     fn default() -> Self {
@@ -23073,651 +24397,160 @@ extern "C" {
         nulls: *mut *mut bool,
     ) -> ::std::os::raw::c_int;
 }
-pub type sig_atomic_t = __sig_atomic_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-    _bindgen_union_align: u64,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __sigval_t = sigval;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub __pad0: ::std::os::raw::c_int,
-    pub _sifields: siginfo_t__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union siginfo_t__bindgen_ty_1 {
-    pub _pad: [::std::os::raw::c_int; 28usize],
-    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
-    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
-    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
-    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
-    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
-    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
-    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
-    _bindgen_union_align: [u64; 14usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
-    pub si_tid: ::std::os::raw::c_int,
-    pub si_overrun: ::std::os::raw::c_int,
-    pub si_sigval: __sigval_t,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-    pub si_sigval: __sigval_t,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_utime: __clock_t,
-    pub si_stime: __clock_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_addr_lsb: ::std::os::raw::c_short,
-    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
-    pub _pkey: __uint32_t,
-    _bindgen_union_align: [u64; 2usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-    pub _lower: *mut ::std::os::raw::c_void,
-    pub _upper: *mut ::std::os::raw::c_void,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
-    pub si_band: ::std::os::raw::c_long,
-    pub si_fd: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
-    pub _call_addr: *mut ::std::os::raw::c_void,
-    pub _syscall: ::std::os::raw::c_int,
-    pub _arch: ::std::os::raw::c_uint,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub const SI_ASYNCNL: ::std::os::raw::c_int = -60;
-pub const SI_DETHREAD: ::std::os::raw::c_int = -7;
-pub const SI_TKILL: ::std::os::raw::c_int = -6;
-pub const SI_SIGIO: ::std::os::raw::c_int = -5;
-pub const SI_ASYNCIO: ::std::os::raw::c_int = -4;
-pub const SI_MESGQ: ::std::os::raw::c_int = -3;
-pub const SI_TIMER: ::std::os::raw::c_int = -2;
-pub const SI_QUEUE: ::std::os::raw::c_int = -1;
-pub const SI_USER: ::std::os::raw::c_int = 0;
-pub const SI_KERNEL: ::std::os::raw::c_int = 128;
-pub type _bindgen_ty_10 = ::std::os::raw::c_int;
-pub const ILL_ILLOPC: ::std::os::raw::c_uint = 1;
-pub const ILL_ILLOPN: ::std::os::raw::c_uint = 2;
-pub const ILL_ILLADR: ::std::os::raw::c_uint = 3;
-pub const ILL_ILLTRP: ::std::os::raw::c_uint = 4;
-pub const ILL_PRVOPC: ::std::os::raw::c_uint = 5;
-pub const ILL_PRVREG: ::std::os::raw::c_uint = 6;
-pub const ILL_COPROC: ::std::os::raw::c_uint = 7;
-pub const ILL_BADSTK: ::std::os::raw::c_uint = 8;
-pub const ILL_BADIADDR: ::std::os::raw::c_uint = 9;
-pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
-pub const FPE_INTDIV: ::std::os::raw::c_uint = 1;
-pub const FPE_INTOVF: ::std::os::raw::c_uint = 2;
-pub const FPE_FLTDIV: ::std::os::raw::c_uint = 3;
-pub const FPE_FLTOVF: ::std::os::raw::c_uint = 4;
-pub const FPE_FLTUND: ::std::os::raw::c_uint = 5;
-pub const FPE_FLTRES: ::std::os::raw::c_uint = 6;
-pub const FPE_FLTINV: ::std::os::raw::c_uint = 7;
-pub const FPE_FLTSUB: ::std::os::raw::c_uint = 8;
-pub const FPE_FLTUNK: ::std::os::raw::c_uint = 14;
-pub const FPE_CONDTRAP: ::std::os::raw::c_uint = 15;
-pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
-pub const SEGV_MAPERR: ::std::os::raw::c_uint = 1;
-pub const SEGV_ACCERR: ::std::os::raw::c_uint = 2;
-pub const SEGV_BNDERR: ::std::os::raw::c_uint = 3;
-pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
-pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
-pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
-pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
-pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
-pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
-pub const BUS_OBJERR: ::std::os::raw::c_uint = 3;
-pub const BUS_MCEERR_AR: ::std::os::raw::c_uint = 4;
-pub const BUS_MCEERR_AO: ::std::os::raw::c_uint = 5;
-pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
-pub const CLD_EXITED: ::std::os::raw::c_uint = 1;
-pub const CLD_KILLED: ::std::os::raw::c_uint = 2;
-pub const CLD_DUMPED: ::std::os::raw::c_uint = 3;
-pub const CLD_TRAPPED: ::std::os::raw::c_uint = 4;
-pub const CLD_STOPPED: ::std::os::raw::c_uint = 5;
-pub const CLD_CONTINUED: ::std::os::raw::c_uint = 6;
-pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
-pub const POLL_IN: ::std::os::raw::c_uint = 1;
-pub const POLL_OUT: ::std::os::raw::c_uint = 2;
-pub const POLL_MSG: ::std::os::raw::c_uint = 3;
-pub const POLL_ERR: ::std::os::raw::c_uint = 4;
-pub const POLL_PRI: ::std::os::raw::c_uint = 5;
-pub const POLL_HUP: ::std::os::raw::c_uint = 6;
-pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
-pub type sigval_t = __sigval_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_value: __sigval_t,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub _sigev_un: sigevent__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigevent__bindgen_ty_1 {
-    pub _pad: [::std::os::raw::c_int; 12usize],
-    pub _tid: __pid_t,
-    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: [u64; 6usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
-    pub _attribute: *mut pthread_attr_t,
-}
-impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigevent__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sigevent_t = sigevent;
-pub const SIGEV_SIGNAL: ::std::os::raw::c_uint = 0;
-pub const SIGEV_NONE: ::std::os::raw::c_uint = 1;
-pub const SIGEV_THREAD: ::std::os::raw::c_uint = 2;
-pub const SIGEV_THREAD_ID: ::std::os::raw::c_uint = 4;
-pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
-pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[pg_guard]
 extern "C" {
-    pub fn __sysv_signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t)
-        -> __sighandler_t;
+    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ssignal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn siggetmask() -> ::std::os::raw::c_int;
-}
-pub type sig_t = __sighandler_t;
-#[pg_guard]
-extern "C" {
-    pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigaddset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigdelset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigismember(
-        __set: *const sigset_t,
-        __signo: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_handler: sigaction__bindgen_ty_1,
-    pub sa_mask: __sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigaction__bindgen_ty_1 {
-    pub sa_handler: __sighandler_t,
-    pub sa_sigaction: ::std::option::Option<
+    pub fn bsd_signal(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
-            arg2: *mut siginfo_t,
-            arg3: *mut ::std::os::raw::c_void,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
         ),
-    >,
-    _bindgen_union_align: u64,
-}
-impl Default for sigaction__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    >;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigprocmask(
-        __how: ::std::os::raw::c_int,
-        __set: *const sigset_t,
-        __oset: *mut sigset_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
+    pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaction(
-        __sig: ::std::os::raw::c_int,
-        __act: *const sigaction,
-        __oact: *mut sigaction,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigwait(
-        __set: *const sigset_t,
-        __sig: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigwaitinfo(__set: *const sigset_t, __info: *mut siginfo_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigtimedwait(
-        __set: *const sigset_t,
-        __info: *mut siginfo_t,
-        __timeout: *const timespec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigqueue(
-        __pid: __pid_t,
-        __sig: ::std::os::raw::c_int,
-        __val: sigval,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpx_sw_bytes {
-    pub magic1: __uint32_t,
-    pub extended_size: __uint32_t,
-    pub xstate_bv: __uint64_t,
-    pub xstate_size: __uint32_t,
-    pub __glibc_reserved1: [__uint32_t; 7usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpxreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _xmmreg {
-    pub element: [__uint32_t; 4usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpstate {
-    pub cwd: __uint16_t,
-    pub swd: __uint16_t,
-    pub ftw: __uint16_t,
-    pub fop: __uint16_t,
-    pub rip: __uint64_t,
-    pub rdp: __uint64_t,
-    pub mxcsr: __uint32_t,
-    pub mxcr_mask: __uint32_t,
-    pub _st: [_fpxreg; 8usize],
-    pub _xmm: [_xmmreg; 16usize],
-    pub __glibc_reserved1: [__uint32_t; 24usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigcontext {
-    pub r8: __uint64_t,
-    pub r9: __uint64_t,
-    pub r10: __uint64_t,
-    pub r11: __uint64_t,
-    pub r12: __uint64_t,
-    pub r13: __uint64_t,
-    pub r14: __uint64_t,
-    pub r15: __uint64_t,
-    pub rdi: __uint64_t,
-    pub rsi: __uint64_t,
-    pub rbp: __uint64_t,
-    pub rbx: __uint64_t,
-    pub rdx: __uint64_t,
-    pub rax: __uint64_t,
-    pub rcx: __uint64_t,
-    pub rsp: __uint64_t,
-    pub rip: __uint64_t,
-    pub eflags: __uint64_t,
-    pub cs: ::std::os::raw::c_ushort,
-    pub gs: ::std::os::raw::c_ushort,
-    pub fs: ::std::os::raw::c_ushort,
-    pub __pad0: ::std::os::raw::c_ushort,
-    pub err: __uint64_t,
-    pub trapno: __uint64_t,
-    pub oldmask: __uint64_t,
-    pub cr2: __uint64_t,
-    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
-    pub __reserved1: [__uint64_t; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigcontext__bindgen_ty_1 {
-    pub fpstate: *mut _fpstate,
-    pub __fpstate_word: __uint64_t,
-    _bindgen_union_align: u64,
-}
-impl Default for sigcontext__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigcontext {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _xsave_hdr {
-    pub xstate_bv: __uint64_t,
-    pub __glibc_reserved1: [__uint64_t; 2usize],
-    pub __glibc_reserved2: [__uint64_t; 5usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _ymmh_state {
-    pub ymmh_space: [__uint32_t; 64usize],
-}
-impl Default for _ymmh_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _xstate {
-    pub fpstate: _fpstate,
-    pub xstate_hdr: _xsave_hdr,
-    pub ymmh: _ymmh_state,
-}
-impl Default for _xstate {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigreturn(__scp: *mut sigcontext) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct stack_t {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_flags: ::std::os::raw::c_int,
-    pub ss_size: usize,
-}
-impl Default for stack_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type greg_t = ::std::os::raw::c_longlong;
-pub type gregset_t = [greg_t; 23usize];
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_fpxreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_xmmreg {
-    pub element: [__uint32_t; 4usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_fpstate {
-    pub cwd: __uint16_t,
-    pub swd: __uint16_t,
-    pub ftw: __uint16_t,
-    pub fop: __uint16_t,
-    pub rip: __uint64_t,
-    pub rdp: __uint64_t,
-    pub mxcsr: __uint32_t,
-    pub mxcr_mask: __uint32_t,
-    pub _st: [_libc_fpxreg; 8usize],
-    pub _xmm: [_libc_xmmreg; 16usize],
-    pub __glibc_reserved1: [__uint32_t; 24usize],
-}
-pub type fpregset_t = *mut _libc_fpstate;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct mcontext_t {
-    pub gregs: gregset_t,
-    pub fpregs: fpregset_t,
-    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
-}
-impl Default for mcontext_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ucontext_t {
-    pub uc_flags: ::std::os::raw::c_ulong,
-    pub uc_link: *mut ucontext_t,
-    pub uc_stack: stack_t,
-    pub uc_mcontext: mcontext_t,
-    pub uc_sigmask: sigset_t,
-    pub __fpregs_mem: _libc_fpstate,
-    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
-}
-impl Default for ucontext_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn siginterrupt(
-        __sig: ::std::os::raw::c_int,
-        __interrupt: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-pub const SS_ONSTACK: ::std::os::raw::c_uint = 1;
-pub const SS_DISABLE: ::std::os::raw::c_uint = 2;
-pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
-#[pg_guard]
-extern "C" {
-    pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigstack(__ss: *mut sigstack, __oss: *mut sigstack) -> ::std::os::raw::c_int;
+    pub fn pthread_kill(arg1: pthread_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn pthread_sigmask(
-        __how: ::std::os::raw::c_int,
-        __newmask: *const __sigset_t,
-        __oldmask: *mut __sigset_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigset_t,
+        arg3: *mut sigset_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_kill(
-        __threadid: pthread_t,
-        __signo: ::std::os::raw::c_int,
+    pub fn sigaction(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigaction,
+        arg3: *mut sigaction,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+    pub fn sigaddset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+    pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigdelset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn siginterrupt(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigismember(arg1: *const sigset_t, arg2: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigprocmask(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigset_t,
+        arg3: *mut sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigset(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+        ),
+    >;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigwait(
+        arg1: *const sigset_t,
+        arg2: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigvec(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sigvec,
+        arg3: *mut sigvec,
+    ) -> ::std::os::raw::c_int;
 }
 pub type pg_time_t = int64;
 #[repr(C)]
@@ -24334,8 +25167,9 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_un {
+    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 108usize],
+    pub sun_path: [::std::os::raw::c_char; 104usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -24965,7 +25799,6 @@ pub struct LWLock {
 pub union LWLockPadded {
     pub lock: LWLock,
     pub pad: [::std::os::raw::c_char; 128usize],
-    _bindgen_union_align: [u32; 32usize],
 }
 impl Default for LWLockPadded {
     fn default() -> Self {
@@ -24977,7 +25810,6 @@ impl Default for LWLockPadded {
 pub union LWLockMinimallyPadded {
     pub lock: LWLock,
     pub pad: [::std::os::raw::c_char; 32usize],
-    _bindgen_union_align: [u32; 8usize],
 }
 impl Default for LWLockMinimallyPadded {
     fn default() -> Self {
@@ -26304,7 +27136,6 @@ pub union PgStat_Msg {
     pub msg_funcpurge: PgStat_MsgFuncpurge,
     pub msg_recoveryconflict: PgStat_MsgRecoveryConflict,
     pub msg_deadlock: PgStat_MsgDeadlock,
-    _bindgen_union_align: [u64; 125usize],
 }
 impl Default for PgStat_Msg {
     fn default() -> Self {
@@ -27841,7 +28672,6 @@ pub struct HeapTupleFields {
 pub union HeapTupleFields__bindgen_ty_1 {
     pub t_cid: CommandId,
     pub t_xvac: TransactionId,
-    _bindgen_union_align: u32,
 }
 impl Default for HeapTupleFields__bindgen_ty_1 {
     fn default() -> Self {
@@ -27874,7 +28704,6 @@ pub struct HeapTupleHeaderData {
 pub union HeapTupleHeaderData__bindgen_ty_1 {
     pub t_heap: HeapTupleFields,
     pub t_datum: DatumTupleFields,
-    _bindgen_union_align: [u32; 3usize],
 }
 impl Default for HeapTupleHeaderData__bindgen_ty_1 {
     fn default() -> Self {
@@ -28081,7 +28910,6 @@ pub union relopt_value__bindgen_ty_1 {
     pub int_val: ::std::os::raw::c_int,
     pub real_val: f64,
     pub string_val: *mut ::std::os::raw::c_char,
-    _bindgen_union_align: u64,
 }
 impl Default for relopt_value__bindgen_ty_1 {
     fn default() -> Self {
@@ -28447,7 +29275,6 @@ pub union SharedInvalidationMessage {
     pub sm: SharedInvalSmgrMsg,
     pub rm: SharedInvalRelmapMsg,
     pub sn: SharedInvalSnapshotMsg,
-    _bindgen_union_align: [u32; 4usize],
 }
 impl Default for SharedInvalidationMessage {
     fn default() -> Self {
@@ -29673,7 +30500,6 @@ impl Default for ExpandedArrayHeader {
 pub union AnyArrayType {
     pub flt: ArrayType,
     pub xpn: ExpandedArrayHeader,
-    _bindgen_union_align: [u64; 17usize],
 }
 impl Default for AnyArrayType {
     fn default() -> Self {
@@ -32406,7 +33232,6 @@ pub union CollectedCommand__bindgen_ty_1 {
     pub createopc: CollectedCommand__bindgen_ty_1__bindgen_ty_5,
     pub atscfg: CollectedCommand__bindgen_ty_1__bindgen_ty_6,
     pub defprivs: CollectedCommand__bindgen_ty_1__bindgen_ty_7,
-    _bindgen_union_align: [u64; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -38352,7 +39177,6 @@ pub union ReorderBufferChange__bindgen_ty_1 {
     pub snapshot: Snapshot,
     pub command_id: CommandId,
     pub tuplecid: ReorderBufferChange__bindgen_ty_1__bindgen_ty_4,
-    _bindgen_union_align: [u64; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -51429,7 +52253,6 @@ pub union JsonbValue__bindgen_ty_1 {
     pub array: JsonbValue__bindgen_ty_1__bindgen_ty_2,
     pub object: JsonbValue__bindgen_ty_1__bindgen_ty_3,
     pub binary: JsonbValue__bindgen_ty_1__bindgen_ty_4,
-    _bindgen_union_align: [u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -53111,11 +53934,6 @@ impl Default for __va_list_tag {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __locale_data {
-    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -181,24 +181,25 @@ pub const BLCKSZ: u32 = 8192;
 pub const DEF_PGPORT: u32 = 28811;
 pub const DEF_PGPORT_STR: &'static [u8; 6usize] = b"28811\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_CBRT: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
 pub const HAVE_CRYPT: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_CRYPT_H: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_SNPRINTF: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DECL_VSNPRINTF: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -208,11 +209,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -222,7 +223,6 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTPTR_T: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
 pub const HAVE_ISINF: u32 = 1;
@@ -233,7 +233,6 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
 pub const HAVE_LONG_LONG_INT: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMMOVE: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
@@ -241,8 +240,9 @@ pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
 pub const HAVE_READLINE_HISTORY_H: u32 = 1;
@@ -252,6 +252,7 @@ pub const HAVE_RINT: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SNPRINTF: u32 = 1;
@@ -264,8 +265,6 @@ pub const HAVE_STRERROR: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRONG_RANDOM: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
@@ -273,29 +272,26 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TM_ZONE: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
 pub const HAVE_TZNAME: u32 = 1;
 pub const HAVE_UINTPTR_T: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNIX_SOCKETS: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
@@ -306,7 +302,6 @@ pub const HAVE_UTIMES: u32 = 1;
 pub const HAVE_UTIME_H: u32 = 1;
 pub const HAVE_VSNPRINTF: u32 = 1;
 pub const HAVE_WCHAR_H: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP16: u32 = 1;
@@ -320,7 +315,6 @@ pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const HAVE__VA_ARGS: u32 = 1;
 pub const INT64_MODIFIER: &'static [u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &'static [u8; 26usize] = b"pgsql-bugs@postgresql.org\0";
@@ -333,7 +327,8 @@ pub const PG_KRB_SRVNAM: &'static [u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &'static [u8; 3usize] = b"11\0";
 pub const PG_VERSION: &'static [u8; 6usize] = b"11.11\0";
 pub const PG_VERSION_NUM: u32 = 110011;
-pub const PG_VERSION_STR : & 'static [u8 ; 115usize] = b"PostgreSQL 11.11 on x86_64-apple-darwin20.3.0, compiled by Apple clang version 12.0.0 (clang-1200.0.32.29), 64-bit\0" ;
+pub const PG_VERSION_STR: &'static [u8; 78usize] =
+    b"PostgreSQL 11.11 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -341,15 +336,13 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -364,510 +357,211 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &'static [u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &'static [u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
-pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
-pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 32;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &'static [u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _I386_SIGNAL_H_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const FP_PREC_24B: u32 = 0;
-pub const FP_PREC_53B: u32 = 2;
-pub const FP_PREC_64B: u32 = 3;
-pub const FP_RND_NEAR: u32 = 0;
-pub const FP_RND_DOWN: u32 = 1;
-pub const FP_RND_UP: u32 = 2;
-pub const FP_CHOP: u32 = 3;
-pub const FP_STATE_BYTES: u32 = 512;
-pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
-pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
-pub const __LASTBRANCH_MAX: u32 = 32;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_CURRENT: u32 = 5;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
+pub const P_tmpdir: &'static [u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -878,7 +572,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -902,88 +596,147 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
@@ -1013,375 +766,355 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &'static [u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &'static [u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &'static [u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &'static [u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_MASTER_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _CTYPE_H: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MAX: u32 = 45;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MAX: u32 = 45;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1393,279 +1126,66 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &'static [u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &'static [u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &'static [u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &'static [u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &'static [u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &'static [u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &'static [u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const _PATH_PWD: &'static [u8; 5usize] = b"/etc\0";
-pub const _PATH_PASSWD: &'static [u8; 12usize] = b"/etc/passwd\0";
-pub const _PASSWD: &'static [u8; 7usize] = b"passwd\0";
-pub const _PATH_MASTERPASSWD: &'static [u8; 19usize] = b"/etc/master.passwd\0";
-pub const _PATH_MASTERPASSWD_LOCK: &'static [u8; 10usize] = b"/etc/ptmp\0";
-pub const _MASTERPASSWD: &'static [u8; 14usize] = b"master.passwd\0";
-pub const _PATH_MP_DB: &'static [u8; 12usize] = b"/etc/pwd.db\0";
-pub const _MP_DB: &'static [u8; 7usize] = b"pwd.db\0";
-pub const _PATH_SMP_DB: &'static [u8; 13usize] = b"/etc/spwd.db\0";
-pub const _SMP_DB: &'static [u8; 8usize] = b"spwd.db\0";
-pub const _PATH_PWD_MKDB: &'static [u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
-pub const _PW_KEYBYNAME: u8 = 49u8;
-pub const _PW_KEYBYNUM: u8 = 50u8;
-pub const _PW_KEYBYUID: u8 = 51u8;
-pub const _PASSWORD_EFMT1: u8 = 95u8;
-pub const _PASSWORD_LEN: u32 = 128;
-pub const _PASSWORD_NOUID: u32 = 1;
-pub const _PASSWORD_NOGID: u32 = 2;
-pub const _PASSWORD_NOCHG: u32 = 4;
-pub const _PASSWORD_NOEXP: u32 = 8;
-pub const _PASSWORD_WARNDAYS: u32 = 14;
-pub const _PASSWORD_CHGNOW: i32 = -1;
+pub const _PWD_H: u32 = 1;
+pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
 pub const PG_BACKEND_VERSIONSTR: &'static [u8; 29usize] = b"postgres (PostgreSQL) 11.11\n\0";
 pub const EXE: &'static [u8; 1usize] = b"\0";
 pub const DEVNULL: &'static [u8; 10usize] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
-pub const FP_SUPERNORMAL: u32 = 6;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1679,13 +1199,8 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const _JBLEN: u32 = 37;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1803,121 +1318,84 @@ pub const LP_DEAD: u32 = 3;
 pub const OffsetNumberMask: u32 = 65535;
 pub const SpecTokenOffsetNumber: u32 = 65534;
 pub const MovedPartitionsOffsetNumber: u32 = 65533;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 8192;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const DSM_IMPL_NONE: u32 = 0;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
@@ -1945,153 +1423,139 @@ pub const AccessExclusiveLock: u32 = 8;
 pub const BITS_PER_BITMAPWORD: u32 = 32;
 pub const RELCACHE_INIT_FILENAME: &'static [u8; 17usize] = b"pg_internal.init\0";
 pub const FIELDNO_HEAPTUPLEDATA_DATA: u32 = 3;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const MAX_TIMESTAMP_PRECISION: u32 = 6;
 pub const MAX_INTERVAL_PRECISION: u32 = 6;
 pub const TS_PREC_INV: f64 = 1000000.0;
@@ -2137,8 +1601,24 @@ pub const HEAP_INSERT_SKIP_FSM: u32 = 2;
 pub const HEAP_INSERT_FROZEN: u32 = 4;
 pub const HEAP_INSERT_SPECULATIVE: u32 = 8;
 pub const HEAP_INSERT_NO_LOGICAL: u32 = 16;
-pub const CLOCKS_PER_SEC: u32 = 1000000;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const PARAM_FLAG_CONST: u32 = 1;
 pub const HASH_PARTITION: u32 = 1;
 pub const HASH_SEGMENT: u32 = 2;
@@ -2155,25 +1635,9 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const DEFAULT_SPINS_PER_DELAY: u32 = 100;
@@ -2267,7 +1731,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const GROUPING_CAN_USE_SORT: u32 = 1;
 pub const GROUPING_CAN_USE_HASH: u32 = 2;
@@ -2290,6 +1753,85 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2308,13 +1850,7 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -3217,7 +2753,6 @@ pub const PROCARRAY_FLAGS_DEFAULT: u32 = 16;
 pub const PROCARRAY_FLAGS_VACUUM: u32 = 18;
 pub const PROCARRAY_FLAGS_ANALYZE: u32 = 20;
 pub const PROCARRAY_FLAGS_VACUUM_ANALYZE: u32 = 22;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &'static [u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3340,429 +2875,195 @@ pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
 pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
-    _bindgen_union_align: [u64; 16usize],
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+    _bindgen_union_align: u32,
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
+}
+impl Default for _G_fpos_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __fpos_t = _G_fpos_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
+}
+impl Default for _G_fpos64_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
-}
-impl Default for __darwin_pthread_handler_rec {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_attr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[pg_guard]
-extern "C" {
-    pub fn renameat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn renamex_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn renameatx_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 #[pg_guard]
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdout: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stderr: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgets(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut FILE,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __mode: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut FILE,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fseek(
-        arg1: *mut FILE,
-        arg2: ::std::os::raw::c_long,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn perror(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3773,39 +3074,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn rewind(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setvbuf(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sscanf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    pub fn renameat(
+        __oldfd: ::std::os::raw::c_int,
+        __old: *const ::std::os::raw::c_char,
+        __newfd: ::std::os::raw::c_int,
+        __new: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3814,135 +3087,207 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vfprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vprintf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn popen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __svfscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flockfile(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn funlockfile(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn tempnam(
         __dir: *const ::std::os::raw::c_char,
-        __prefix: *const ::std::os::raw::c_char,
+        __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-pub type off_t = __darwin_off_t;
 #[pg_guard]
 extern "C" {
-    pub fn fseeko(
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
         __stream: *mut FILE,
-        __offset: off_t,
-        __whence: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
+        -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmemopen(
+        __s: *mut ::std::os::raw::c_void,
+        __len: usize,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn open_memstream(
+        __bufloc: *mut *mut ::std::os::raw::c_char,
+        __sizeloc: *mut usize,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setvbuf(
+        __stream: *mut FILE,
+        __buf: *mut ::std::os::raw::c_char,
+        __modes: ::std::os::raw::c_int,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> off_t;
+    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setlinebuf(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fprintf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vfprintf(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vprintf(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vsprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn snprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vsnprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vdprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sscanf(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_fscanf"]
+    pub fn fscanf1(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_scanf"]
+    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_sscanf"]
+    pub fn sscanf1(
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
         ...
     ) -> ::std::os::raw::c_int;
@@ -3950,2037 +3295,299 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn vfscanf(
-        __stream: *mut FILE,
+        __s: *mut FILE,
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vscanf(
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsnprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vsscanf(
-        __str: *const ::std::os::raw::c_char,
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    #[link_name = "\u{1}__isoc99_vfscanf"]
+    pub fn vfscanf1(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vdprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
+    #[link_name = "\u{1}__isoc99_vscanf"]
+    pub fn vscanf1(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_vsscanf"]
+    pub fn vsscanf1(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgets(
+        __s: *mut ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __getdelim(
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn getdelim(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __delimiter: ::std::os::raw::c_int,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn getline(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmemopen(
-        __buf: *mut ::std::os::raw::c_void,
+    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __s: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread_unlocked(
+        __ptr: *mut ::std::os::raw::c_void,
         __size: usize,
-        __mode: *const ::std::os::raw::c_char,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite_unlocked(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: usize,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseek(
+        __stream: *mut FILE,
+        __off: ::std::os::raw::c_long,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rewind(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseeko(
+        __stream: *mut FILE,
+        __off: __off_t,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftello(__stream: *mut FILE) -> __off_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr_unlocked(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn perror(__s: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn popen(
+        __command: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn open_memstream(
-        __bufp: *mut *mut ::std::os::raw::c_char,
-        __sizep: *mut usize,
-    ) -> *mut FILE;
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
+    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+    pub fn flockfile(__stream: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn asprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn funlockfile(__stream: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmtcheck(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-#[pg_guard]
-extern "C" {
-    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuffer(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vasprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn zopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn funopen(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg3: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg4: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: fpos_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> fpos_t,
-        >,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-        >,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __snprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __vsprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __vsnprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        arg6: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_i386_thread_state {
-    pub __eax: ::std::os::raw::c_uint,
-    pub __ebx: ::std::os::raw::c_uint,
-    pub __ecx: ::std::os::raw::c_uint,
-    pub __edx: ::std::os::raw::c_uint,
-    pub __edi: ::std::os::raw::c_uint,
-    pub __esi: ::std::os::raw::c_uint,
-    pub __ebp: ::std::os::raw::c_uint,
-    pub __esp: ::std::os::raw::c_uint,
-    pub __ss: ::std::os::raw::c_uint,
-    pub __eflags: ::std::os::raw::c_uint,
-    pub __eip: ::std::os::raw::c_uint,
-    pub __cs: ::std::os::raw::c_uint,
-    pub __ds: ::std::os::raw::c_uint,
-    pub __es: ::std::os::raw::c_uint,
-    pub __fs: ::std::os::raw::c_uint,
-    pub __gs: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_fp_control {
-    pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-}
-impl __darwin_fp_control {
-    #[inline]
-    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
-    }
-    #[inline]
-    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 2u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
-    }
-    #[inline]
-    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(10usize, 2u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __invalid: ::std::os::raw::c_ushort,
-        __denorm: ::std::os::raw::c_ushort,
-        __zdiv: ::std::os::raw::c_ushort,
-        __ovrfl: ::std::os::raw::c_ushort,
-        __undfl: ::std::os::raw::c_ushort,
-        __precis: ::std::os::raw::c_ushort,
-        __pc: ::std::os::raw::c_ushort,
-        __rc: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
-            __invalid as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
-            __denorm as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
-            __zdiv as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
-            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
-            __ovrfl as u64
-        });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
-            __undfl as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
-            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
-            __precis as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 2u8, {
-            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
-            __pc as u64
-        });
-        __bindgen_bitfield_unit.set(10usize, 2u8, {
-            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
-            __rc as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-pub type __darwin_fp_control_t = __darwin_fp_control;
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_fp_status {
-    pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-}
-impl __darwin_fp_status {
-    #[inline]
-    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(6usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(9usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(10usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
-    }
-    #[inline]
-    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(11usize, 3u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(14usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(15usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __invalid: ::std::os::raw::c_ushort,
-        __denorm: ::std::os::raw::c_ushort,
-        __zdiv: ::std::os::raw::c_ushort,
-        __ovrfl: ::std::os::raw::c_ushort,
-        __undfl: ::std::os::raw::c_ushort,
-        __precis: ::std::os::raw::c_ushort,
-        __stkflt: ::std::os::raw::c_ushort,
-        __errsumm: ::std::os::raw::c_ushort,
-        __c0: ::std::os::raw::c_ushort,
-        __c1: ::std::os::raw::c_ushort,
-        __c2: ::std::os::raw::c_ushort,
-        __tos: ::std::os::raw::c_ushort,
-        __c3: ::std::os::raw::c_ushort,
-        __busy: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
-            __invalid as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
-            __denorm as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
-            __zdiv as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
-            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
-            __ovrfl as u64
-        });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
-            __undfl as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
-            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
-            __precis as u64
-        });
-        __bindgen_bitfield_unit.set(6usize, 1u8, {
-            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
-            __stkflt as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
-            __errsumm as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 1u8, {
-            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
-            __c0 as u64
-        });
-        __bindgen_bitfield_unit.set(9usize, 1u8, {
-            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
-            __c1 as u64
-        });
-        __bindgen_bitfield_unit.set(10usize, 1u8, {
-            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
-            __c2 as u64
-        });
-        __bindgen_bitfield_unit.set(11usize, 3u8, {
-            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
-            __tos as u64
-        });
-        __bindgen_bitfield_unit.set(14usize, 1u8, {
-            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
-            __c3 as u64
-        });
-        __bindgen_bitfield_unit.set(15usize, 1u8, {
-            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
-            __busy as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-pub type __darwin_fp_status_t = __darwin_fp_status;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mmst_reg {
-    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
-    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_xmm_reg {
-    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_ymm_reg {
-    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_zmm_reg {
-    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
-}
-impl Default for __darwin_zmm_reg {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_opmask_reg {
-    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_float_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-}
-impl Default for __darwin_i386_float_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_avx_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-}
-impl Default for __darwin_i386_avx_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_avx512_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_k0: __darwin_opmask_reg,
-    pub __fpu_k1: __darwin_opmask_reg,
-    pub __fpu_k2: __darwin_opmask_reg,
-    pub __fpu_k3: __darwin_opmask_reg,
-    pub __fpu_k4: __darwin_opmask_reg,
-    pub __fpu_k5: __darwin_opmask_reg,
-    pub __fpu_k6: __darwin_opmask_reg,
-    pub __fpu_k7: __darwin_opmask_reg,
-    pub __fpu_zmmh0: __darwin_ymm_reg,
-    pub __fpu_zmmh1: __darwin_ymm_reg,
-    pub __fpu_zmmh2: __darwin_ymm_reg,
-    pub __fpu_zmmh3: __darwin_ymm_reg,
-    pub __fpu_zmmh4: __darwin_ymm_reg,
-    pub __fpu_zmmh5: __darwin_ymm_reg,
-    pub __fpu_zmmh6: __darwin_ymm_reg,
-    pub __fpu_zmmh7: __darwin_ymm_reg,
-}
-impl Default for __darwin_i386_avx512_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_i386_exception_state {
-    pub __trapno: __uint16_t,
-    pub __cpu: __uint16_t,
-    pub __err: __uint32_t,
-    pub __faultvaddr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_debug_state32 {
-    pub __dr0: ::std::os::raw::c_uint,
-    pub __dr1: ::std::os::raw::c_uint,
-    pub __dr2: ::std::os::raw::c_uint,
-    pub __dr3: ::std::os::raw::c_uint,
-    pub __dr4: ::std::os::raw::c_uint,
-    pub __dr5: ::std::os::raw::c_uint,
-    pub __dr6: ::std::os::raw::c_uint,
-    pub __dr7: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __x86_instruction_state {
-    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
-    pub __insn_offset: ::std::os::raw::c_int,
-    pub __out_of_synch: ::std::os::raw::c_int,
-    pub __insn_bytes: [__uint8_t; 2380usize],
-    pub __insn_cacheline: [__uint8_t; 64usize],
-}
-impl Default for __x86_instruction_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __last_branch_record {
-    pub __from_ip: __uint64_t,
-    pub __to_ip: __uint64_t,
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __bindgen_padding_0: u32,
-}
-impl __last_branch_record {
-    #[inline]
-    pub fn __mispredict(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___mispredict(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __tsx_abort(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __in_tsx(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___in_tsx(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __cycle_count(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set___cycle_count(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __reserved(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
-    }
-    #[inline]
-    pub fn set___reserved(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(19usize, 13u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __mispredict: __uint32_t,
-        __tsx_abort: __uint32_t,
-        __in_tsx: __uint32_t,
-        __cycle_count: __uint32_t,
-        __reserved: __uint32_t,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
-            __mispredict as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
-            __tsx_abort as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
-            __in_tsx as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 16u8, {
-            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
-            __cycle_count as u64
-        });
-        __bindgen_bitfield_unit.set(19usize, 13u8, {
-            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
-            __reserved as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __last_branch_state {
-    pub __lbr_count: ::std::os::raw::c_int,
-    pub _bitfield_align_1: [u32; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __lbrs: [__last_branch_record; 32usize],
-}
-impl __last_branch_state {
-    #[inline]
-    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __reserved(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
-    }
-    #[inline]
-    pub fn set___reserved(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 30u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __lbr_supported_tsx: __uint32_t,
-        __lbr_supported_cycle_count: __uint32_t,
-        __reserved: __uint32_t,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
-            __lbr_supported_tsx as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __lbr_supported_cycle_count: u32 =
-                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
-            __lbr_supported_cycle_count as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 30u8, {
-            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
-            __reserved as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __x86_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_thread_state64 {
-    pub __rax: __uint64_t,
-    pub __rbx: __uint64_t,
-    pub __rcx: __uint64_t,
-    pub __rdx: __uint64_t,
-    pub __rdi: __uint64_t,
-    pub __rsi: __uint64_t,
-    pub __rbp: __uint64_t,
-    pub __rsp: __uint64_t,
-    pub __r8: __uint64_t,
-    pub __r9: __uint64_t,
-    pub __r10: __uint64_t,
-    pub __r11: __uint64_t,
-    pub __r12: __uint64_t,
-    pub __r13: __uint64_t,
-    pub __r14: __uint64_t,
-    pub __r15: __uint64_t,
-    pub __rip: __uint64_t,
-    pub __rflags: __uint64_t,
-    pub __cs: __uint64_t,
-    pub __fs: __uint64_t,
-    pub __gs: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_thread_full_state64 {
-    pub __ss64: __darwin_x86_thread_state64,
-    pub __ds: __uint64_t,
-    pub __es: __uint64_t,
-    pub __ss: __uint64_t,
-    pub __gsbase: __uint64_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_float_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-}
-impl Default for __darwin_x86_float_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_avx_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_ymmh8: __darwin_xmm_reg,
-    pub __fpu_ymmh9: __darwin_xmm_reg,
-    pub __fpu_ymmh10: __darwin_xmm_reg,
-    pub __fpu_ymmh11: __darwin_xmm_reg,
-    pub __fpu_ymmh12: __darwin_xmm_reg,
-    pub __fpu_ymmh13: __darwin_xmm_reg,
-    pub __fpu_ymmh14: __darwin_xmm_reg,
-    pub __fpu_ymmh15: __darwin_xmm_reg,
-}
-impl Default for __darwin_x86_avx_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_avx512_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_ymmh8: __darwin_xmm_reg,
-    pub __fpu_ymmh9: __darwin_xmm_reg,
-    pub __fpu_ymmh10: __darwin_xmm_reg,
-    pub __fpu_ymmh11: __darwin_xmm_reg,
-    pub __fpu_ymmh12: __darwin_xmm_reg,
-    pub __fpu_ymmh13: __darwin_xmm_reg,
-    pub __fpu_ymmh14: __darwin_xmm_reg,
-    pub __fpu_ymmh15: __darwin_xmm_reg,
-    pub __fpu_k0: __darwin_opmask_reg,
-    pub __fpu_k1: __darwin_opmask_reg,
-    pub __fpu_k2: __darwin_opmask_reg,
-    pub __fpu_k3: __darwin_opmask_reg,
-    pub __fpu_k4: __darwin_opmask_reg,
-    pub __fpu_k5: __darwin_opmask_reg,
-    pub __fpu_k6: __darwin_opmask_reg,
-    pub __fpu_k7: __darwin_opmask_reg,
-    pub __fpu_zmmh0: __darwin_ymm_reg,
-    pub __fpu_zmmh1: __darwin_ymm_reg,
-    pub __fpu_zmmh2: __darwin_ymm_reg,
-    pub __fpu_zmmh3: __darwin_ymm_reg,
-    pub __fpu_zmmh4: __darwin_ymm_reg,
-    pub __fpu_zmmh5: __darwin_ymm_reg,
-    pub __fpu_zmmh6: __darwin_ymm_reg,
-    pub __fpu_zmmh7: __darwin_ymm_reg,
-    pub __fpu_zmmh8: __darwin_ymm_reg,
-    pub __fpu_zmmh9: __darwin_ymm_reg,
-    pub __fpu_zmmh10: __darwin_ymm_reg,
-    pub __fpu_zmmh11: __darwin_ymm_reg,
-    pub __fpu_zmmh12: __darwin_ymm_reg,
-    pub __fpu_zmmh13: __darwin_ymm_reg,
-    pub __fpu_zmmh14: __darwin_ymm_reg,
-    pub __fpu_zmmh15: __darwin_ymm_reg,
-    pub __fpu_zmm16: __darwin_zmm_reg,
-    pub __fpu_zmm17: __darwin_zmm_reg,
-    pub __fpu_zmm18: __darwin_zmm_reg,
-    pub __fpu_zmm19: __darwin_zmm_reg,
-    pub __fpu_zmm20: __darwin_zmm_reg,
-    pub __fpu_zmm21: __darwin_zmm_reg,
-    pub __fpu_zmm22: __darwin_zmm_reg,
-    pub __fpu_zmm23: __darwin_zmm_reg,
-    pub __fpu_zmm24: __darwin_zmm_reg,
-    pub __fpu_zmm25: __darwin_zmm_reg,
-    pub __fpu_zmm26: __darwin_zmm_reg,
-    pub __fpu_zmm27: __darwin_zmm_reg,
-    pub __fpu_zmm28: __darwin_zmm_reg,
-    pub __fpu_zmm29: __darwin_zmm_reg,
-    pub __fpu_zmm30: __darwin_zmm_reg,
-    pub __fpu_zmm31: __darwin_zmm_reg,
-}
-impl Default for __darwin_x86_avx512_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_exception_state64 {
-    pub __trapno: __uint16_t,
-    pub __cpu: __uint16_t,
-    pub __err: __uint32_t,
-    pub __faultvaddr: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_debug_state64 {
-    pub __dr0: __uint64_t,
-    pub __dr1: __uint64_t,
-    pub __dr2: __uint64_t,
-    pub __dr3: __uint64_t,
-    pub __dr4: __uint64_t,
-    pub __dr5: __uint64_t,
-    pub __dr6: __uint64_t,
-    pub __dr7: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_float_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_avx_state,
-}
-impl Default for __darwin_mcontext_avx32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_avx512_state,
-}
-impl Default for __darwin_mcontext_avx512_32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_float_state64,
-}
-impl Default for __darwin_mcontext64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_float_state64,
-}
-impl Default for __darwin_mcontext64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_avx_state64,
-}
-impl Default for __darwin_mcontext_avx64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_avx_state64,
-}
-impl Default for __darwin_mcontext_avx64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_avx512_state64,
-}
-impl Default for __darwin_mcontext_avx512_64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_avx512_state64,
-}
-impl Default for __darwin_mcontext_avx512_64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-    _bindgen_union_align: u64,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    _bindgen_union_align: u64,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-pub type rusage_info_current = rusage_info_v5;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setpriority(
-        arg1: ::std::os::raw::c_int,
-        arg2: id_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-    _bindgen_union_align: u32,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn waitpid(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn waitid(
-        arg1: idtype_t,
-        arg2: id_t,
-        arg3: *mut siginfo_t,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait3(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut rusage,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait4(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut rusage,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -6001,7 +3608,595 @@ pub struct lldiv_t {
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+    pub fn __ctype_get_mb_cur_max() -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtod(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtof(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtold(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtol(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoul(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtouq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoll(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoull(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[pg_guard]
+extern "C" {
+    pub fn select(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *mut timeval,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pselect(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *const timespec,
+        __sigmask: *const __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __bindgen_anon_1: __pthread_cond_s__bindgen_ty_1,
+    pub __bindgen_anon_2: __pthread_cond_s__bindgen_ty_2,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __pthread_cond_s__bindgen_ty_1 {
+    pub __wseq: ::std::os::raw::c_ulonglong,
+    pub __wseq32: __pthread_cond_s__bindgen_ty_1__bindgen_ty_1,
+    _bindgen_union_align: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_cond_s__bindgen_ty_1__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __pthread_cond_s__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __pthread_cond_s__bindgen_ty_2 {
+    pub __g1_start: ::std::os::raw::c_ulonglong,
+    pub __g1_start32: __pthread_cond_s__bindgen_ty_2__bindgen_ty_1,
+    _bindgen_union_align: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_cond_s__bindgen_ty_2__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __pthread_cond_s__bindgen_ty_2 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 7usize],
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 5usize],
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+    _bindgen_union_align: [u64; 6usize],
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 7usize],
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: u64,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 4usize],
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn random() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom(__seed: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn initstate(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom_r(
+        __seed: ::std::os::raw::c_uint,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn initstate_r(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate_r(
+        __statebuf: *mut ::std::os::raw::c_char,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand(__seed: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48(__seedval: ::std::os::raw::c_long);
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48_r(
+        __seedval: ::std::os::raw::c_long,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48_r(
+        __seed16v: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48_r(
+        __param: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -6010,13 +4205,9 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn calloc(
-        __count: ::std::os::raw::c_ulong,
+        __nmemb: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -6027,11 +4218,23 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+    pub fn reallocarray(
+        __ptr: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
+}
+#[pg_guard]
+extern "C" {
+    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -6043,74 +4246,247 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
     pub fn abort();
 }
 #[pg_guard]
 extern "C" {
-    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+    pub fn at_quick_exit(
+        __func: ::std::option::Option<unsafe extern "C" fn()>,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+    pub fn on_exit(
+        __func: ::std::option::Option<
+            unsafe extern "C" fn(
+                __status: ::std::os::raw::c_int,
+                __arg: *mut ::std::os::raw::c_void,
+            ),
+        >,
+        __arg: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn exit(__status: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+    pub fn quick_exit(__status: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+    pub fn _Exit(__status: ::std::os::raw::c_int);
 }
+#[pg_guard]
+extern "C" {
+    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setenv(
+        __name: *const ::std::os::raw::c_char,
+        __value: *const ::std::os::raw::c_char,
+        __replace: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearenv() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemps(
+        __template: *mut ::std::os::raw::c_char,
+        __suffixlen: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn realpath(
+        __name: *const ::std::os::raw::c_char,
+        __resolved: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[pg_guard]
 extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn exit(arg1: ::std::os::raw::c_int);
+    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
+    pub fn lldiv(
+        __numer: ::std::os::raw::c_longlong,
+        __denom: ::std::os::raw::c_longlong,
+    ) -> lldiv_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qecvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qfcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qgcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qecvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qfcvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -6118,594 +4494,70 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
-}
-#[pg_guard]
-extern "C" {
     pub fn mbtowc(
-        arg1: *mut wchar_t,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: usize,
+        __pwc: *mut wchar_t,
+        __s: *const ::std::os::raw::c_char,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
+    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
+    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn srand(arg1: ::std::os::raw::c_uint);
+    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtod(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtof(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtol(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtold(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoll(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoul(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoull(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _Exit(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn getsubopt(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+        __optionp: *mut *mut ::std::os::raw::c_char,
+        __tokens: *const *mut ::std::os::raw::c_char,
+        __valuep: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn initstate(
-        arg1: ::std::os::raw::c_uint,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ptsname_r(
-        fildes: ::std::os::raw::c_int,
-        buffer: *mut ::std::os::raw::c_char,
-        buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-    pub fn realpath(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __overwrite: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setkey(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48(arg1: ::std::os::raw::c_long);
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom(arg1: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[pg_guard]
-extern "C" {
-    pub fn arc4random() -> u32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_stir();
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bsearch_b(
-        __key: *const ::std::os::raw::c_void,
-        __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+    pub fn memcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cgetcap(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetclose() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetfirst(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetmatch(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetnext(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetnum(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetstr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetustr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_daemon$1050"]
-    pub fn daemon(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn devname_r(
-        arg1: dev_t,
-        arg2: mode_t,
-        buf: *mut ::std::os::raw::c_char,
-        len: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getbsize(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_long,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprogname() -> *const ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn heapsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn heapsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mergesort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mergesort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn qsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn qsort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn radixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sradixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sranddev();
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandomdev();
-}
-#[pg_guard]
-extern "C" {
-    pub fn reallocf(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
+    pub fn memmove(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtonum(
-        __numstr: *const ::std::os::raw::c_char,
-        __minval: ::std::os::raw::c_longlong,
-        __maxval: ::std::os::raw::c_longlong,
-        __errstrp: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_longlong;
+    pub fn memccpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtoq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtouq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
+    pub fn memset(
+        __s: *mut ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -6720,40 +4572,40 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn memcpy(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmove(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset(
-        __b: *mut ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
+    pub fn strcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strncat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -6765,43 +4617,6 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcspn(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
     pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
@@ -6810,17 +4625,68 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncpy(
-        __dst: *mut ::std::os::raw::c_char,
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm(
+        __dest: *mut ::std::os::raw::c_char,
         __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[pg_guard]
+extern "C" {
+    pub fn strcoll_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __l: locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm_l(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+        __l: locale_t,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strndup(
+        __string: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strpbrk(
+    pub fn strchr(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -6832,170 +4698,164 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strspn(
+    pub fn strcspn(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __reject: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
     pub fn strstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
+        __haystack: *const ::std::os::raw::c_char,
+        __needle: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strtok(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strxfrm(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn __strtok_r(
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strtok_r(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
-        __lasts: *mut *mut ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__xpg_strerror_r"]
     pub fn strerror_r(
         __errnum: ::std::os::raw::c_int,
-        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buf: *mut ::std::os::raw::c_char,
         __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn strerror_l(
+        __errnum: ::std::os::raw::c_int,
+        __l: locale_t,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memccpy(
-        __dst: *mut ::std::os::raw::c_void,
+    pub fn bcmp(
+        __s1: *const ::std::os::raw::c_void,
+        __s2: *const ::std::os::raw::c_void,
+        __n: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcopy(
         __src: *const ::std::os::raw::c_void,
+        __dest: *mut ::std::os::raw::c_void,
+        __n: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
+}
+#[pg_guard]
+extern "C" {
+    pub fn index(
+        __s: *const ::std::os::raw::c_char,
         __c: ::std::os::raw::c_int,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn stpcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpncpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
+    pub fn rindex(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strndup(
+    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcasecmp(
         __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strncasecmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn strcasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[pg_guard]
-extern "C" {
-    pub fn memset_s(
-        __s: *mut ::std::os::raw::c_void,
-        __smax: rsize_t,
-        __c: ::std::os::raw::c_int,
-        __n: rsize_t,
-    ) -> errno_t;
+    pub fn strncasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __n: usize,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmem(
-        __big: *const ::std::os::raw::c_void,
-        __big_len: usize,
-        __little: *const ::std::os::raw::c_void,
-        __little_len: usize,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern4(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern4: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern8(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern8: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern16(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern16: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcasestr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strnstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-        __len: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
 }
 #[pg_guard]
 extern "C" {
@@ -7006,158 +4866,67 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn swab(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: isize,
-    );
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timingsafe_bcmp(
-        __b1: *const ::std::os::raw::c_void,
-        __b2: *const ::std::os::raw::c_void,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strsignal_r(
-        __sig: ::std::os::raw::c_int,
-        __strsignalbuf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcmp(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcopy(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-}
-#[pg_guard]
-extern "C" {
-    pub fn index(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn __stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rindex(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+    pub fn stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
-#[pg_guard]
-extern "C" {
-    pub fn strncasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-pub type max_align_t = u128;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[pg_guard]
 extern "C" {
-    pub fn __darwin_check_fd_set_overflow(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[pg_guard]
-extern "C" {
-    pub fn __error() -> *mut ::std::os::raw::c_int;
+    pub fn __errno_location() -> *mut ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7181,8 +4950,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -7194,14 +4963,34 @@ impl Default for lconv {
 }
 #[pg_guard]
 extern "C" {
+    pub fn setlocale(
+        __category: ::std::os::raw::c_int,
+        __locale: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
     pub fn localeconv() -> *mut lconv;
 }
 #[pg_guard]
 extern "C" {
-    pub fn setlocale(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn newlocale(
+        __category_mask: ::std::os::raw::c_int,
+        __locale: *const ::std::os::raw::c_char,
+        __base: locale_t,
+    ) -> locale_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn duplocale(__dataset: locale_t) -> locale_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freelocale(__dataset: locale_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uselocale(__dataset: locale_t) -> locale_t;
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
 pub type int8 = ::std::os::raw::c_schar;
@@ -7314,115 +5103,167 @@ impl Default for PGAlignedXLogBlock {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const _ISupper: ::std::os::raw::c_uint = 256;
+pub const _ISlower: ::std::os::raw::c_uint = 512;
+pub const _ISalpha: ::std::os::raw::c_uint = 1024;
+pub const _ISdigit: ::std::os::raw::c_uint = 2048;
+pub const _ISxdigit: ::std::os::raw::c_uint = 4096;
+pub const _ISspace: ::std::os::raw::c_uint = 8192;
+pub const _ISprint: ::std::os::raw::c_uint = 16384;
+pub const _ISgraph: ::std::os::raw::c_uint = 32768;
+pub const _ISblank: ::std::os::raw::c_uint = 1;
+pub const _IScntrl: ::std::os::raw::c_uint = 2;
+pub const _ISpunct: ::std::os::raw::c_uint = 4;
+pub const _ISalnum: ::std::os::raw::c_uint = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
+    pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
+    pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
+    pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __maskrune(
-        arg1: __darwin_ct_rune_t,
-        arg2: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
+    pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-pub type socklen_t = __darwin_socklen_t;
-pub type sa_family_t = __uint8_t;
+#[pg_guard]
+extern "C" {
+    pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -7434,71 +5275,67 @@ impl Default for iovec {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
-}
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const MSG_OOB: ::std::os::raw::c_uint = 1;
+pub const MSG_PEEK: ::std::os::raw::c_uint = 2;
+pub const MSG_DONTROUTE: ::std::os::raw::c_uint = 4;
+pub const MSG_CTRUNC: ::std::os::raw::c_uint = 8;
+pub const MSG_PROXY: ::std::os::raw::c_uint = 16;
+pub const MSG_TRUNC: ::std::os::raw::c_uint = 32;
+pub const MSG_DONTWAIT: ::std::os::raw::c_uint = 64;
+pub const MSG_EOR: ::std::os::raw::c_uint = 128;
+pub const MSG_WAITALL: ::std::os::raw::c_uint = 256;
+pub const MSG_FIN: ::std::os::raw::c_uint = 512;
+pub const MSG_SYN: ::std::os::raw::c_uint = 1024;
+pub const MSG_CONFIRM: ::std::os::raw::c_uint = 2048;
+pub const MSG_RST: ::std::os::raw::c_uint = 4096;
+pub const MSG_ERRQUEUE: ::std::os::raw::c_uint = 8192;
+pub const MSG_NOSIGNAL: ::std::os::raw::c_uint = 16384;
+pub const MSG_MORE: ::std::os::raw::c_uint = 32768;
+pub const MSG_WAITFORONE: ::std::os::raw::c_uint = 65536;
+pub const MSG_BATCH: ::std::os::raw::c_uint = 262144;
+pub const MSG_ZEROCOPY: ::std::os::raw::c_uint = 67108864;
+pub const MSG_FASTOPEN: ::std::os::raw::c_uint = 536870912;
+pub const MSG_CMSG_CLOEXEC: ::std::os::raw::c_uint = 1073741824;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -7507,225 +5344,239 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+}
+pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn accept(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bind(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sockaddr,
-        arg3: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn connect(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sockaddr,
-        arg3: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpeername(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockname(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockopt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_void,
-        arg5: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn listen(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recv(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recvfrom(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-        arg5: *mut sockaddr,
-        arg6: *mut socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recvmsg(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut msghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn send(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendmsg(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const msghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendto(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-        arg5: *const sockaddr,
-        arg6: socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setsockopt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_void,
-        arg5: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn shutdown(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
+pub const SHUT_RD: ::std::os::raw::c_uint = 0;
+pub const SHUT_WR: ::std::os::raw::c_uint = 1;
+pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn socket(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
+        __domain: ::std::os::raw::c_int,
+        __type: ::std::os::raw::c_int,
+        __protocol: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn socketpair(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
+        __domain: ::std::os::raw::c_int,
+        __type: ::std::os::raw::c_int,
+        __protocol: ::std::os::raw::c_int,
+        __fds: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sendfile(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: off_t,
-        arg4: *mut off_t,
-        arg5: *mut sf_hdtr,
-        arg6: ::std::os::raw::c_int,
+    pub fn bind(
+        __fd: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-}
-#[pg_guard]
-extern "C" {
-    pub fn connectx(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sa_endpoints_t,
-        arg3: sae_associd_t,
-        arg4: ::std::os::raw::c_uint,
-        arg5: *const iovec,
-        arg6: ::std::os::raw::c_uint,
-        arg7: *mut usize,
-        arg8: *mut sae_connid_t,
+    pub fn getsockname(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __len: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn disconnectx(
-        arg1: ::std::os::raw::c_int,
-        arg2: sae_associd_t,
-        arg3: sae_connid_t,
+    pub fn connect(
+        __fd: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
+#[pg_guard]
+extern "C" {
+    pub fn getpeername(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __len: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn send(
+        __fd: ::std::os::raw::c_int,
+        __buf: *const ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recv(
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendto(
+        __fd: ::std::os::raw::c_int,
+        __buf: *const ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __addr_len: socklen_t,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recvfrom(
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __addr_len: *mut socklen_t,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendmsg(
+        __fd: ::std::os::raw::c_int,
+        __message: *const msghdr,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recvmsg(
+        __fd: ::std::os::raw::c_int,
+        __message: *mut msghdr,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsockopt(
+        __fd: ::std::os::raw::c_int,
+        __level: ::std::os::raw::c_int,
+        __optname: ::std::os::raw::c_int,
+        __optval: *mut ::std::os::raw::c_void,
+        __optlen: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setsockopt(
+        __fd: ::std::os::raw::c_int,
+        __level: ::std::os::raw::c_int,
+        __optname: ::std::os::raw::c_int,
+        __optval: *const ::std::os::raw::c_void,
+        __optlen: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn accept(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __addr_len: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn shutdown(
+        __fd: ::std::os::raw::c_int,
+        __how: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isfdtype(
+        __fd: ::std::os::raw::c_int,
+        __fdtype: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -7740,12 +5591,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -7753,113 +5598,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn setipv4sourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: in_addr,
-        arg3: in_addr,
-        arg4: u32,
-        arg5: u32,
-        arg6: *mut in_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipv4sourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: in_addr,
-        arg3: in_addr,
-        arg4: *mut u32,
-        arg5: *mut u32,
-        arg6: *mut in_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setsourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: u32,
-        arg3: *mut sockaddr,
-        arg4: socklen_t,
-        arg5: u32,
-        arg6: u32,
-        arg7: *mut sockaddr_storage,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: u32,
-        arg3: *mut sockaddr,
-        arg4: socklen_t,
-        arg5: *mut u32,
-        arg6: *mut u32,
-        arg7: *mut sockaddr_storage,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: ::std::os::raw::c_uint = 0;
+pub const IPPROTO_ICMP: ::std::os::raw::c_uint = 1;
+pub const IPPROTO_IGMP: ::std::os::raw::c_uint = 2;
+pub const IPPROTO_IPIP: ::std::os::raw::c_uint = 4;
+pub const IPPROTO_TCP: ::std::os::raw::c_uint = 6;
+pub const IPPROTO_EGP: ::std::os::raw::c_uint = 8;
+pub const IPPROTO_PUP: ::std::os::raw::c_uint = 12;
+pub const IPPROTO_UDP: ::std::os::raw::c_uint = 17;
+pub const IPPROTO_IDP: ::std::os::raw::c_uint = 22;
+pub const IPPROTO_TP: ::std::os::raw::c_uint = 29;
+pub const IPPROTO_DCCP: ::std::os::raw::c_uint = 33;
+pub const IPPROTO_IPV6: ::std::os::raw::c_uint = 41;
+pub const IPPROTO_RSVP: ::std::os::raw::c_uint = 46;
+pub const IPPROTO_GRE: ::std::os::raw::c_uint = 47;
+pub const IPPROTO_ESP: ::std::os::raw::c_uint = 50;
+pub const IPPROTO_AH: ::std::os::raw::c_uint = 51;
+pub const IPPROTO_MTP: ::std::os::raw::c_uint = 92;
+pub const IPPROTO_BEETPH: ::std::os::raw::c_uint = 94;
+pub const IPPROTO_ENCAP: ::std::os::raw::c_uint = 98;
+pub const IPPROTO_PIM: ::std::os::raw::c_uint = 103;
+pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
+pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
+pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
+pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
+pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
+pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
+pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
+pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
+pub const IPPROTO_FRAGMENT: ::std::os::raw::c_uint = 44;
+pub const IPPROTO_ICMPV6: ::std::os::raw::c_uint = 58;
+pub const IPPROTO_NONE: ::std::os::raw::c_uint = 59;
+pub const IPPROTO_DSTOPTS: ::std::os::raw::c_uint = 60;
+pub const IPPROTO_MH: ::std::os::raw::c_uint = 135;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: ::std::os::raw::c_uint = 7;
+pub const IPPORT_DISCARD: ::std::os::raw::c_uint = 9;
+pub const IPPORT_SYSTAT: ::std::os::raw::c_uint = 11;
+pub const IPPORT_DAYTIME: ::std::os::raw::c_uint = 13;
+pub const IPPORT_NETSTAT: ::std::os::raw::c_uint = 15;
+pub const IPPORT_FTP: ::std::os::raw::c_uint = 21;
+pub const IPPORT_TELNET: ::std::os::raw::c_uint = 23;
+pub const IPPORT_SMTP: ::std::os::raw::c_uint = 25;
+pub const IPPORT_TIMESERVER: ::std::os::raw::c_uint = 37;
+pub const IPPORT_NAMESERVER: ::std::os::raw::c_uint = 42;
+pub const IPPORT_WHOIS: ::std::os::raw::c_uint = 43;
+pub const IPPORT_MTP: ::std::os::raw::c_uint = 57;
+pub const IPPORT_TFTP: ::std::os::raw::c_uint = 69;
+pub const IPPORT_RJE: ::std::os::raw::c_uint = 77;
+pub const IPPORT_FINGER: ::std::os::raw::c_uint = 79;
+pub const IPPORT_TTYLINK: ::std::os::raw::c_uint = 87;
+pub const IPPORT_SUPDUP: ::std::os::raw::c_uint = 95;
+pub const IPPORT_EXECSERVER: ::std::os::raw::c_uint = 512;
+pub const IPPORT_LOGINSERVER: ::std::os::raw::c_uint = 513;
+pub const IPPORT_CMDSERVER: ::std::os::raw::c_uint = 514;
+pub const IPPORT_EFSSERVER: ::std::os::raw::c_uint = 520;
+pub const IPPORT_BIFFUDP: ::std::os::raw::c_uint = 512;
+pub const IPPORT_WHOSERVER: ::std::os::raw::c_uint = 513;
+pub const IPPORT_ROUTESERVER: ::std::os::raw::c_uint = 520;
+pub const IPPORT_RESERVED: ::std::os::raw::c_uint = 1024;
+pub const IPPORT_USERRESERVED: ::std::os::raw::c_uint = 5000;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
     _bindgen_union_align: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
@@ -7872,22 +5691,6 @@ impl Default for in6_addr {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type in6_addr_t = in6_addr;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
-    pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
-}
-impl Default for sockaddr_in6 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
 #[pg_guard]
 extern "C" {
     pub static in6addr_any: in6_addr;
@@ -7896,21 +5699,40 @@ extern "C" {
 extern "C" {
     pub static in6addr_loopback: in6_addr;
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: u32,
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
+impl Default for sockaddr_in6 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -7925,303 +5747,79 @@ impl Default for ipv6_mreq {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ntohl(__netlong: u32) -> u32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *mut *mut cmsghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn ntohs(__netshort: u16) -> u16;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_append(
-        arg1: *mut cmsghdr,
-        arg2: *const __uint8_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn htonl(__hostlong: u32) -> u32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_alloc(
-        arg1: *mut cmsghdr,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> *mut __uint8_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_option_next(
-        arg1: *const cmsghdr,
-        arg2: *mut *mut __uint8_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_option_find(
-        arg1: *const cmsghdr,
-        arg2: *mut *mut __uint8_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut cmsghdr;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_add(
-        arg1: *mut cmsghdr,
-        arg2: *const in6_addr,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_lasthop(
-        arg1: *mut cmsghdr,
-        arg2: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_getaddr(arg1: *mut cmsghdr, arg2: ::std::os::raw::c_int) -> *mut in6_addr;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_getflags(
-        arg1: *const cmsghdr,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_append(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: __uint8_t,
-        arg5: socklen_t,
-        arg6: __uint8_t,
-        arg7: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_finish(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_set_val(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_next(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut __uint8_t,
-        arg5: *mut socklen_t,
-        arg6: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_find(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: __uint8_t,
-        arg5: *mut socklen_t,
-        arg6: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_get_val(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> socklen_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_add(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *const in6_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_reverse(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_getaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut in6_addr;
+    pub fn htons(__hostshort: u16) -> u16;
 }
 #[pg_guard]
 extern "C" {
     pub fn bindresvport(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr_in,
+        __sockfd: ::std::os::raw::c_int,
+        __sock_in: *mut sockaddr_in,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bindresvport_sa(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
+    pub fn bindresvport6(
+        __sockfd: ::std::os::raw::c_int,
+        __sock_in: *mut sockaddr_in6,
     ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct hostent {
-    pub h_name: *mut ::std::os::raw::c_char,
-    pub h_aliases: *mut *mut ::std::os::raw::c_char,
-    pub h_addrtype: ::std::os::raw::c_int,
-    pub h_length: ::std::os::raw::c_int,
-    pub h_addr_list: *mut *mut ::std::os::raw::c_char,
-}
-impl Default for hostent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct servent {
-    pub s_name: *mut ::std::os::raw::c_char,
-    pub s_aliases: *mut *mut ::std::os::raw::c_char,
-    pub s_port: ::std::os::raw::c_int,
-    pub s_proto: *mut ::std::os::raw::c_char,
-}
-impl Default for servent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct protoent {
-    pub p_name: *mut ::std::os::raw::c_char,
-    pub p_aliases: *mut *mut ::std::os::raw::c_char,
-    pub p_proto: ::std::os::raw::c_int,
-}
-impl Default for protoent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -8237,167 +5835,7 @@ impl Default for rpcent {
 }
 #[pg_guard]
 extern "C" {
-    pub fn endhostent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endprotoent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endservent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn freeaddrinfo(arg1: *mut addrinfo);
-}
-#[pg_guard]
-extern "C" {
-    pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getaddrinfo(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const addrinfo,
-        arg4: *mut *mut addrinfo,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent() -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnameinfo(
-        arg1: *const sockaddr,
-        arg2: socklen_t,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: socklen_t,
-        arg5: *mut ::std::os::raw::c_char,
-        arg6: socklen_t,
-        arg7: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent() -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent() -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent() -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sethostent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setprotoent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setservent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn freehostent(arg1: *mut hostent);
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipnodebyaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipnodebyname(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent() -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrpcent(stayopen: ::std::os::raw::c_int);
+    pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
@@ -8405,28 +5843,348 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn herror(arg1: *const ::std::os::raw::c_char);
+    pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn innetgr(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-        arg4: *const ::std::os::raw::c_char,
+    pub fn getrpcent() -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getnetgrent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+    pub fn getrpcbynumber_r(
+        __number: ::std::os::raw::c_int,
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcent_r(
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn herror(__str: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hostent {
+    pub h_name: *mut ::std::os::raw::c_char,
+    pub h_aliases: *mut *mut ::std::os::raw::c_char,
+    pub h_addrtype: ::std::os::raw::c_int,
+    pub h_length: ::std::os::raw::c_int,
+    pub h_addr_list: *mut *mut ::std::os::raw::c_char,
+}
+impl Default for hostent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sethostent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endhostent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent() -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyaddr(
+        __addr: *const ::std::os::raw::c_void,
+        __len: __socklen_t,
+        __type: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2(
+        __name: *const ::std::os::raw::c_char,
+        __af: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent_r(
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyaddr_r(
+        __addr: *const ::std::os::raw::c_void,
+        __len: __socklen_t,
+        __type: ::std::os::raw::c_int,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2_r(
+        __name: *const ::std::os::raw::c_char,
+        __af: ::std::os::raw::c_int,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent() -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent_r(
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr_r(
+        __net: u32,
+        __type: ::std::os::raw::c_int,
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct servent {
+    pub s_name: *mut ::std::os::raw::c_char,
+    pub s_aliases: *mut *mut ::std::os::raw::c_char,
+    pub s_port: ::std::os::raw::c_int,
+    pub s_proto: *mut ::std::os::raw::c_char,
+}
+impl Default for servent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setservent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endservent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent() -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname(
+        __name: *const ::std::os::raw::c_char,
+        __proto: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport(
+        __port: ::std::os::raw::c_int,
+        __proto: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent_r(
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __proto: *const ::std::os::raw::c_char,
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport_r(
+        __port: ::std::os::raw::c_int,
+        __proto: *const ::std::os::raw::c_char,
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct protoent {
+    pub p_name: *mut ::std::os::raw::c_char,
+    pub p_aliases: *mut *mut ::std::os::raw::c_char,
+    pub p_proto: ::std::os::raw::c_int,
+}
+impl Default for protoent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endprotoent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent() -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent_r(
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber_r(
+        __proto: ::std::os::raw::c_int,
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -8434,58 +6192,187 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+    pub fn getnetgrent(
+        __hostp: *mut *mut ::std::os::raw::c_char,
+        __userp: *mut *mut ::std::os::raw::c_char,
+        __domainp: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn innetgr(
+        __netgroup: *const ::std::os::raw::c_char,
+        __host: *const ::std::os::raw::c_char,
+        __user: *const ::std::os::raw::c_char,
+        __domain: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetgrent_r(
+        __hostp: *mut *mut ::std::os::raw::c_char,
+        __userp: *mut *mut ::std::os::raw::c_char,
+        __domainp: *mut *mut ::std::os::raw::c_char,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rcmd(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_ushort,
+        __locuser: *const ::std::os::raw::c_char,
+        __remuser: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rcmd_af(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_ushort,
+        __locuser: *const ::std::os::raw::c_char,
+        __remuser: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rexec(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_int,
+        __name: *const ::std::os::raw::c_char,
+        __pass: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rexec_af(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_int,
+        __name: *const ::std::os::raw::c_char,
+        __pass: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ruserok(
+        __rhost: *const ::std::os::raw::c_char,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ruserok_af(
+        __rhost: *const ::std::os::raw::c_char,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iruserok(
+        __raddr: u32,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iruserok_af(
+        __raddr: *const ::std::os::raw::c_void,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rresvport_af(
+        __alport: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct passwd {
-    pub pw_name: *mut ::std::os::raw::c_char,
-    pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: uid_t,
-    pub pw_gid: gid_t,
-    pub pw_change: __darwin_time_t,
-    pub pw_class: *mut ::std::os::raw::c_char,
-    pub pw_gecos: *mut ::std::os::raw::c_char,
-    pub pw_dir: *mut ::std::os::raw::c_char,
-    pub pw_shell: *mut ::std::os::raw::c_char,
-    pub pw_expire: __darwin_time_t,
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
 }
-impl Default for passwd {
+impl Default for addrinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwuid(arg1: uid_t) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuid_r(
-        arg1: uid_t,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
+    pub fn getaddrinfo(
+        __name: *const ::std::os::raw::c_char,
+        __service: *const ::std::os::raw::c_char,
+        __req: *const addrinfo,
+        __pai: *mut *mut addrinfo,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwnam_r(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
-    ) -> ::std::os::raw::c_int;
+    pub fn freeaddrinfo(__ai: *mut addrinfo);
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwent() -> *mut passwd;
+    pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnameinfo(
+        __sa: *const sockaddr,
+        __salen: socklen_t,
+        __host: *mut ::std::os::raw::c_char,
+        __hostlen: socklen_t,
+        __serv: *mut ::std::os::raw::c_char,
+        __servlen: socklen_t,
+        __flags: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct passwd {
+    pub pw_name: *mut ::std::os::raw::c_char,
+    pub pw_passwd: *mut ::std::os::raw::c_char,
+    pub pw_uid: __uid_t,
+    pub pw_gid: __gid_t,
+    pub pw_gecos: *mut ::std::os::raw::c_char,
+    pub pw_dir: *mut ::std::os::raw::c_char,
+    pub pw_shell: *mut ::std::os::raw::c_char,
+}
+impl Default for passwd {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
@@ -8495,86 +6382,63 @@ extern "C" {
 extern "C" {
     pub fn endpwent();
 }
-pub type uuid_t = __darwin_uuid_t;
-pub type uuid_string_t = __darwin_uuid_string_t;
 #[pg_guard]
 extern "C" {
-    pub static UUID_NULL: uuid_t;
+    pub fn getpwent() -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
+    pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_compare(
-        uu1: *mut ::std::os::raw::c_uchar,
-        uu2: *mut ::std::os::raw::c_uchar,
+    pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwent_r(
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_early_random(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_parse(
-        in_: *mut ::std::os::raw::c_char,
-        uu: *mut ::std::os::raw::c_uchar,
+    pub fn getpwuid_r(
+        __uid: __uid_t,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+    pub fn getpwnam_r(
+        __name: *const ::std::os::raw::c_char,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_unparse_lower(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_unparse_upper(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn user_from_uid(arg1: uid_t, arg2: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuuid_r(
-        arg1: *mut ::std::os::raw::c_uchar,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
+    pub fn fgetpwent_r(
+        __stream: *mut FILE,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -8839,783 +6703,347 @@ extern "C" {
 extern "C" {
     pub fn pg_srand48(seed: ::std::os::raw::c_long);
 }
+#[pg_guard]
+extern "C" {
+    pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpeereid(
+        sock: ::std::os::raw::c_int,
+        uid: *mut uid_t,
+        gid: *mut gid_t,
+    ) -> ::std::os::raw::c_int;
+}
 pub type float_t = f32;
 pub type double_t = f64;
 #[pg_guard]
 extern "C" {
-    pub fn __math_errhandling() -> ::std::os::raw::c_int;
+    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
+    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosf(arg1: f32) -> f32;
+    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acos(arg1: f64) -> f64;
+    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosl(arg1: u128) -> u128;
+    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinf(arg1: f32) -> f32;
+    pub fn acos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asin(arg1: f64) -> f64;
+    pub fn __acos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinl(arg1: u128) -> u128;
+    pub fn asin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanf(arg1: f32) -> f32;
+    pub fn __asin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan(arg1: f64) -> f64;
+    pub fn atan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanl(arg1: u128) -> u128;
+    pub fn __atan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+    pub fn atan2(__y: f64, __x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2(arg1: f64, arg2: f64) -> f64;
+    pub fn __atan2(__y: f64, __x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
+    pub fn cos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosf(arg1: f32) -> f32;
+    pub fn __cos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cos(arg1: f64) -> f64;
+    pub fn sin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosl(arg1: u128) -> u128;
+    pub fn __sin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinf(arg1: f32) -> f32;
+    pub fn tan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sin(arg1: f64) -> f64;
+    pub fn __tan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinl(arg1: u128) -> u128;
+    pub fn cosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanf(arg1: f32) -> f32;
+    pub fn __cosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tan(arg1: f64) -> f64;
+    pub fn sinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanl(arg1: u128) -> u128;
+    pub fn __sinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acoshf(arg1: f32) -> f32;
+    pub fn tanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosh(arg1: f64) -> f64;
+    pub fn __tanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acoshl(arg1: u128) -> u128;
+    pub fn acosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinhf(arg1: f32) -> f32;
+    pub fn __acosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinh(arg1: f64) -> f64;
+    pub fn asinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinhl(arg1: u128) -> u128;
+    pub fn __asinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanhf(arg1: f32) -> f32;
+    pub fn atanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanh(arg1: f64) -> f64;
+    pub fn __atanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanhl(arg1: u128) -> u128;
+    pub fn exp(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn coshf(arg1: f32) -> f32;
+    pub fn __exp(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosh(arg1: f64) -> f64;
+    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn coshl(arg1: u128) -> u128;
+    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinhf(arg1: f32) -> f32;
+    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinh(arg1: f64) -> f64;
+    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinhl(arg1: u128) -> u128;
+    pub fn log(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanhf(arg1: f32) -> f32;
+    pub fn __log(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanh(arg1: f64) -> f64;
+    pub fn log10(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanhl(arg1: u128) -> u128;
+    pub fn __log10(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expf(arg1: f32) -> f32;
+    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp(arg1: f64) -> f64;
+    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expl(arg1: u128) -> u128;
+    pub fn expm1(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2f(arg1: f32) -> f32;
+    pub fn __expm1(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2(arg1: f64) -> f64;
+    pub fn log1p(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2l(arg1: u128) -> u128;
+    pub fn __log1p(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1f(arg1: f32) -> f32;
+    pub fn logb(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1(arg1: f64) -> f64;
+    pub fn __logb(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1l(arg1: u128) -> u128;
+    pub fn exp2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logf(arg1: f32) -> f32;
+    pub fn __exp2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log(arg1: f64) -> f64;
+    pub fn log2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logl(arg1: u128) -> u128;
+    pub fn __log2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10f(arg1: f32) -> f32;
+    pub fn pow(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10(arg1: f64) -> f64;
+    pub fn __pow(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10l(arg1: u128) -> u128;
+    pub fn sqrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2f(arg1: f32) -> f32;
+    pub fn __sqrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2(arg1: f64) -> f64;
+    pub fn hypot(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2l(arg1: u128) -> u128;
+    pub fn __hypot(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1pf(arg1: f32) -> f32;
+    pub fn cbrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1p(arg1: f64) -> f64;
+    pub fn __cbrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1pl(arg1: u128) -> u128;
+    pub fn ceil(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logbf(arg1: f32) -> f32;
+    pub fn __ceil(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logb(arg1: f64) -> f64;
+    pub fn fabs(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logbl(arg1: u128) -> u128;
+    pub fn __fabs(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+    pub fn floor(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn __floor(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
+    pub fn fmod(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn __fmod(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
+    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+    pub fn drem(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn __drem(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
+    pub fn significand(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __significand(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn copysign(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
+    pub fn __copysign(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabs(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrt(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypot(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pow(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrt(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erff(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erf(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammal(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammal(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceilf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceil(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceill(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floor(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyint(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rint(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn round(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn trunc(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmod(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainder(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysign(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdim(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmax(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmin(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __inff() -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __inf() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __infl() -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nan() -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp10f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp10(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cospif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cospi(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinpif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinpi(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanpif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanpi(arg1: f64) -> f64;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincosf_stret(arg1: f32) -> __float2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincos_stret(arg1: f64) -> __double2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincospif_stret(arg1: f32) -> __float2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincospi_stret(arg1: f64) -> __double2;
+    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -9623,7 +7051,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __j0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn j1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9631,7 +7067,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn y0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9639,31 +7083,47 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __y1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalb(arg1: f64, arg2: f64) -> f64;
+    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut signgam: ::std::os::raw::c_int;
+    pub fn erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn __erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn drem(arg1: f64, arg2: f64) -> f64;
+    pub fn __erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn lgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9671,21 +7131,1369 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn significand(arg1: f64) -> f64;
+    pub fn __gamma(arg1: f64) -> f64;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
+#[pg_guard]
+extern "C" {
+    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
 }
-impl Default for exception {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+#[pg_guard]
+extern "C" {
+    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafter(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafter(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttoward(__x: f64, __y: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainder(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainder(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn round(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __round(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn trunc(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __trunc(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdim(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdim(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmax(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmax(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmin(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmin(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalb(__x: f64, __n: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalb(__x: f64, __n: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atan2f(__y: f32, __x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atan2f(__y: f32, __x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn coshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __coshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acoshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acoshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log10f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log10f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expm1f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expm1f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log1pf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log1pf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logbf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logbf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn exp2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn powf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __powf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sqrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sqrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn hypotf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __hypotf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cbrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cbrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ceilf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ceilf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fabsf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fabsf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn floorf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __floorf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmodf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmodf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dremf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __dremf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significandf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __significandf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn copysignf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __copysignf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erff(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erff(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __gammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainderf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainderf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __roundf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn truncf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __truncf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdimf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdimf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fminf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbf(__x: f32, __n: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbf(__x: f32, __n: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atan2l(__y: u128, __x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atan2l(__y: u128, __x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn coshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __coshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acoshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acoshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log10l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log10l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expm1l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expm1l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log1pl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log1pl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logbl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logbl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn exp2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn powl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __powl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sqrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sqrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn hypotl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __hypotl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cbrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cbrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ceill(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ceill(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fabsl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fabsl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn floorl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __floorl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmodl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmodl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dreml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __dreml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significandl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __significandl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn copysignl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __copysignl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfcl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfcl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __gammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainderl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __roundl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn truncl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __truncl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdiml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fminl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbl(__x: u128, __n: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbl(__x: u128, __n: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut signgam: ::std::os::raw::c_int;
+}
+pub const FP_NAN: ::std::os::raw::c_uint = 0;
+pub const FP_INFINITE: ::std::os::raw::c_uint = 1;
+pub const FP_ZERO: ::std::os::raw::c_uint = 2;
+pub const FP_SUBNORMAL: ::std::os::raw::c_uint = 3;
+pub const FP_NORMAL: ::std::os::raw::c_uint = 4;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
@@ -9815,28 +8623,39 @@ extern "C" {
         include_command_not_found: bool,
     ) -> bool;
 }
-pub type jmp_buf = [::std::os::raw::c_int; 37usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 38usize];
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
+}
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
-    pub fn setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
+    pub fn __sigsetjmp(
+        __env: *mut __jmp_buf_tag,
+        __savemask: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn _setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
+    pub fn longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmperror();
+    pub fn _longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
 }
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
     pub fn errstart(
@@ -12777,239 +11596,83 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
+#[pg_guard]
+extern "C" {
+    pub fn fcntl(
+        __fd: ::std::os::raw::c_int,
+        __cmd: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fbootstraptransfer {
-    pub fbt_offset: off_t,
-    pub fbt_length: usize,
-    pub fbt_buffer: *mut ::std::os::raw::c_void,
-}
-impl Default for fbootstraptransfer {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fbootstraptransfer_t = fbootstraptransfer;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn open(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __oflag: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn openat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
+        __fd: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __oflag: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn creat(arg1: *const ::std::os::raw::c_char, arg2: mode_t) -> ::std::os::raw::c_int;
+    pub fn creat(__file: *const ::std::os::raw::c_char, __mode: mode_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fcntl(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        ...
+    pub fn lockf(
+        __fd: ::std::os::raw::c_int,
+        __cmd: ::std::os::raw::c_int,
+        __len: off_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn openx_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: filesec_t,
+    pub fn posix_fadvise(
+        __fd: ::std::os::raw::c_int,
+        __offset: off_t,
+        __len: off_t,
+        __advise: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn open_dprotected_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flock(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_init() -> filesec_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_free(arg1: filesec_t);
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_get_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_query_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_set_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *const ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_unset_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
+    pub fn posix_fallocate(
+        __fd: ::std::os::raw::c_int,
+        __offset: off_t,
+        __len: off_t,
     ) -> ::std::os::raw::c_int;
 }
 pub type XLogRecPtr = uint64;
@@ -14874,32 +13537,18 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-#[pg_guard]
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[pg_guard]
 extern "C" {
@@ -14907,48 +13556,88 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+    pub fn time(__timer: *mut time_t) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+    pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime(arg1: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime(arg1: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktime(arg1: *mut tm) -> time_t;
+    pub fn mktime(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn strftime(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: *const ::std::os::raw::c_char,
-        arg4: *const tm,
+        __s: *mut ::std::os::raw::c_char,
+        __maxsize: usize,
+        __format: *const ::std::os::raw::c_char,
+        __tp: *const tm,
     ) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strptime(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut tm,
+    pub fn strftime_l(
+        __s: *mut ::std::os::raw::c_char,
+        __maxsize: usize,
+        __format: *const ::std::os::raw::c_char,
+        __tp: *const tm,
+        __loc: locale_t,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime(__timer: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime(__timer: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime_r(
+        __tp: *const tm,
+        __buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn time(arg1: *mut time_t) -> time_t;
+    pub fn ctime_r(
+        __timer: *const time_t,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[pg_guard]
 extern "C" {
@@ -14956,59 +13645,31 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn asctime_r(
-        arg1: *const tm,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub static mut daylight: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctime_r(
-        arg1: *const time_t,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub static mut timezone: ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+    pub fn timegm(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+    pub fn timelocal(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix2time(arg1: time_t) -> time_t;
+    pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tzsetwall();
+    pub fn nanosleep(
+        __requested_time: *const timespec,
+        __remaining: *mut timespec,
+    ) -> ::std::os::raw::c_int;
 }
-#[pg_guard]
-extern "C" {
-    pub fn time2posix(arg1: time_t) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timelocal(arg1: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timegm(arg1: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanosleep(__rqtp: *const timespec, __rmtp: *mut timespec) -> ::std::os::raw::c_int;
-}
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn clock_getres(__clock_id: clockid_t, __res: *mut timespec) -> ::std::os::raw::c_int;
@@ -15019,15 +13680,56 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-}
-#[pg_guard]
-extern "C" {
     pub fn clock_settime(__clock_id: clockid_t, __tp: *const timespec) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timespec_get(ts: *mut timespec, base: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn clock_nanosleep(
+        __clock_id: clockid_t,
+        __flags: ::std::os::raw::c_int,
+        __req: *const timespec,
+        __rem: *mut timespec,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clock_getcpuclockid(__pid: pid_t, __clock_id: *mut clockid_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_create(
+        __clock_id: clockid_t,
+        __evp: *mut sigevent,
+        __timerid: *mut timer_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_settime(
+        __timerid: timer_t,
+        __flags: ::std::os::raw::c_int,
+        __value: *const itimerspec,
+        __ovalue: *mut itimerspec,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_gettime(__timerid: timer_t, __value: *mut itimerspec) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timespec_get(
+        __ts: *mut timespec,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 pub type instr_time = timespec;
 #[repr(C)]
@@ -16256,104 +14958,82 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const DT_UNKNOWN: ::std::os::raw::c_uint = 0;
+pub const DT_FIFO: ::std::os::raw::c_uint = 1;
+pub const DT_CHR: ::std::os::raw::c_uint = 2;
+pub const DT_DIR: ::std::os::raw::c_uint = 4;
+pub const DT_BLK: ::std::os::raw::c_uint = 6;
+pub const DT_REG: ::std::os::raw::c_uint = 8;
+pub const DT_LNK: ::std::os::raw::c_uint = 10;
+pub const DT_SOCK: ::std::os::raw::c_uint = 12;
+pub const DT_WHT: ::std::os::raw::c_uint = 14;
+pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+pub type DIR = __dirstream;
+#[pg_guard]
+extern "C" {
+    pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+    pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_opendir$INODE64"]
-    pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+    pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_readdir$INODE64"]
-    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+    pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_readdir_r$INODE64"]
     pub fn readdir_r(
-        arg1: *mut DIR,
-        arg2: *mut dirent,
-        arg3: *mut *mut dirent,
+        __dirp: *mut DIR,
+        __entry: *mut dirent,
+        __result: *mut *mut dirent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_rewinddir$INODE64"]
-    pub fn rewinddir(arg1: *mut DIR);
+    pub fn rewinddir(__dirp: *mut DIR);
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_seekdir$INODE64"]
-    pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+    pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_telldir$INODE64"]
-    pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+    pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_fdopendir$INODE64"]
-    pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+    pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_alphasort$INODE64"]
-    pub fn alphasort(arg1: *mut *const dirent, arg2: *mut *const dirent) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_scandir$INODE64"]
     pub fn scandir(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut *mut dirent,
-        arg3: ::std::option::Option<
+        __dir: *const ::std::os::raw::c_char,
+        __namelist: *mut *mut *mut dirent,
+        __selector: ::std::option::Option<
             unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
         >,
-        arg4: ::std::option::Option<
+        __cmp: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut *const dirent,
                 arg2: *mut *const dirent,
@@ -16363,29 +15043,16 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_scandir_b$INODE64"]
-    pub fn scandir_b(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut *mut dirent,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
+    pub fn alphasort(__e1: *mut *const dirent, __e2: *mut *const dirent) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
     pub fn getdirentries(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}___opendir2$INODE64"]
-    pub fn __opendir2(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int)
-        -> *mut DIR;
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+        __basep: *mut __off_t,
+    ) -> __ssize_t;
 }
 pub type File = ::std::os::raw::c_int;
 #[pg_guard]
@@ -24406,160 +23073,651 @@ extern "C" {
         nulls: *mut *mut bool,
     ) -> ::std::os::raw::c_int;
 }
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
+    _bindgen_union_align: u64,
+}
+impl Default for sigval {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+    _bindgen_union_align: [u64; 14usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+    _bindgen_union_align: [u64; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub const SI_ASYNCNL: ::std::os::raw::c_int = -60;
+pub const SI_DETHREAD: ::std::os::raw::c_int = -7;
+pub const SI_TKILL: ::std::os::raw::c_int = -6;
+pub const SI_SIGIO: ::std::os::raw::c_int = -5;
+pub const SI_ASYNCIO: ::std::os::raw::c_int = -4;
+pub const SI_MESGQ: ::std::os::raw::c_int = -3;
+pub const SI_TIMER: ::std::os::raw::c_int = -2;
+pub const SI_QUEUE: ::std::os::raw::c_int = -1;
+pub const SI_USER: ::std::os::raw::c_int = 0;
+pub const SI_KERNEL: ::std::os::raw::c_int = 128;
+pub type _bindgen_ty_10 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: ::std::os::raw::c_uint = 1;
+pub const ILL_ILLOPN: ::std::os::raw::c_uint = 2;
+pub const ILL_ILLADR: ::std::os::raw::c_uint = 3;
+pub const ILL_ILLTRP: ::std::os::raw::c_uint = 4;
+pub const ILL_PRVOPC: ::std::os::raw::c_uint = 5;
+pub const ILL_PRVREG: ::std::os::raw::c_uint = 6;
+pub const ILL_COPROC: ::std::os::raw::c_uint = 7;
+pub const ILL_BADSTK: ::std::os::raw::c_uint = 8;
+pub const ILL_BADIADDR: ::std::os::raw::c_uint = 9;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: ::std::os::raw::c_uint = 1;
+pub const FPE_INTOVF: ::std::os::raw::c_uint = 2;
+pub const FPE_FLTDIV: ::std::os::raw::c_uint = 3;
+pub const FPE_FLTOVF: ::std::os::raw::c_uint = 4;
+pub const FPE_FLTUND: ::std::os::raw::c_uint = 5;
+pub const FPE_FLTRES: ::std::os::raw::c_uint = 6;
+pub const FPE_FLTINV: ::std::os::raw::c_uint = 7;
+pub const FPE_FLTSUB: ::std::os::raw::c_uint = 8;
+pub const FPE_FLTUNK: ::std::os::raw::c_uint = 14;
+pub const FPE_CONDTRAP: ::std::os::raw::c_uint = 15;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: ::std::os::raw::c_uint = 1;
+pub const SEGV_ACCERR: ::std::os::raw::c_uint = 2;
+pub const SEGV_BNDERR: ::std::os::raw::c_uint = 3;
+pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
+pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
+pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
+pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
+pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
+pub const BUS_OBJERR: ::std::os::raw::c_uint = 3;
+pub const BUS_MCEERR_AR: ::std::os::raw::c_uint = 4;
+pub const BUS_MCEERR_AO: ::std::os::raw::c_uint = 5;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: ::std::os::raw::c_uint = 1;
+pub const CLD_KILLED: ::std::os::raw::c_uint = 2;
+pub const CLD_DUMPED: ::std::os::raw::c_uint = 3;
+pub const CLD_TRAPPED: ::std::os::raw::c_uint = 4;
+pub const CLD_STOPPED: ::std::os::raw::c_uint = 5;
+pub const CLD_CONTINUED: ::std::os::raw::c_uint = 6;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
+pub const POLL_IN: ::std::os::raw::c_uint = 1;
+pub const POLL_OUT: ::std::os::raw::c_uint = 2;
+pub const POLL_MSG: ::std::os::raw::c_uint = 3;
+pub const POLL_ERR: ::std::os::raw::c_uint = 4;
+pub const POLL_PRI: ::std::os::raw::c_uint = 5;
+pub const POLL_HUP: ::std::os::raw::c_uint = 6;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+    _bindgen_union_align: [u64; 6usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: ::std::os::raw::c_uint = 0;
+pub const SIGEV_NONE: ::std::os::raw::c_uint = 1;
+pub const SIGEV_THREAD: ::std::os::raw::c_uint = 2;
+pub const SIGEV_THREAD_ID: ::std::os::raw::c_uint = 4;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[pg_guard]
 extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+    pub fn __sysv_signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t)
+        -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+    pub fn signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bsd_signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
+    pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ssignal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_kill(arg1: pthread_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_sigmask(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigset_t,
-        arg3: *mut sigset_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaction(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigaction,
-        arg3: *mut sigaction,
-    ) -> ::std::os::raw::c_int;
+    pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaddset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
+    pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigdelset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn siggetmask() -> ::std::os::raw::c_int;
+}
+pub type sig_t = __sighandler_t;
+#[pg_guard]
+extern "C" {
+    pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn siginterrupt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigismember(arg1: *const sigset_t, arg2: ::std::os::raw::c_int)
+    pub fn sigaddset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigdelset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigismember(
+        __set: *const sigset_t,
+        __signo: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+    _bindgen_union_align: u64,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
     pub fn sigprocmask(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigset_t,
-        arg3: *mut sigset_t,
+        __how: ::std::os::raw::c_int,
+        __set: *const sigset_t,
+        __oset: *mut sigset_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigset(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
+    pub fn sigaction(
+        __sig: ::std::os::raw::c_int,
+        __act: *const sigaction,
+        __oact: *mut sigaction,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn sigwait(
-        arg1: *const sigset_t,
-        arg2: *mut ::std::os::raw::c_int,
+        __set: *const sigset_t,
+        __sig: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
+    pub fn sigwaitinfo(__set: *const sigset_t, __info: *mut siginfo_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigvec(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sigvec,
-        arg3: *mut sigvec,
+    pub fn sigtimedwait(
+        __set: *const sigset_t,
+        __info: *mut siginfo_t,
+        __timeout: *const timespec,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigqueue(
+        __pid: __pid_t,
+        __sig: ::std::os::raw::c_int,
+        __val: sigval,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+    _bindgen_union_align: u64,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigreturn(__scp: *mut sigcontext) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn siginterrupt(
+        __sig: ::std::os::raw::c_int,
+        __interrupt: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub const SS_ONSTACK: ::std::os::raw::c_uint = 1;
+pub const SS_DISABLE: ::std::os::raw::c_uint = 2;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
+#[pg_guard]
+extern "C" {
+    pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigstack(__ss: *mut sigstack, __oss: *mut sigstack) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pthread_sigmask(
+        __how: ::std::os::raw::c_int,
+        __newmask: *const __sigset_t,
+        __oldmask: *mut __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pthread_kill(
+        __threadid: pthread_t,
+        __signo: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
 }
 pub type pg_time_t = int64;
 #[repr(C)]
@@ -25176,9 +24334,8 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -53954,6 +53111,11 @@ impl Default for __va_list_tag {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -181,26 +181,25 @@ pub const BLCKSZ: u32 = 8192;
 pub const DEF_PGPORT: u32 = 28812;
 pub const DEF_PGPORT_STR: &'static [u8; 6usize] = b"28812\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_CBRT: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
-pub const HAVE_COPYFILE: u32 = 1;
-pub const HAVE_COPYFILE_H: u32 = 1;
 pub const HAVE_CRYPT: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_CRYPT_H: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_RTLD_GLOBAL: u32 = 1;
 pub const HAVE_DECL_RTLD_NOW: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -210,11 +209,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -224,7 +223,6 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTPTR_T: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
 pub const HAVE_ISINF: u32 = 1;
@@ -235,7 +233,6 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
 pub const HAVE_LONG_LONG_INT: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMMOVE: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
@@ -243,9 +240,11 @@ pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
+pub const HAVE_PPOLL: u32 = 1;
 pub const HAVE_PREAD: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_PWRITE: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
@@ -256,6 +255,7 @@ pub const HAVE_RINT: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SPINLOCKS: u32 = 1;
@@ -263,11 +263,10 @@ pub const HAVE_SRANDOM: u32 = 1;
 pub const HAVE_STDBOOL_H: u32 = 1;
 pub const HAVE_STDINT_H: u32 = 1;
 pub const HAVE_STDLIB_H: u32 = 1;
+pub const HAVE_STRCHRNUL: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOF: u32 = 1;
@@ -275,29 +274,27 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
+pub const HAVE_SYS_PRCTL_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TM_ZONE: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
 pub const HAVE_TZNAME: u32 = 1;
 pub const HAVE_UINTPTR_T: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNIX_SOCKETS: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
@@ -307,7 +304,6 @@ pub const HAVE_UTIME: u32 = 1;
 pub const HAVE_UTIMES: u32 = 1;
 pub const HAVE_UTIME_H: u32 = 1;
 pub const HAVE_WCHAR_H: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE_X86_64_POPCNTQ: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
@@ -324,7 +320,6 @@ pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
 pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const INT64_MODIFIER: &'static [u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &'static [u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
@@ -337,7 +332,8 @@ pub const PG_KRB_SRVNAM: &'static [u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &'static [u8; 3usize] = b"12\0";
 pub const PG_VERSION: &'static [u8; 5usize] = b"12.6\0";
 pub const PG_VERSION_NUM: u32 = 120006;
-pub const PG_VERSION_STR : & 'static [u8 ; 114usize] = b"PostgreSQL 12.6 on x86_64-apple-darwin20.3.0, compiled by Apple clang version 12.0.0 (clang-1200.0.32.29), 64-bit\0" ;
+pub const PG_VERSION_STR: &'static [u8; 77usize] =
+    b"PostgreSQL 12.6 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -345,15 +341,13 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -368,510 +362,211 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &'static [u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &'static [u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
-pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
-pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 32;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &'static [u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _I386_SIGNAL_H_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const FP_PREC_24B: u32 = 0;
-pub const FP_PREC_53B: u32 = 2;
-pub const FP_PREC_64B: u32 = 3;
-pub const FP_RND_NEAR: u32 = 0;
-pub const FP_RND_DOWN: u32 = 1;
-pub const FP_RND_UP: u32 = 2;
-pub const FP_CHOP: u32 = 3;
-pub const FP_STATE_BYTES: u32 = 512;
-pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
-pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
-pub const __LASTBRANCH_MAX: u32 = 32;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_CURRENT: u32 = 5;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
+pub const P_tmpdir: &'static [u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -882,7 +577,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -906,88 +601,147 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
@@ -1017,375 +771,355 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &'static [u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &'static [u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &'static [u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &'static [u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_MASTER_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _CTYPE_H: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MAX: u32 = 45;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MAX: u32 = 45;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1397,269 +1131,49 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &'static [u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &'static [u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &'static [u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &'static [u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &'static [u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &'static [u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &'static [u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const _PATH_PWD: &'static [u8; 5usize] = b"/etc\0";
-pub const _PATH_PASSWD: &'static [u8; 12usize] = b"/etc/passwd\0";
-pub const _PASSWD: &'static [u8; 7usize] = b"passwd\0";
-pub const _PATH_MASTERPASSWD: &'static [u8; 19usize] = b"/etc/master.passwd\0";
-pub const _PATH_MASTERPASSWD_LOCK: &'static [u8; 10usize] = b"/etc/ptmp\0";
-pub const _MASTERPASSWD: &'static [u8; 14usize] = b"master.passwd\0";
-pub const _PATH_MP_DB: &'static [u8; 12usize] = b"/etc/pwd.db\0";
-pub const _MP_DB: &'static [u8; 7usize] = b"pwd.db\0";
-pub const _PATH_SMP_DB: &'static [u8; 13usize] = b"/etc/spwd.db\0";
-pub const _SMP_DB: &'static [u8; 8usize] = b"spwd.db\0";
-pub const _PATH_PWD_MKDB: &'static [u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
-pub const _PW_KEYBYNAME: u8 = 49u8;
-pub const _PW_KEYBYNUM: u8 = 50u8;
-pub const _PW_KEYBYUID: u8 = 51u8;
-pub const _PASSWORD_EFMT1: u8 = 95u8;
-pub const _PASSWORD_LEN: u32 = 128;
-pub const _PASSWORD_NOUID: u32 = 1;
-pub const _PASSWORD_NOGID: u32 = 2;
-pub const _PASSWORD_NOCHG: u32 = 4;
-pub const _PASSWORD_NOEXP: u32 = 8;
-pub const _PASSWORD_WARNDAYS: u32 = 14;
-pub const _PASSWORD_CHGNOW: i32 = -1;
+pub const _PWD_H: u32 = 1;
+pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
 pub const PG_BACKEND_VERSIONSTR: &'static [u8; 28usize] = b"postgres (PostgreSQL) 12.6\n\0";
 pub const EXE: &'static [u8; 1usize] = b"\0";
@@ -1667,11 +1181,18 @@ pub const DEVNULL: &'static [u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
 pub const PG_STRERROR_R_BUFLEN: u32 = 256;
 pub const PG_IOLBF: u32 = 1;
-pub const FP_SUPERNORMAL: u32 = 6;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1685,13 +1206,8 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const _JBLEN: u32 = 37;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1776,153 +1292,139 @@ pub const MaxTransactionIdAttributeNumber: i32 = -4;
 pub const MaxCommandIdAttributeNumber: i32 = -5;
 pub const TableOidAttributeNumber: i32 = -6;
 pub const FirstLowInvalidHeapAttributeNumber: i32 = -7;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const FirstGenbkiObjectId: u32 = 10000;
 pub const FirstBootstrapObjectId: u32 = 12000;
 pub const FirstNormalObjectId: u32 = 16384;
@@ -1986,8 +1488,24 @@ pub const FIELDNO_HEAPTUPLETABLESLOT_OFF: u32 = 2;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_TUPLE: u32 = 1;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_OFF: u32 = 4;
 pub const BITS_PER_BITMAPWORD: u32 = 64;
-pub const CLOCKS_PER_SEC: u32 = 1000000;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const PARAM_FLAG_CONST: u32 = 1;
 pub const BTLessStrategyNumber: u32 = 1;
 pub const BTLessEqualStrategyNumber: u32 = 2;
@@ -2046,25 +1564,66 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
+pub const _POSIX_ARG_MAX: u32 = 4096;
+pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
+pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
+pub const _POSIX_MAX_CANON: u32 = 255;
+pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_NAME_MAX: u32 = 14;
+pub const _POSIX_NGROUPS_MAX: u32 = 8;
+pub const _POSIX_OPEN_MAX: u32 = 20;
+pub const _POSIX_PATH_MAX: u32 = 256;
+pub const _POSIX_PIPE_BUF: u32 = 512;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
+pub const _POSIX_RTSIG_MAX: u32 = 8;
+pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
+pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
+pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
+pub const _POSIX_SYMLINK_MAX: u32 = 255;
+pub const _POSIX_SYMLOOP_MAX: u32 = 8;
+pub const _POSIX_TIMER_MAX: u32 = 32;
+pub const _POSIX_TTY_NAME_MAX: u32 = 9;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const DSM_IMPL_POSIX: u32 = 1;
@@ -2108,121 +1667,27 @@ pub const INDEX_SIZE_MASK: u32 = 8191;
 pub const INDEX_AM_RESERVED_BIT: u32 = 8192;
 pub const INDEX_VAR_MASK: u32 = 16384;
 pub const INDEX_NULL_MASK: u32 = 32768;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
-pub const _POSIX_ARG_MAX: u32 = 4096;
-pub const _POSIX_CHILD_MAX: u32 = 25;
-pub const _POSIX_LINK_MAX: u32 = 8;
-pub const _POSIX_MAX_CANON: u32 = 255;
-pub const _POSIX_MAX_INPUT: u32 = 255;
-pub const _POSIX_NAME_MAX: u32 = 14;
-pub const _POSIX_NGROUPS_MAX: u32 = 8;
-pub const _POSIX_OPEN_MAX: u32 = 20;
-pub const _POSIX_PATH_MAX: u32 = 256;
-pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
 pub const _POSIX2_BC_BASE_MAX: u32 = 99;
 pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
 pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
 pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
+pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
 pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
 pub const _POSIX2_LINE_MAX: u32 = 2048;
 pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
-pub const _POSIX_RTSIG_MAX: u32 = 8;
-pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
-pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
-pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 8192;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
-pub const _POSIX_SYMLINK_MAX: u32 = 255;
-pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
-pub const _POSIX_TTY_NAME_MAX: u32 = 9;
 pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
-pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const SIZEOF_DSA_POINTER: u32 = 8;
 pub const DSA_POINTER_FORMAT: &'static [u8; 7usize] = b"%016lx\0";
 pub const DSA_ALLOC_HUGE: u32 = 1;
@@ -2306,7 +1771,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const REINDEXOPT_REPORT_PROGRESS: u32 = 2;
 pub const MaxAllocHugeSize: u32 = 0;
@@ -2325,6 +1789,85 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2343,13 +1886,7 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -2534,7 +2071,6 @@ pub const F_HAS_GARBAGE: u32 = 16;
 pub const GIST_PAGE_ID: u32 = 65409;
 pub const EOH_HEADER_MAGIC: i32 = -1;
 pub const EA_MAGIC: u32 = 689375833;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &'static [u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3392,429 +2928,195 @@ pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
 pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
-    _bindgen_union_align: [u64; 16usize],
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+    _bindgen_union_align: u32,
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
+}
+impl Default for _G_fpos_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __fpos_t = _G_fpos_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
+}
+impl Default for _G_fpos64_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
-}
-impl Default for __darwin_pthread_handler_rec {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_attr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[pg_guard]
-extern "C" {
-    pub fn renameat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn renamex_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn renameatx_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 #[pg_guard]
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdout: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stderr: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgets(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut FILE,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __mode: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut FILE,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fseek(
-        arg1: *mut FILE,
-        arg2: ::std::os::raw::c_long,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn perror(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3825,39 +3127,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn rewind(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setvbuf(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sscanf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    pub fn renameat(
+        __oldfd: ::std::os::raw::c_int,
+        __old: *const ::std::os::raw::c_char,
+        __newfd: ::std::os::raw::c_int,
+        __new: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3866,135 +3140,207 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vfprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vprintf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn popen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __svfscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flockfile(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn funlockfile(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn tempnam(
         __dir: *const ::std::os::raw::c_char,
-        __prefix: *const ::std::os::raw::c_char,
+        __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-pub type off_t = __darwin_off_t;
 #[pg_guard]
 extern "C" {
-    pub fn fseeko(
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
         __stream: *mut FILE,
-        __offset: off_t,
-        __whence: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
+        -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmemopen(
+        __s: *mut ::std::os::raw::c_void,
+        __len: usize,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn open_memstream(
+        __bufloc: *mut *mut ::std::os::raw::c_char,
+        __sizeloc: *mut usize,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setvbuf(
+        __stream: *mut FILE,
+        __buf: *mut ::std::os::raw::c_char,
+        __modes: ::std::os::raw::c_int,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> off_t;
+    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setlinebuf(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fprintf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vfprintf(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vprintf(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vsprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn snprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vsnprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vdprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sscanf(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_fscanf"]
+    pub fn fscanf1(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_scanf"]
+    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_sscanf"]
+    pub fn sscanf1(
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
         ...
     ) -> ::std::os::raw::c_int;
@@ -4002,2037 +3348,299 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn vfscanf(
-        __stream: *mut FILE,
+        __s: *mut FILE,
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vscanf(
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsnprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vsscanf(
-        __str: *const ::std::os::raw::c_char,
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    #[link_name = "\u{1}__isoc99_vfscanf"]
+    pub fn vfscanf1(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vdprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
+    #[link_name = "\u{1}__isoc99_vscanf"]
+    pub fn vscanf1(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_vsscanf"]
+    pub fn vsscanf1(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgets(
+        __s: *mut ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __getdelim(
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn getdelim(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __delimiter: ::std::os::raw::c_int,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn getline(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmemopen(
-        __buf: *mut ::std::os::raw::c_void,
+    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __s: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread_unlocked(
+        __ptr: *mut ::std::os::raw::c_void,
         __size: usize,
-        __mode: *const ::std::os::raw::c_char,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite_unlocked(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: usize,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseek(
+        __stream: *mut FILE,
+        __off: ::std::os::raw::c_long,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rewind(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseeko(
+        __stream: *mut FILE,
+        __off: __off_t,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftello(__stream: *mut FILE) -> __off_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr_unlocked(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn perror(__s: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn popen(
+        __command: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn open_memstream(
-        __bufp: *mut *mut ::std::os::raw::c_char,
-        __sizep: *mut usize,
-    ) -> *mut FILE;
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
+    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+    pub fn flockfile(__stream: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn asprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn funlockfile(__stream: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmtcheck(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-#[pg_guard]
-extern "C" {
-    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuffer(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vasprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn zopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn funopen(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg3: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg4: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: fpos_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> fpos_t,
-        >,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-        >,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __snprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __vsprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __vsnprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        arg6: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_i386_thread_state {
-    pub __eax: ::std::os::raw::c_uint,
-    pub __ebx: ::std::os::raw::c_uint,
-    pub __ecx: ::std::os::raw::c_uint,
-    pub __edx: ::std::os::raw::c_uint,
-    pub __edi: ::std::os::raw::c_uint,
-    pub __esi: ::std::os::raw::c_uint,
-    pub __ebp: ::std::os::raw::c_uint,
-    pub __esp: ::std::os::raw::c_uint,
-    pub __ss: ::std::os::raw::c_uint,
-    pub __eflags: ::std::os::raw::c_uint,
-    pub __eip: ::std::os::raw::c_uint,
-    pub __cs: ::std::os::raw::c_uint,
-    pub __ds: ::std::os::raw::c_uint,
-    pub __es: ::std::os::raw::c_uint,
-    pub __fs: ::std::os::raw::c_uint,
-    pub __gs: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_fp_control {
-    pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-}
-impl __darwin_fp_control {
-    #[inline]
-    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
-    }
-    #[inline]
-    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 2u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
-    }
-    #[inline]
-    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(10usize, 2u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __invalid: ::std::os::raw::c_ushort,
-        __denorm: ::std::os::raw::c_ushort,
-        __zdiv: ::std::os::raw::c_ushort,
-        __ovrfl: ::std::os::raw::c_ushort,
-        __undfl: ::std::os::raw::c_ushort,
-        __precis: ::std::os::raw::c_ushort,
-        __pc: ::std::os::raw::c_ushort,
-        __rc: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
-            __invalid as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
-            __denorm as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
-            __zdiv as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
-            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
-            __ovrfl as u64
-        });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
-            __undfl as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
-            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
-            __precis as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 2u8, {
-            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
-            __pc as u64
-        });
-        __bindgen_bitfield_unit.set(10usize, 2u8, {
-            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
-            __rc as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-pub type __darwin_fp_control_t = __darwin_fp_control;
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_fp_status {
-    pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-}
-impl __darwin_fp_status {
-    #[inline]
-    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(6usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(9usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(10usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
-    }
-    #[inline]
-    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(11usize, 3u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(14usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(15usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __invalid: ::std::os::raw::c_ushort,
-        __denorm: ::std::os::raw::c_ushort,
-        __zdiv: ::std::os::raw::c_ushort,
-        __ovrfl: ::std::os::raw::c_ushort,
-        __undfl: ::std::os::raw::c_ushort,
-        __precis: ::std::os::raw::c_ushort,
-        __stkflt: ::std::os::raw::c_ushort,
-        __errsumm: ::std::os::raw::c_ushort,
-        __c0: ::std::os::raw::c_ushort,
-        __c1: ::std::os::raw::c_ushort,
-        __c2: ::std::os::raw::c_ushort,
-        __tos: ::std::os::raw::c_ushort,
-        __c3: ::std::os::raw::c_ushort,
-        __busy: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
-            __invalid as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
-            __denorm as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
-            __zdiv as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
-            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
-            __ovrfl as u64
-        });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
-            __undfl as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
-            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
-            __precis as u64
-        });
-        __bindgen_bitfield_unit.set(6usize, 1u8, {
-            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
-            __stkflt as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
-            __errsumm as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 1u8, {
-            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
-            __c0 as u64
-        });
-        __bindgen_bitfield_unit.set(9usize, 1u8, {
-            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
-            __c1 as u64
-        });
-        __bindgen_bitfield_unit.set(10usize, 1u8, {
-            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
-            __c2 as u64
-        });
-        __bindgen_bitfield_unit.set(11usize, 3u8, {
-            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
-            __tos as u64
-        });
-        __bindgen_bitfield_unit.set(14usize, 1u8, {
-            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
-            __c3 as u64
-        });
-        __bindgen_bitfield_unit.set(15usize, 1u8, {
-            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
-            __busy as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-pub type __darwin_fp_status_t = __darwin_fp_status;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mmst_reg {
-    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
-    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_xmm_reg {
-    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_ymm_reg {
-    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_zmm_reg {
-    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
-}
-impl Default for __darwin_zmm_reg {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_opmask_reg {
-    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_float_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-}
-impl Default for __darwin_i386_float_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_avx_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-}
-impl Default for __darwin_i386_avx_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_avx512_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_k0: __darwin_opmask_reg,
-    pub __fpu_k1: __darwin_opmask_reg,
-    pub __fpu_k2: __darwin_opmask_reg,
-    pub __fpu_k3: __darwin_opmask_reg,
-    pub __fpu_k4: __darwin_opmask_reg,
-    pub __fpu_k5: __darwin_opmask_reg,
-    pub __fpu_k6: __darwin_opmask_reg,
-    pub __fpu_k7: __darwin_opmask_reg,
-    pub __fpu_zmmh0: __darwin_ymm_reg,
-    pub __fpu_zmmh1: __darwin_ymm_reg,
-    pub __fpu_zmmh2: __darwin_ymm_reg,
-    pub __fpu_zmmh3: __darwin_ymm_reg,
-    pub __fpu_zmmh4: __darwin_ymm_reg,
-    pub __fpu_zmmh5: __darwin_ymm_reg,
-    pub __fpu_zmmh6: __darwin_ymm_reg,
-    pub __fpu_zmmh7: __darwin_ymm_reg,
-}
-impl Default for __darwin_i386_avx512_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_i386_exception_state {
-    pub __trapno: __uint16_t,
-    pub __cpu: __uint16_t,
-    pub __err: __uint32_t,
-    pub __faultvaddr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_debug_state32 {
-    pub __dr0: ::std::os::raw::c_uint,
-    pub __dr1: ::std::os::raw::c_uint,
-    pub __dr2: ::std::os::raw::c_uint,
-    pub __dr3: ::std::os::raw::c_uint,
-    pub __dr4: ::std::os::raw::c_uint,
-    pub __dr5: ::std::os::raw::c_uint,
-    pub __dr6: ::std::os::raw::c_uint,
-    pub __dr7: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __x86_instruction_state {
-    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
-    pub __insn_offset: ::std::os::raw::c_int,
-    pub __out_of_synch: ::std::os::raw::c_int,
-    pub __insn_bytes: [__uint8_t; 2380usize],
-    pub __insn_cacheline: [__uint8_t; 64usize],
-}
-impl Default for __x86_instruction_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __last_branch_record {
-    pub __from_ip: __uint64_t,
-    pub __to_ip: __uint64_t,
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __bindgen_padding_0: u32,
-}
-impl __last_branch_record {
-    #[inline]
-    pub fn __mispredict(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___mispredict(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __tsx_abort(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __in_tsx(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___in_tsx(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __cycle_count(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set___cycle_count(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __reserved(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
-    }
-    #[inline]
-    pub fn set___reserved(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(19usize, 13u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __mispredict: __uint32_t,
-        __tsx_abort: __uint32_t,
-        __in_tsx: __uint32_t,
-        __cycle_count: __uint32_t,
-        __reserved: __uint32_t,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
-            __mispredict as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
-            __tsx_abort as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
-            __in_tsx as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 16u8, {
-            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
-            __cycle_count as u64
-        });
-        __bindgen_bitfield_unit.set(19usize, 13u8, {
-            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
-            __reserved as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __last_branch_state {
-    pub __lbr_count: ::std::os::raw::c_int,
-    pub _bitfield_align_1: [u32; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __lbrs: [__last_branch_record; 32usize],
-}
-impl __last_branch_state {
-    #[inline]
-    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __reserved(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
-    }
-    #[inline]
-    pub fn set___reserved(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 30u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __lbr_supported_tsx: __uint32_t,
-        __lbr_supported_cycle_count: __uint32_t,
-        __reserved: __uint32_t,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
-            __lbr_supported_tsx as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __lbr_supported_cycle_count: u32 =
-                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
-            __lbr_supported_cycle_count as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 30u8, {
-            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
-            __reserved as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __x86_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_thread_state64 {
-    pub __rax: __uint64_t,
-    pub __rbx: __uint64_t,
-    pub __rcx: __uint64_t,
-    pub __rdx: __uint64_t,
-    pub __rdi: __uint64_t,
-    pub __rsi: __uint64_t,
-    pub __rbp: __uint64_t,
-    pub __rsp: __uint64_t,
-    pub __r8: __uint64_t,
-    pub __r9: __uint64_t,
-    pub __r10: __uint64_t,
-    pub __r11: __uint64_t,
-    pub __r12: __uint64_t,
-    pub __r13: __uint64_t,
-    pub __r14: __uint64_t,
-    pub __r15: __uint64_t,
-    pub __rip: __uint64_t,
-    pub __rflags: __uint64_t,
-    pub __cs: __uint64_t,
-    pub __fs: __uint64_t,
-    pub __gs: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_thread_full_state64 {
-    pub __ss64: __darwin_x86_thread_state64,
-    pub __ds: __uint64_t,
-    pub __es: __uint64_t,
-    pub __ss: __uint64_t,
-    pub __gsbase: __uint64_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_float_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-}
-impl Default for __darwin_x86_float_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_avx_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_ymmh8: __darwin_xmm_reg,
-    pub __fpu_ymmh9: __darwin_xmm_reg,
-    pub __fpu_ymmh10: __darwin_xmm_reg,
-    pub __fpu_ymmh11: __darwin_xmm_reg,
-    pub __fpu_ymmh12: __darwin_xmm_reg,
-    pub __fpu_ymmh13: __darwin_xmm_reg,
-    pub __fpu_ymmh14: __darwin_xmm_reg,
-    pub __fpu_ymmh15: __darwin_xmm_reg,
-}
-impl Default for __darwin_x86_avx_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_avx512_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_ymmh8: __darwin_xmm_reg,
-    pub __fpu_ymmh9: __darwin_xmm_reg,
-    pub __fpu_ymmh10: __darwin_xmm_reg,
-    pub __fpu_ymmh11: __darwin_xmm_reg,
-    pub __fpu_ymmh12: __darwin_xmm_reg,
-    pub __fpu_ymmh13: __darwin_xmm_reg,
-    pub __fpu_ymmh14: __darwin_xmm_reg,
-    pub __fpu_ymmh15: __darwin_xmm_reg,
-    pub __fpu_k0: __darwin_opmask_reg,
-    pub __fpu_k1: __darwin_opmask_reg,
-    pub __fpu_k2: __darwin_opmask_reg,
-    pub __fpu_k3: __darwin_opmask_reg,
-    pub __fpu_k4: __darwin_opmask_reg,
-    pub __fpu_k5: __darwin_opmask_reg,
-    pub __fpu_k6: __darwin_opmask_reg,
-    pub __fpu_k7: __darwin_opmask_reg,
-    pub __fpu_zmmh0: __darwin_ymm_reg,
-    pub __fpu_zmmh1: __darwin_ymm_reg,
-    pub __fpu_zmmh2: __darwin_ymm_reg,
-    pub __fpu_zmmh3: __darwin_ymm_reg,
-    pub __fpu_zmmh4: __darwin_ymm_reg,
-    pub __fpu_zmmh5: __darwin_ymm_reg,
-    pub __fpu_zmmh6: __darwin_ymm_reg,
-    pub __fpu_zmmh7: __darwin_ymm_reg,
-    pub __fpu_zmmh8: __darwin_ymm_reg,
-    pub __fpu_zmmh9: __darwin_ymm_reg,
-    pub __fpu_zmmh10: __darwin_ymm_reg,
-    pub __fpu_zmmh11: __darwin_ymm_reg,
-    pub __fpu_zmmh12: __darwin_ymm_reg,
-    pub __fpu_zmmh13: __darwin_ymm_reg,
-    pub __fpu_zmmh14: __darwin_ymm_reg,
-    pub __fpu_zmmh15: __darwin_ymm_reg,
-    pub __fpu_zmm16: __darwin_zmm_reg,
-    pub __fpu_zmm17: __darwin_zmm_reg,
-    pub __fpu_zmm18: __darwin_zmm_reg,
-    pub __fpu_zmm19: __darwin_zmm_reg,
-    pub __fpu_zmm20: __darwin_zmm_reg,
-    pub __fpu_zmm21: __darwin_zmm_reg,
-    pub __fpu_zmm22: __darwin_zmm_reg,
-    pub __fpu_zmm23: __darwin_zmm_reg,
-    pub __fpu_zmm24: __darwin_zmm_reg,
-    pub __fpu_zmm25: __darwin_zmm_reg,
-    pub __fpu_zmm26: __darwin_zmm_reg,
-    pub __fpu_zmm27: __darwin_zmm_reg,
-    pub __fpu_zmm28: __darwin_zmm_reg,
-    pub __fpu_zmm29: __darwin_zmm_reg,
-    pub __fpu_zmm30: __darwin_zmm_reg,
-    pub __fpu_zmm31: __darwin_zmm_reg,
-}
-impl Default for __darwin_x86_avx512_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_exception_state64 {
-    pub __trapno: __uint16_t,
-    pub __cpu: __uint16_t,
-    pub __err: __uint32_t,
-    pub __faultvaddr: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_debug_state64 {
-    pub __dr0: __uint64_t,
-    pub __dr1: __uint64_t,
-    pub __dr2: __uint64_t,
-    pub __dr3: __uint64_t,
-    pub __dr4: __uint64_t,
-    pub __dr5: __uint64_t,
-    pub __dr6: __uint64_t,
-    pub __dr7: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_float_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_avx_state,
-}
-impl Default for __darwin_mcontext_avx32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_avx512_state,
-}
-impl Default for __darwin_mcontext_avx512_32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_float_state64,
-}
-impl Default for __darwin_mcontext64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_float_state64,
-}
-impl Default for __darwin_mcontext64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_avx_state64,
-}
-impl Default for __darwin_mcontext_avx64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_avx_state64,
-}
-impl Default for __darwin_mcontext_avx64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_avx512_state64,
-}
-impl Default for __darwin_mcontext_avx512_64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_avx512_state64,
-}
-impl Default for __darwin_mcontext_avx512_64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-    _bindgen_union_align: u64,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    _bindgen_union_align: u64,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-pub type rusage_info_current = rusage_info_v5;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setpriority(
-        arg1: ::std::os::raw::c_int,
-        arg2: id_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-    _bindgen_union_align: u32,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn waitpid(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn waitid(
-        arg1: idtype_t,
-        arg2: id_t,
-        arg3: *mut siginfo_t,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait3(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut rusage,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait4(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut rusage,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -6053,7 +3661,595 @@ pub struct lldiv_t {
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+    pub fn __ctype_get_mb_cur_max() -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtod(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtof(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtold(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtol(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoul(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtouq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoll(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoull(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[pg_guard]
+extern "C" {
+    pub fn select(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *mut timeval,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pselect(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *const timespec,
+        __sigmask: *const __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __bindgen_anon_1: __pthread_cond_s__bindgen_ty_1,
+    pub __bindgen_anon_2: __pthread_cond_s__bindgen_ty_2,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __pthread_cond_s__bindgen_ty_1 {
+    pub __wseq: ::std::os::raw::c_ulonglong,
+    pub __wseq32: __pthread_cond_s__bindgen_ty_1__bindgen_ty_1,
+    _bindgen_union_align: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_cond_s__bindgen_ty_1__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __pthread_cond_s__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __pthread_cond_s__bindgen_ty_2 {
+    pub __g1_start: ::std::os::raw::c_ulonglong,
+    pub __g1_start32: __pthread_cond_s__bindgen_ty_2__bindgen_ty_1,
+    _bindgen_union_align: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_cond_s__bindgen_ty_2__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __pthread_cond_s__bindgen_ty_2 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 7usize],
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 5usize],
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+    _bindgen_union_align: [u64; 6usize],
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 7usize],
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: u64,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 4usize],
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn random() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom(__seed: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn initstate(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom_r(
+        __seed: ::std::os::raw::c_uint,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn initstate_r(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate_r(
+        __statebuf: *mut ::std::os::raw::c_char,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand(__seed: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48(__seedval: ::std::os::raw::c_long);
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48_r(
+        __seedval: ::std::os::raw::c_long,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48_r(
+        __seed16v: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48_r(
+        __param: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -6062,13 +4258,9 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn calloc(
-        __count: ::std::os::raw::c_ulong,
+        __nmemb: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -6079,11 +4271,23 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+    pub fn reallocarray(
+        __ptr: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
+}
+#[pg_guard]
+extern "C" {
+    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -6095,74 +4299,247 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
     pub fn abort();
 }
 #[pg_guard]
 extern "C" {
-    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+    pub fn at_quick_exit(
+        __func: ::std::option::Option<unsafe extern "C" fn()>,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+    pub fn on_exit(
+        __func: ::std::option::Option<
+            unsafe extern "C" fn(
+                __status: ::std::os::raw::c_int,
+                __arg: *mut ::std::os::raw::c_void,
+            ),
+        >,
+        __arg: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn exit(__status: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+    pub fn quick_exit(__status: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+    pub fn _Exit(__status: ::std::os::raw::c_int);
 }
+#[pg_guard]
+extern "C" {
+    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setenv(
+        __name: *const ::std::os::raw::c_char,
+        __value: *const ::std::os::raw::c_char,
+        __replace: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearenv() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemps(
+        __template: *mut ::std::os::raw::c_char,
+        __suffixlen: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn realpath(
+        __name: *const ::std::os::raw::c_char,
+        __resolved: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[pg_guard]
 extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn exit(arg1: ::std::os::raw::c_int);
+    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
+    pub fn lldiv(
+        __numer: ::std::os::raw::c_longlong,
+        __denom: ::std::os::raw::c_longlong,
+    ) -> lldiv_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qecvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qfcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qgcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qecvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qfcvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -6170,594 +4547,70 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
-}
-#[pg_guard]
-extern "C" {
     pub fn mbtowc(
-        arg1: *mut wchar_t,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: usize,
+        __pwc: *mut wchar_t,
+        __s: *const ::std::os::raw::c_char,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
+    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
+    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn srand(arg1: ::std::os::raw::c_uint);
+    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtod(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtof(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtol(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtold(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoll(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoul(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoull(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _Exit(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn getsubopt(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+        __optionp: *mut *mut ::std::os::raw::c_char,
+        __tokens: *const *mut ::std::os::raw::c_char,
+        __valuep: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn initstate(
-        arg1: ::std::os::raw::c_uint,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ptsname_r(
-        fildes: ::std::os::raw::c_int,
-        buffer: *mut ::std::os::raw::c_char,
-        buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-    pub fn realpath(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __overwrite: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setkey(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48(arg1: ::std::os::raw::c_long);
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom(arg1: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[pg_guard]
-extern "C" {
-    pub fn arc4random() -> u32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_stir();
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bsearch_b(
-        __key: *const ::std::os::raw::c_void,
-        __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+    pub fn memcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cgetcap(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetclose() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetfirst(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetmatch(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetnext(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetnum(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetstr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetustr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_daemon$1050"]
-    pub fn daemon(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn devname_r(
-        arg1: dev_t,
-        arg2: mode_t,
-        buf: *mut ::std::os::raw::c_char,
-        len: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getbsize(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_long,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprogname() -> *const ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn heapsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn heapsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mergesort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mergesort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn qsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn qsort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn radixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sradixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sranddev();
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandomdev();
-}
-#[pg_guard]
-extern "C" {
-    pub fn reallocf(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
+    pub fn memmove(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtonum(
-        __numstr: *const ::std::os::raw::c_char,
-        __minval: ::std::os::raw::c_longlong,
-        __maxval: ::std::os::raw::c_longlong,
-        __errstrp: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_longlong;
+    pub fn memccpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtoq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtouq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
+    pub fn memset(
+        __s: *mut ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -6772,40 +4625,40 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn memcpy(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmove(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset(
-        __b: *mut ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
+    pub fn strcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strncat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -6817,43 +4670,6 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcspn(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
     pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
@@ -6862,17 +4678,68 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncpy(
-        __dst: *mut ::std::os::raw::c_char,
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm(
+        __dest: *mut ::std::os::raw::c_char,
         __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[pg_guard]
+extern "C" {
+    pub fn strcoll_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __l: locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm_l(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+        __l: locale_t,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strndup(
+        __string: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strpbrk(
+    pub fn strchr(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -6884,170 +4751,164 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strspn(
+    pub fn strcspn(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __reject: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
     pub fn strstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
+        __haystack: *const ::std::os::raw::c_char,
+        __needle: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strtok(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strxfrm(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn __strtok_r(
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strtok_r(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
-        __lasts: *mut *mut ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__xpg_strerror_r"]
     pub fn strerror_r(
         __errnum: ::std::os::raw::c_int,
-        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buf: *mut ::std::os::raw::c_char,
         __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn strerror_l(
+        __errnum: ::std::os::raw::c_int,
+        __l: locale_t,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memccpy(
-        __dst: *mut ::std::os::raw::c_void,
+    pub fn bcmp(
+        __s1: *const ::std::os::raw::c_void,
+        __s2: *const ::std::os::raw::c_void,
+        __n: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcopy(
         __src: *const ::std::os::raw::c_void,
+        __dest: *mut ::std::os::raw::c_void,
+        __n: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
+}
+#[pg_guard]
+extern "C" {
+    pub fn index(
+        __s: *const ::std::os::raw::c_char,
         __c: ::std::os::raw::c_int,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn stpcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpncpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
+    pub fn rindex(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strndup(
+    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcasecmp(
         __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strncasecmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn strcasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[pg_guard]
-extern "C" {
-    pub fn memset_s(
-        __s: *mut ::std::os::raw::c_void,
-        __smax: rsize_t,
-        __c: ::std::os::raw::c_int,
-        __n: rsize_t,
-    ) -> errno_t;
+    pub fn strncasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __n: usize,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmem(
-        __big: *const ::std::os::raw::c_void,
-        __big_len: usize,
-        __little: *const ::std::os::raw::c_void,
-        __little_len: usize,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern4(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern4: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern8(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern8: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern16(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern16: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcasestr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strnstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-        __len: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
 }
 #[pg_guard]
 extern "C" {
@@ -7058,158 +4919,67 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn swab(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: isize,
-    );
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timingsafe_bcmp(
-        __b1: *const ::std::os::raw::c_void,
-        __b2: *const ::std::os::raw::c_void,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strsignal_r(
-        __sig: ::std::os::raw::c_int,
-        __strsignalbuf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcmp(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcopy(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-}
-#[pg_guard]
-extern "C" {
-    pub fn index(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn __stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rindex(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+    pub fn stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
-#[pg_guard]
-extern "C" {
-    pub fn strncasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-pub type max_align_t = u128;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[pg_guard]
 extern "C" {
-    pub fn __darwin_check_fd_set_overflow(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[pg_guard]
-extern "C" {
-    pub fn __error() -> *mut ::std::os::raw::c_int;
+    pub fn __errno_location() -> *mut ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7233,8 +5003,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -7246,14 +5016,34 @@ impl Default for lconv {
 }
 #[pg_guard]
 extern "C" {
+    pub fn setlocale(
+        __category: ::std::os::raw::c_int,
+        __locale: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
     pub fn localeconv() -> *mut lconv;
 }
 #[pg_guard]
 extern "C" {
-    pub fn setlocale(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn newlocale(
+        __category_mask: ::std::os::raw::c_int,
+        __locale: *const ::std::os::raw::c_char,
+        __base: locale_t,
+    ) -> locale_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn duplocale(__dataset: locale_t) -> locale_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freelocale(__dataset: locale_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uselocale(__dataset: locale_t) -> locale_t;
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
 pub type int8 = ::std::os::raw::c_schar;
@@ -7366,115 +5156,167 @@ impl Default for PGAlignedXLogBlock {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const _ISupper: ::std::os::raw::c_uint = 256;
+pub const _ISlower: ::std::os::raw::c_uint = 512;
+pub const _ISalpha: ::std::os::raw::c_uint = 1024;
+pub const _ISdigit: ::std::os::raw::c_uint = 2048;
+pub const _ISxdigit: ::std::os::raw::c_uint = 4096;
+pub const _ISspace: ::std::os::raw::c_uint = 8192;
+pub const _ISprint: ::std::os::raw::c_uint = 16384;
+pub const _ISgraph: ::std::os::raw::c_uint = 32768;
+pub const _ISblank: ::std::os::raw::c_uint = 1;
+pub const _IScntrl: ::std::os::raw::c_uint = 2;
+pub const _ISpunct: ::std::os::raw::c_uint = 4;
+pub const _ISalnum: ::std::os::raw::c_uint = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
+    pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
+    pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
+    pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __maskrune(
-        arg1: __darwin_ct_rune_t,
-        arg2: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
+    pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-pub type socklen_t = __darwin_socklen_t;
-pub type sa_family_t = __uint8_t;
+#[pg_guard]
+extern "C" {
+    pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -7486,71 +5328,67 @@ impl Default for iovec {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
-}
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const MSG_OOB: ::std::os::raw::c_uint = 1;
+pub const MSG_PEEK: ::std::os::raw::c_uint = 2;
+pub const MSG_DONTROUTE: ::std::os::raw::c_uint = 4;
+pub const MSG_CTRUNC: ::std::os::raw::c_uint = 8;
+pub const MSG_PROXY: ::std::os::raw::c_uint = 16;
+pub const MSG_TRUNC: ::std::os::raw::c_uint = 32;
+pub const MSG_DONTWAIT: ::std::os::raw::c_uint = 64;
+pub const MSG_EOR: ::std::os::raw::c_uint = 128;
+pub const MSG_WAITALL: ::std::os::raw::c_uint = 256;
+pub const MSG_FIN: ::std::os::raw::c_uint = 512;
+pub const MSG_SYN: ::std::os::raw::c_uint = 1024;
+pub const MSG_CONFIRM: ::std::os::raw::c_uint = 2048;
+pub const MSG_RST: ::std::os::raw::c_uint = 4096;
+pub const MSG_ERRQUEUE: ::std::os::raw::c_uint = 8192;
+pub const MSG_NOSIGNAL: ::std::os::raw::c_uint = 16384;
+pub const MSG_MORE: ::std::os::raw::c_uint = 32768;
+pub const MSG_WAITFORONE: ::std::os::raw::c_uint = 65536;
+pub const MSG_BATCH: ::std::os::raw::c_uint = 262144;
+pub const MSG_ZEROCOPY: ::std::os::raw::c_uint = 67108864;
+pub const MSG_FASTOPEN: ::std::os::raw::c_uint = 536870912;
+pub const MSG_CMSG_CLOEXEC: ::std::os::raw::c_uint = 1073741824;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -7559,225 +5397,239 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+}
+pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn accept(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bind(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sockaddr,
-        arg3: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn connect(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sockaddr,
-        arg3: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpeername(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockname(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockopt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_void,
-        arg5: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn listen(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recv(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recvfrom(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-        arg5: *mut sockaddr,
-        arg6: *mut socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recvmsg(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut msghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn send(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendmsg(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const msghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendto(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-        arg5: *const sockaddr,
-        arg6: socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setsockopt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_void,
-        arg5: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn shutdown(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
+pub const SHUT_RD: ::std::os::raw::c_uint = 0;
+pub const SHUT_WR: ::std::os::raw::c_uint = 1;
+pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn socket(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
+        __domain: ::std::os::raw::c_int,
+        __type: ::std::os::raw::c_int,
+        __protocol: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn socketpair(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
+        __domain: ::std::os::raw::c_int,
+        __type: ::std::os::raw::c_int,
+        __protocol: ::std::os::raw::c_int,
+        __fds: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sendfile(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: off_t,
-        arg4: *mut off_t,
-        arg5: *mut sf_hdtr,
-        arg6: ::std::os::raw::c_int,
+    pub fn bind(
+        __fd: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-}
-#[pg_guard]
-extern "C" {
-    pub fn connectx(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sa_endpoints_t,
-        arg3: sae_associd_t,
-        arg4: ::std::os::raw::c_uint,
-        arg5: *const iovec,
-        arg6: ::std::os::raw::c_uint,
-        arg7: *mut usize,
-        arg8: *mut sae_connid_t,
+    pub fn getsockname(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __len: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn disconnectx(
-        arg1: ::std::os::raw::c_int,
-        arg2: sae_associd_t,
-        arg3: sae_connid_t,
+    pub fn connect(
+        __fd: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
+#[pg_guard]
+extern "C" {
+    pub fn getpeername(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __len: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn send(
+        __fd: ::std::os::raw::c_int,
+        __buf: *const ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recv(
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendto(
+        __fd: ::std::os::raw::c_int,
+        __buf: *const ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __addr_len: socklen_t,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recvfrom(
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __addr_len: *mut socklen_t,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendmsg(
+        __fd: ::std::os::raw::c_int,
+        __message: *const msghdr,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recvmsg(
+        __fd: ::std::os::raw::c_int,
+        __message: *mut msghdr,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsockopt(
+        __fd: ::std::os::raw::c_int,
+        __level: ::std::os::raw::c_int,
+        __optname: ::std::os::raw::c_int,
+        __optval: *mut ::std::os::raw::c_void,
+        __optlen: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setsockopt(
+        __fd: ::std::os::raw::c_int,
+        __level: ::std::os::raw::c_int,
+        __optname: ::std::os::raw::c_int,
+        __optval: *const ::std::os::raw::c_void,
+        __optlen: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn accept(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __addr_len: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn shutdown(
+        __fd: ::std::os::raw::c_int,
+        __how: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isfdtype(
+        __fd: ::std::os::raw::c_int,
+        __fdtype: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -7792,12 +5644,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -7805,113 +5651,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn setipv4sourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: in_addr,
-        arg3: in_addr,
-        arg4: u32,
-        arg5: u32,
-        arg6: *mut in_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipv4sourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: in_addr,
-        arg3: in_addr,
-        arg4: *mut u32,
-        arg5: *mut u32,
-        arg6: *mut in_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setsourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: u32,
-        arg3: *mut sockaddr,
-        arg4: socklen_t,
-        arg5: u32,
-        arg6: u32,
-        arg7: *mut sockaddr_storage,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: u32,
-        arg3: *mut sockaddr,
-        arg4: socklen_t,
-        arg5: *mut u32,
-        arg6: *mut u32,
-        arg7: *mut sockaddr_storage,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: ::std::os::raw::c_uint = 0;
+pub const IPPROTO_ICMP: ::std::os::raw::c_uint = 1;
+pub const IPPROTO_IGMP: ::std::os::raw::c_uint = 2;
+pub const IPPROTO_IPIP: ::std::os::raw::c_uint = 4;
+pub const IPPROTO_TCP: ::std::os::raw::c_uint = 6;
+pub const IPPROTO_EGP: ::std::os::raw::c_uint = 8;
+pub const IPPROTO_PUP: ::std::os::raw::c_uint = 12;
+pub const IPPROTO_UDP: ::std::os::raw::c_uint = 17;
+pub const IPPROTO_IDP: ::std::os::raw::c_uint = 22;
+pub const IPPROTO_TP: ::std::os::raw::c_uint = 29;
+pub const IPPROTO_DCCP: ::std::os::raw::c_uint = 33;
+pub const IPPROTO_IPV6: ::std::os::raw::c_uint = 41;
+pub const IPPROTO_RSVP: ::std::os::raw::c_uint = 46;
+pub const IPPROTO_GRE: ::std::os::raw::c_uint = 47;
+pub const IPPROTO_ESP: ::std::os::raw::c_uint = 50;
+pub const IPPROTO_AH: ::std::os::raw::c_uint = 51;
+pub const IPPROTO_MTP: ::std::os::raw::c_uint = 92;
+pub const IPPROTO_BEETPH: ::std::os::raw::c_uint = 94;
+pub const IPPROTO_ENCAP: ::std::os::raw::c_uint = 98;
+pub const IPPROTO_PIM: ::std::os::raw::c_uint = 103;
+pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
+pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
+pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
+pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
+pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
+pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
+pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
+pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
+pub const IPPROTO_FRAGMENT: ::std::os::raw::c_uint = 44;
+pub const IPPROTO_ICMPV6: ::std::os::raw::c_uint = 58;
+pub const IPPROTO_NONE: ::std::os::raw::c_uint = 59;
+pub const IPPROTO_DSTOPTS: ::std::os::raw::c_uint = 60;
+pub const IPPROTO_MH: ::std::os::raw::c_uint = 135;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: ::std::os::raw::c_uint = 7;
+pub const IPPORT_DISCARD: ::std::os::raw::c_uint = 9;
+pub const IPPORT_SYSTAT: ::std::os::raw::c_uint = 11;
+pub const IPPORT_DAYTIME: ::std::os::raw::c_uint = 13;
+pub const IPPORT_NETSTAT: ::std::os::raw::c_uint = 15;
+pub const IPPORT_FTP: ::std::os::raw::c_uint = 21;
+pub const IPPORT_TELNET: ::std::os::raw::c_uint = 23;
+pub const IPPORT_SMTP: ::std::os::raw::c_uint = 25;
+pub const IPPORT_TIMESERVER: ::std::os::raw::c_uint = 37;
+pub const IPPORT_NAMESERVER: ::std::os::raw::c_uint = 42;
+pub const IPPORT_WHOIS: ::std::os::raw::c_uint = 43;
+pub const IPPORT_MTP: ::std::os::raw::c_uint = 57;
+pub const IPPORT_TFTP: ::std::os::raw::c_uint = 69;
+pub const IPPORT_RJE: ::std::os::raw::c_uint = 77;
+pub const IPPORT_FINGER: ::std::os::raw::c_uint = 79;
+pub const IPPORT_TTYLINK: ::std::os::raw::c_uint = 87;
+pub const IPPORT_SUPDUP: ::std::os::raw::c_uint = 95;
+pub const IPPORT_EXECSERVER: ::std::os::raw::c_uint = 512;
+pub const IPPORT_LOGINSERVER: ::std::os::raw::c_uint = 513;
+pub const IPPORT_CMDSERVER: ::std::os::raw::c_uint = 514;
+pub const IPPORT_EFSSERVER: ::std::os::raw::c_uint = 520;
+pub const IPPORT_BIFFUDP: ::std::os::raw::c_uint = 512;
+pub const IPPORT_WHOSERVER: ::std::os::raw::c_uint = 513;
+pub const IPPORT_ROUTESERVER: ::std::os::raw::c_uint = 520;
+pub const IPPORT_RESERVED: ::std::os::raw::c_uint = 1024;
+pub const IPPORT_USERRESERVED: ::std::os::raw::c_uint = 5000;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
     _bindgen_union_align: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
@@ -7924,22 +5744,6 @@ impl Default for in6_addr {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type in6_addr_t = in6_addr;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
-    pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
-}
-impl Default for sockaddr_in6 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
 #[pg_guard]
 extern "C" {
     pub static in6addr_any: in6_addr;
@@ -7948,21 +5752,40 @@ extern "C" {
 extern "C" {
     pub static in6addr_loopback: in6_addr;
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: u32,
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
+impl Default for sockaddr_in6 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -7977,303 +5800,79 @@ impl Default for ipv6_mreq {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ntohl(__netlong: u32) -> u32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *mut *mut cmsghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn ntohs(__netshort: u16) -> u16;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_append(
-        arg1: *mut cmsghdr,
-        arg2: *const __uint8_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn htonl(__hostlong: u32) -> u32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_alloc(
-        arg1: *mut cmsghdr,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> *mut __uint8_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_option_next(
-        arg1: *const cmsghdr,
-        arg2: *mut *mut __uint8_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_option_find(
-        arg1: *const cmsghdr,
-        arg2: *mut *mut __uint8_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut cmsghdr;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_add(
-        arg1: *mut cmsghdr,
-        arg2: *const in6_addr,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_lasthop(
-        arg1: *mut cmsghdr,
-        arg2: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_getaddr(arg1: *mut cmsghdr, arg2: ::std::os::raw::c_int) -> *mut in6_addr;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_getflags(
-        arg1: *const cmsghdr,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_append(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: __uint8_t,
-        arg5: socklen_t,
-        arg6: __uint8_t,
-        arg7: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_finish(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_set_val(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_next(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut __uint8_t,
-        arg5: *mut socklen_t,
-        arg6: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_find(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: __uint8_t,
-        arg5: *mut socklen_t,
-        arg6: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_get_val(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> socklen_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_add(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *const in6_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_reverse(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_getaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut in6_addr;
+    pub fn htons(__hostshort: u16) -> u16;
 }
 #[pg_guard]
 extern "C" {
     pub fn bindresvport(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr_in,
+        __sockfd: ::std::os::raw::c_int,
+        __sock_in: *mut sockaddr_in,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bindresvport_sa(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
+    pub fn bindresvport6(
+        __sockfd: ::std::os::raw::c_int,
+        __sock_in: *mut sockaddr_in6,
     ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct hostent {
-    pub h_name: *mut ::std::os::raw::c_char,
-    pub h_aliases: *mut *mut ::std::os::raw::c_char,
-    pub h_addrtype: ::std::os::raw::c_int,
-    pub h_length: ::std::os::raw::c_int,
-    pub h_addr_list: *mut *mut ::std::os::raw::c_char,
-}
-impl Default for hostent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct servent {
-    pub s_name: *mut ::std::os::raw::c_char,
-    pub s_aliases: *mut *mut ::std::os::raw::c_char,
-    pub s_port: ::std::os::raw::c_int,
-    pub s_proto: *mut ::std::os::raw::c_char,
-}
-impl Default for servent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct protoent {
-    pub p_name: *mut ::std::os::raw::c_char,
-    pub p_aliases: *mut *mut ::std::os::raw::c_char,
-    pub p_proto: ::std::os::raw::c_int,
-}
-impl Default for protoent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -8289,167 +5888,7 @@ impl Default for rpcent {
 }
 #[pg_guard]
 extern "C" {
-    pub fn endhostent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endprotoent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endservent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn freeaddrinfo(arg1: *mut addrinfo);
-}
-#[pg_guard]
-extern "C" {
-    pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getaddrinfo(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const addrinfo,
-        arg4: *mut *mut addrinfo,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent() -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnameinfo(
-        arg1: *const sockaddr,
-        arg2: socklen_t,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: socklen_t,
-        arg5: *mut ::std::os::raw::c_char,
-        arg6: socklen_t,
-        arg7: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent() -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent() -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent() -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sethostent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setprotoent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setservent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn freehostent(arg1: *mut hostent);
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipnodebyaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipnodebyname(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent() -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrpcent(stayopen: ::std::os::raw::c_int);
+    pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
@@ -8457,28 +5896,348 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn herror(arg1: *const ::std::os::raw::c_char);
+    pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn innetgr(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-        arg4: *const ::std::os::raw::c_char,
+    pub fn getrpcent() -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getnetgrent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+    pub fn getrpcbynumber_r(
+        __number: ::std::os::raw::c_int,
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcent_r(
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn herror(__str: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hostent {
+    pub h_name: *mut ::std::os::raw::c_char,
+    pub h_aliases: *mut *mut ::std::os::raw::c_char,
+    pub h_addrtype: ::std::os::raw::c_int,
+    pub h_length: ::std::os::raw::c_int,
+    pub h_addr_list: *mut *mut ::std::os::raw::c_char,
+}
+impl Default for hostent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sethostent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endhostent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent() -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyaddr(
+        __addr: *const ::std::os::raw::c_void,
+        __len: __socklen_t,
+        __type: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2(
+        __name: *const ::std::os::raw::c_char,
+        __af: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent_r(
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyaddr_r(
+        __addr: *const ::std::os::raw::c_void,
+        __len: __socklen_t,
+        __type: ::std::os::raw::c_int,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2_r(
+        __name: *const ::std::os::raw::c_char,
+        __af: ::std::os::raw::c_int,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent() -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent_r(
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr_r(
+        __net: u32,
+        __type: ::std::os::raw::c_int,
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct servent {
+    pub s_name: *mut ::std::os::raw::c_char,
+    pub s_aliases: *mut *mut ::std::os::raw::c_char,
+    pub s_port: ::std::os::raw::c_int,
+    pub s_proto: *mut ::std::os::raw::c_char,
+}
+impl Default for servent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setservent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endservent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent() -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname(
+        __name: *const ::std::os::raw::c_char,
+        __proto: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport(
+        __port: ::std::os::raw::c_int,
+        __proto: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent_r(
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __proto: *const ::std::os::raw::c_char,
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport_r(
+        __port: ::std::os::raw::c_int,
+        __proto: *const ::std::os::raw::c_char,
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct protoent {
+    pub p_name: *mut ::std::os::raw::c_char,
+    pub p_aliases: *mut *mut ::std::os::raw::c_char,
+    pub p_proto: ::std::os::raw::c_int,
+}
+impl Default for protoent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endprotoent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent() -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent_r(
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber_r(
+        __proto: ::std::os::raw::c_int,
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -8486,58 +6245,187 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+    pub fn getnetgrent(
+        __hostp: *mut *mut ::std::os::raw::c_char,
+        __userp: *mut *mut ::std::os::raw::c_char,
+        __domainp: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn innetgr(
+        __netgroup: *const ::std::os::raw::c_char,
+        __host: *const ::std::os::raw::c_char,
+        __user: *const ::std::os::raw::c_char,
+        __domain: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetgrent_r(
+        __hostp: *mut *mut ::std::os::raw::c_char,
+        __userp: *mut *mut ::std::os::raw::c_char,
+        __domainp: *mut *mut ::std::os::raw::c_char,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rcmd(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_ushort,
+        __locuser: *const ::std::os::raw::c_char,
+        __remuser: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rcmd_af(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_ushort,
+        __locuser: *const ::std::os::raw::c_char,
+        __remuser: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rexec(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_int,
+        __name: *const ::std::os::raw::c_char,
+        __pass: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rexec_af(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_int,
+        __name: *const ::std::os::raw::c_char,
+        __pass: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ruserok(
+        __rhost: *const ::std::os::raw::c_char,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ruserok_af(
+        __rhost: *const ::std::os::raw::c_char,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iruserok(
+        __raddr: u32,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iruserok_af(
+        __raddr: *const ::std::os::raw::c_void,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rresvport_af(
+        __alport: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct passwd {
-    pub pw_name: *mut ::std::os::raw::c_char,
-    pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: uid_t,
-    pub pw_gid: gid_t,
-    pub pw_change: __darwin_time_t,
-    pub pw_class: *mut ::std::os::raw::c_char,
-    pub pw_gecos: *mut ::std::os::raw::c_char,
-    pub pw_dir: *mut ::std::os::raw::c_char,
-    pub pw_shell: *mut ::std::os::raw::c_char,
-    pub pw_expire: __darwin_time_t,
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
 }
-impl Default for passwd {
+impl Default for addrinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwuid(arg1: uid_t) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuid_r(
-        arg1: uid_t,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
+    pub fn getaddrinfo(
+        __name: *const ::std::os::raw::c_char,
+        __service: *const ::std::os::raw::c_char,
+        __req: *const addrinfo,
+        __pai: *mut *mut addrinfo,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwnam_r(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
-    ) -> ::std::os::raw::c_int;
+    pub fn freeaddrinfo(__ai: *mut addrinfo);
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwent() -> *mut passwd;
+    pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnameinfo(
+        __sa: *const sockaddr,
+        __salen: socklen_t,
+        __host: *mut ::std::os::raw::c_char,
+        __hostlen: socklen_t,
+        __serv: *mut ::std::os::raw::c_char,
+        __servlen: socklen_t,
+        __flags: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct passwd {
+    pub pw_name: *mut ::std::os::raw::c_char,
+    pub pw_passwd: *mut ::std::os::raw::c_char,
+    pub pw_uid: __uid_t,
+    pub pw_gid: __gid_t,
+    pub pw_gecos: *mut ::std::os::raw::c_char,
+    pub pw_dir: *mut ::std::os::raw::c_char,
+    pub pw_shell: *mut ::std::os::raw::c_char,
+}
+impl Default for passwd {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
@@ -8547,86 +6435,63 @@ extern "C" {
 extern "C" {
     pub fn endpwent();
 }
-pub type uuid_t = __darwin_uuid_t;
-pub type uuid_string_t = __darwin_uuid_string_t;
 #[pg_guard]
 extern "C" {
-    pub static UUID_NULL: uuid_t;
+    pub fn getpwent() -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
+    pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_compare(
-        uu1: *mut ::std::os::raw::c_uchar,
-        uu2: *mut ::std::os::raw::c_uchar,
+    pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwent_r(
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_early_random(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_parse(
-        in_: *mut ::std::os::raw::c_char,
-        uu: *mut ::std::os::raw::c_uchar,
+    pub fn getpwuid_r(
+        __uid: __uid_t,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+    pub fn getpwnam_r(
+        __name: *const ::std::os::raw::c_char,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_unparse_lower(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_unparse_upper(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn user_from_uid(arg1: uid_t, arg2: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuuid_r(
-        arg1: *mut ::std::os::raw::c_uchar,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
+    pub fn fgetpwent_r(
+        __stream: *mut FILE,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -8973,783 +6838,347 @@ extern "C" {
 extern "C" {
     pub fn pg_srand48(seed: ::std::os::raw::c_long);
 }
+#[pg_guard]
+extern "C" {
+    pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpeereid(
+        sock: ::std::os::raw::c_int,
+        uid: *mut uid_t,
+        gid: *mut gid_t,
+    ) -> ::std::os::raw::c_int;
+}
 pub type float_t = f32;
 pub type double_t = f64;
 #[pg_guard]
 extern "C" {
-    pub fn __math_errhandling() -> ::std::os::raw::c_int;
+    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
+    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosf(arg1: f32) -> f32;
+    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acos(arg1: f64) -> f64;
+    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosl(arg1: u128) -> u128;
+    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinf(arg1: f32) -> f32;
+    pub fn acos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asin(arg1: f64) -> f64;
+    pub fn __acos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinl(arg1: u128) -> u128;
+    pub fn asin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanf(arg1: f32) -> f32;
+    pub fn __asin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan(arg1: f64) -> f64;
+    pub fn atan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanl(arg1: u128) -> u128;
+    pub fn __atan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+    pub fn atan2(__y: f64, __x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2(arg1: f64, arg2: f64) -> f64;
+    pub fn __atan2(__y: f64, __x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
+    pub fn cos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosf(arg1: f32) -> f32;
+    pub fn __cos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cos(arg1: f64) -> f64;
+    pub fn sin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosl(arg1: u128) -> u128;
+    pub fn __sin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinf(arg1: f32) -> f32;
+    pub fn tan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sin(arg1: f64) -> f64;
+    pub fn __tan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinl(arg1: u128) -> u128;
+    pub fn cosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanf(arg1: f32) -> f32;
+    pub fn __cosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tan(arg1: f64) -> f64;
+    pub fn sinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanl(arg1: u128) -> u128;
+    pub fn __sinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acoshf(arg1: f32) -> f32;
+    pub fn tanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosh(arg1: f64) -> f64;
+    pub fn __tanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acoshl(arg1: u128) -> u128;
+    pub fn acosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinhf(arg1: f32) -> f32;
+    pub fn __acosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinh(arg1: f64) -> f64;
+    pub fn asinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinhl(arg1: u128) -> u128;
+    pub fn __asinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanhf(arg1: f32) -> f32;
+    pub fn atanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanh(arg1: f64) -> f64;
+    pub fn __atanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanhl(arg1: u128) -> u128;
+    pub fn exp(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn coshf(arg1: f32) -> f32;
+    pub fn __exp(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosh(arg1: f64) -> f64;
+    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn coshl(arg1: u128) -> u128;
+    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinhf(arg1: f32) -> f32;
+    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinh(arg1: f64) -> f64;
+    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinhl(arg1: u128) -> u128;
+    pub fn log(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanhf(arg1: f32) -> f32;
+    pub fn __log(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanh(arg1: f64) -> f64;
+    pub fn log10(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanhl(arg1: u128) -> u128;
+    pub fn __log10(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expf(arg1: f32) -> f32;
+    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp(arg1: f64) -> f64;
+    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expl(arg1: u128) -> u128;
+    pub fn expm1(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2f(arg1: f32) -> f32;
+    pub fn __expm1(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2(arg1: f64) -> f64;
+    pub fn log1p(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2l(arg1: u128) -> u128;
+    pub fn __log1p(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1f(arg1: f32) -> f32;
+    pub fn logb(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1(arg1: f64) -> f64;
+    pub fn __logb(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1l(arg1: u128) -> u128;
+    pub fn exp2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logf(arg1: f32) -> f32;
+    pub fn __exp2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log(arg1: f64) -> f64;
+    pub fn log2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logl(arg1: u128) -> u128;
+    pub fn __log2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10f(arg1: f32) -> f32;
+    pub fn pow(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10(arg1: f64) -> f64;
+    pub fn __pow(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10l(arg1: u128) -> u128;
+    pub fn sqrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2f(arg1: f32) -> f32;
+    pub fn __sqrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2(arg1: f64) -> f64;
+    pub fn hypot(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2l(arg1: u128) -> u128;
+    pub fn __hypot(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1pf(arg1: f32) -> f32;
+    pub fn cbrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1p(arg1: f64) -> f64;
+    pub fn __cbrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1pl(arg1: u128) -> u128;
+    pub fn ceil(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logbf(arg1: f32) -> f32;
+    pub fn __ceil(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logb(arg1: f64) -> f64;
+    pub fn fabs(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logbl(arg1: u128) -> u128;
+    pub fn __fabs(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+    pub fn floor(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn __floor(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
+    pub fn fmod(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn __fmod(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
+    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+    pub fn drem(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn __drem(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
+    pub fn significand(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __significand(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn copysign(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
+    pub fn __copysign(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabs(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrt(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypot(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pow(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrt(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erff(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erf(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammal(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammal(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceilf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceil(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceill(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floor(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyint(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rint(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn round(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn trunc(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmod(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainder(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysign(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdim(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmax(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmin(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __inff() -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __inf() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __infl() -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nan() -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp10f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp10(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cospif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cospi(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinpif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinpi(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanpif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanpi(arg1: f64) -> f64;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincosf_stret(arg1: f32) -> __float2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincos_stret(arg1: f64) -> __double2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincospif_stret(arg1: f32) -> __float2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincospi_stret(arg1: f64) -> __double2;
+    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -9757,7 +7186,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __j0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn j1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9765,7 +7202,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn y0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9773,31 +7218,47 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __y1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalb(arg1: f64, arg2: f64) -> f64;
+    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut signgam: ::std::os::raw::c_int;
+    pub fn erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn __erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn drem(arg1: f64, arg2: f64) -> f64;
+    pub fn __erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn lgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9805,21 +7266,1369 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn significand(arg1: f64) -> f64;
+    pub fn __gamma(arg1: f64) -> f64;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
+#[pg_guard]
+extern "C" {
+    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
 }
-impl Default for exception {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+#[pg_guard]
+extern "C" {
+    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafter(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafter(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttoward(__x: f64, __y: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainder(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainder(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn round(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __round(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn trunc(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __trunc(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdim(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdim(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmax(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmax(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmin(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmin(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalb(__x: f64, __n: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalb(__x: f64, __n: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atan2f(__y: f32, __x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atan2f(__y: f32, __x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn coshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __coshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acoshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acoshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log10f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log10f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expm1f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expm1f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log1pf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log1pf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logbf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logbf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn exp2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn powf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __powf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sqrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sqrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn hypotf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __hypotf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cbrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cbrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ceilf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ceilf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fabsf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fabsf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn floorf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __floorf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmodf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmodf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dremf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __dremf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significandf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __significandf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn copysignf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __copysignf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erff(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erff(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __gammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainderf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainderf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __roundf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn truncf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __truncf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdimf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdimf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fminf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbf(__x: f32, __n: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbf(__x: f32, __n: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atan2l(__y: u128, __x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atan2l(__y: u128, __x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn coshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __coshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acoshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acoshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log10l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log10l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expm1l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expm1l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log1pl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log1pl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logbl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logbl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn exp2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn powl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __powl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sqrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sqrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn hypotl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __hypotl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cbrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cbrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ceill(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ceill(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fabsl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fabsl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn floorl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __floorl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmodl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmodl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dreml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __dreml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significandl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __significandl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn copysignl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __copysignl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfcl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfcl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __gammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainderl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __roundl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn truncl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __truncl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdiml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fminl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbl(__x: u128, __n: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbl(__x: u128, __n: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut signgam: ::std::os::raw::c_int;
+}
+pub const FP_NAN: ::std::os::raw::c_uint = 0;
+pub const FP_INFINITE: ::std::os::raw::c_uint = 1;
+pub const FP_ZERO: ::std::os::raw::c_uint = 2;
+pub const FP_SUBNORMAL: ::std::os::raw::c_uint = 3;
+pub const FP_NORMAL: ::std::os::raw::c_uint = 4;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
@@ -9941,28 +8750,39 @@ extern "C" {
         include_command_not_found: bool,
     ) -> bool;
 }
-pub type jmp_buf = [::std::os::raw::c_int; 37usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 38usize];
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
+}
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
-    pub fn setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
+    pub fn __sigsetjmp(
+        __env: *mut __jmp_buf_tag,
+        __savemask: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn _setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
+    pub fn longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmperror();
+    pub fn _longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
 }
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
     pub fn errstart(
@@ -12157,239 +10977,83 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
+#[pg_guard]
+extern "C" {
+    pub fn fcntl(
+        __fd: ::std::os::raw::c_int,
+        __cmd: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fbootstraptransfer {
-    pub fbt_offset: off_t,
-    pub fbt_length: usize,
-    pub fbt_buffer: *mut ::std::os::raw::c_void,
-}
-impl Default for fbootstraptransfer {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fbootstraptransfer_t = fbootstraptransfer;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn open(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __oflag: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn openat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
+        __fd: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __oflag: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn creat(arg1: *const ::std::os::raw::c_char, arg2: mode_t) -> ::std::os::raw::c_int;
+    pub fn creat(__file: *const ::std::os::raw::c_char, __mode: mode_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fcntl(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        ...
+    pub fn lockf(
+        __fd: ::std::os::raw::c_int,
+        __cmd: ::std::os::raw::c_int,
+        __len: off_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn openx_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: filesec_t,
+    pub fn posix_fadvise(
+        __fd: ::std::os::raw::c_int,
+        __offset: off_t,
+        __len: off_t,
+        __advise: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn open_dprotected_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flock(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_init() -> filesec_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_free(arg1: filesec_t);
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_get_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_query_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_set_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *const ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_unset_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
+    pub fn posix_fallocate(
+        __fd: ::std::os::raw::c_int,
+        __offset: off_t,
+        __len: off_t,
     ) -> ::std::os::raw::c_int;
 }
 pub type XLogRecPtr = uint64;
@@ -13324,32 +11988,18 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-#[pg_guard]
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[pg_guard]
 extern "C" {
@@ -13357,48 +12007,88 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+    pub fn time(__timer: *mut time_t) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+    pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime(arg1: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime(arg1: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktime(arg1: *mut tm) -> time_t;
+    pub fn mktime(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn strftime(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: *const ::std::os::raw::c_char,
-        arg4: *const tm,
+        __s: *mut ::std::os::raw::c_char,
+        __maxsize: usize,
+        __format: *const ::std::os::raw::c_char,
+        __tp: *const tm,
     ) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strptime(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut tm,
+    pub fn strftime_l(
+        __s: *mut ::std::os::raw::c_char,
+        __maxsize: usize,
+        __format: *const ::std::os::raw::c_char,
+        __tp: *const tm,
+        __loc: locale_t,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime(__timer: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime(__timer: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime_r(
+        __tp: *const tm,
+        __buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn time(arg1: *mut time_t) -> time_t;
+    pub fn ctime_r(
+        __timer: *const time_t,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[pg_guard]
 extern "C" {
@@ -13406,59 +12096,31 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn asctime_r(
-        arg1: *const tm,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub static mut daylight: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctime_r(
-        arg1: *const time_t,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub static mut timezone: ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+    pub fn timegm(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+    pub fn timelocal(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix2time(arg1: time_t) -> time_t;
+    pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tzsetwall();
+    pub fn nanosleep(
+        __requested_time: *const timespec,
+        __remaining: *mut timespec,
+    ) -> ::std::os::raw::c_int;
 }
-#[pg_guard]
-extern "C" {
-    pub fn time2posix(arg1: time_t) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timelocal(arg1: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timegm(arg1: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanosleep(__rqtp: *const timespec, __rmtp: *mut timespec) -> ::std::os::raw::c_int;
-}
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn clock_getres(__clock_id: clockid_t, __res: *mut timespec) -> ::std::os::raw::c_int;
@@ -13469,15 +12131,56 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-}
-#[pg_guard]
-extern "C" {
     pub fn clock_settime(__clock_id: clockid_t, __tp: *const timespec) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timespec_get(ts: *mut timespec, base: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn clock_nanosleep(
+        __clock_id: clockid_t,
+        __flags: ::std::os::raw::c_int,
+        __req: *const timespec,
+        __rem: *mut timespec,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clock_getcpuclockid(__pid: pid_t, __clock_id: *mut clockid_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_create(
+        __clock_id: clockid_t,
+        __evp: *mut sigevent,
+        __timerid: *mut timer_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_settime(
+        __timerid: timer_t,
+        __flags: ::std::os::raw::c_int,
+        __value: *const itimerspec,
+        __ovalue: *mut itimerspec,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_gettime(__timerid: timer_t, __value: *mut itimerspec) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timespec_get(
+        __ts: *mut timespec,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 pub type instr_time = timespec;
 #[repr(C)]
@@ -15755,104 +14458,82 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const DT_UNKNOWN: ::std::os::raw::c_uint = 0;
+pub const DT_FIFO: ::std::os::raw::c_uint = 1;
+pub const DT_CHR: ::std::os::raw::c_uint = 2;
+pub const DT_DIR: ::std::os::raw::c_uint = 4;
+pub const DT_BLK: ::std::os::raw::c_uint = 6;
+pub const DT_REG: ::std::os::raw::c_uint = 8;
+pub const DT_LNK: ::std::os::raw::c_uint = 10;
+pub const DT_SOCK: ::std::os::raw::c_uint = 12;
+pub const DT_WHT: ::std::os::raw::c_uint = 14;
+pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+pub type DIR = __dirstream;
+#[pg_guard]
+extern "C" {
+    pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+    pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_opendir$INODE64"]
-    pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+    pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_readdir$INODE64"]
-    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+    pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_readdir_r$INODE64"]
     pub fn readdir_r(
-        arg1: *mut DIR,
-        arg2: *mut dirent,
-        arg3: *mut *mut dirent,
+        __dirp: *mut DIR,
+        __entry: *mut dirent,
+        __result: *mut *mut dirent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_rewinddir$INODE64"]
-    pub fn rewinddir(arg1: *mut DIR);
+    pub fn rewinddir(__dirp: *mut DIR);
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_seekdir$INODE64"]
-    pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+    pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_telldir$INODE64"]
-    pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+    pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_fdopendir$INODE64"]
-    pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+    pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_alphasort$INODE64"]
-    pub fn alphasort(arg1: *mut *const dirent, arg2: *mut *const dirent) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_scandir$INODE64"]
     pub fn scandir(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut *mut dirent,
-        arg3: ::std::option::Option<
+        __dir: *const ::std::os::raw::c_char,
+        __namelist: *mut *mut *mut dirent,
+        __selector: ::std::option::Option<
             unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
         >,
-        arg4: ::std::option::Option<
+        __cmp: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut *const dirent,
                 arg2: *mut *const dirent,
@@ -15862,29 +14543,16 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_scandir_b$INODE64"]
-    pub fn scandir_b(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut *mut dirent,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
+    pub fn alphasort(__e1: *mut *const dirent, __e2: *mut *const dirent) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
     pub fn getdirentries(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}___opendir2$INODE64"]
-    pub fn __opendir2(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int)
-        -> *mut DIR;
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+        __basep: *mut __off_t,
+    ) -> __ssize_t;
 }
 pub type File = ::std::os::raw::c_int;
 #[pg_guard]
@@ -23139,160 +21807,651 @@ extern "C" {
         nulls: *mut *mut bool,
     ) -> ::std::os::raw::c_int;
 }
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
+    _bindgen_union_align: u64,
+}
+impl Default for sigval {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+    _bindgen_union_align: [u64; 14usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+    _bindgen_union_align: [u64; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub const SI_ASYNCNL: ::std::os::raw::c_int = -60;
+pub const SI_DETHREAD: ::std::os::raw::c_int = -7;
+pub const SI_TKILL: ::std::os::raw::c_int = -6;
+pub const SI_SIGIO: ::std::os::raw::c_int = -5;
+pub const SI_ASYNCIO: ::std::os::raw::c_int = -4;
+pub const SI_MESGQ: ::std::os::raw::c_int = -3;
+pub const SI_TIMER: ::std::os::raw::c_int = -2;
+pub const SI_QUEUE: ::std::os::raw::c_int = -1;
+pub const SI_USER: ::std::os::raw::c_int = 0;
+pub const SI_KERNEL: ::std::os::raw::c_int = 128;
+pub type _bindgen_ty_10 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: ::std::os::raw::c_uint = 1;
+pub const ILL_ILLOPN: ::std::os::raw::c_uint = 2;
+pub const ILL_ILLADR: ::std::os::raw::c_uint = 3;
+pub const ILL_ILLTRP: ::std::os::raw::c_uint = 4;
+pub const ILL_PRVOPC: ::std::os::raw::c_uint = 5;
+pub const ILL_PRVREG: ::std::os::raw::c_uint = 6;
+pub const ILL_COPROC: ::std::os::raw::c_uint = 7;
+pub const ILL_BADSTK: ::std::os::raw::c_uint = 8;
+pub const ILL_BADIADDR: ::std::os::raw::c_uint = 9;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: ::std::os::raw::c_uint = 1;
+pub const FPE_INTOVF: ::std::os::raw::c_uint = 2;
+pub const FPE_FLTDIV: ::std::os::raw::c_uint = 3;
+pub const FPE_FLTOVF: ::std::os::raw::c_uint = 4;
+pub const FPE_FLTUND: ::std::os::raw::c_uint = 5;
+pub const FPE_FLTRES: ::std::os::raw::c_uint = 6;
+pub const FPE_FLTINV: ::std::os::raw::c_uint = 7;
+pub const FPE_FLTSUB: ::std::os::raw::c_uint = 8;
+pub const FPE_FLTUNK: ::std::os::raw::c_uint = 14;
+pub const FPE_CONDTRAP: ::std::os::raw::c_uint = 15;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: ::std::os::raw::c_uint = 1;
+pub const SEGV_ACCERR: ::std::os::raw::c_uint = 2;
+pub const SEGV_BNDERR: ::std::os::raw::c_uint = 3;
+pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
+pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
+pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
+pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
+pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
+pub const BUS_OBJERR: ::std::os::raw::c_uint = 3;
+pub const BUS_MCEERR_AR: ::std::os::raw::c_uint = 4;
+pub const BUS_MCEERR_AO: ::std::os::raw::c_uint = 5;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: ::std::os::raw::c_uint = 1;
+pub const CLD_KILLED: ::std::os::raw::c_uint = 2;
+pub const CLD_DUMPED: ::std::os::raw::c_uint = 3;
+pub const CLD_TRAPPED: ::std::os::raw::c_uint = 4;
+pub const CLD_STOPPED: ::std::os::raw::c_uint = 5;
+pub const CLD_CONTINUED: ::std::os::raw::c_uint = 6;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
+pub const POLL_IN: ::std::os::raw::c_uint = 1;
+pub const POLL_OUT: ::std::os::raw::c_uint = 2;
+pub const POLL_MSG: ::std::os::raw::c_uint = 3;
+pub const POLL_ERR: ::std::os::raw::c_uint = 4;
+pub const POLL_PRI: ::std::os::raw::c_uint = 5;
+pub const POLL_HUP: ::std::os::raw::c_uint = 6;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+    _bindgen_union_align: [u64; 6usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: ::std::os::raw::c_uint = 0;
+pub const SIGEV_NONE: ::std::os::raw::c_uint = 1;
+pub const SIGEV_THREAD: ::std::os::raw::c_uint = 2;
+pub const SIGEV_THREAD_ID: ::std::os::raw::c_uint = 4;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[pg_guard]
 extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+    pub fn __sysv_signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t)
+        -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+    pub fn signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bsd_signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
+    pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ssignal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_kill(arg1: pthread_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_sigmask(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigset_t,
-        arg3: *mut sigset_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaction(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigaction,
-        arg3: *mut sigaction,
-    ) -> ::std::os::raw::c_int;
+    pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaddset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
+    pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigdelset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn siggetmask() -> ::std::os::raw::c_int;
+}
+pub type sig_t = __sighandler_t;
+#[pg_guard]
+extern "C" {
+    pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn siginterrupt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigismember(arg1: *const sigset_t, arg2: ::std::os::raw::c_int)
+    pub fn sigaddset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigdelset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigismember(
+        __set: *const sigset_t,
+        __signo: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+    _bindgen_union_align: u64,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
     pub fn sigprocmask(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigset_t,
-        arg3: *mut sigset_t,
+        __how: ::std::os::raw::c_int,
+        __set: *const sigset_t,
+        __oset: *mut sigset_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigset(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
+    pub fn sigaction(
+        __sig: ::std::os::raw::c_int,
+        __act: *const sigaction,
+        __oact: *mut sigaction,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn sigwait(
-        arg1: *const sigset_t,
-        arg2: *mut ::std::os::raw::c_int,
+        __set: *const sigset_t,
+        __sig: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
+    pub fn sigwaitinfo(__set: *const sigset_t, __info: *mut siginfo_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigvec(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sigvec,
-        arg3: *mut sigvec,
+    pub fn sigtimedwait(
+        __set: *const sigset_t,
+        __info: *mut siginfo_t,
+        __timeout: *const timespec,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigqueue(
+        __pid: __pid_t,
+        __sig: ::std::os::raw::c_int,
+        __val: sigval,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+    _bindgen_union_align: u64,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigreturn(__scp: *mut sigcontext) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn siginterrupt(
+        __sig: ::std::os::raw::c_int,
+        __interrupt: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub const SS_ONSTACK: ::std::os::raw::c_uint = 1;
+pub const SS_DISABLE: ::std::os::raw::c_uint = 2;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
+#[pg_guard]
+extern "C" {
+    pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigstack(__ss: *mut sigstack, __oss: *mut sigstack) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pthread_sigmask(
+        __how: ::std::os::raw::c_int,
+        __newmask: *const __sigset_t,
+        __oldmask: *mut __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pthread_kill(
+        __threadid: pthread_t,
+        __signo: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
 }
 pub type pg_time_t = int64;
 #[repr(C)]
@@ -23913,9 +23072,8 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -55201,6 +54359,11 @@ impl Default for __va_list_tag {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -181,25 +181,26 @@ pub const BLCKSZ: u32 = 8192;
 pub const DEF_PGPORT: u32 = 28812;
 pub const DEF_PGPORT_STR: &'static [u8; 6usize] = b"28812\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
-pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_CBRT: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
+pub const HAVE_COPYFILE: u32 = 1;
+pub const HAVE_COPYFILE_H: u32 = 1;
 pub const HAVE_CRYPT: u32 = 1;
-pub const HAVE_CRYPT_H: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 1;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 0;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
 pub const HAVE_DECL_RTLD_GLOBAL: u32 = 1;
 pub const HAVE_DECL_RTLD_NOW: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 0;
-pub const HAVE_DECL_STRLCPY: u32 = 0;
+pub const HAVE_DECL_STRLCAT: u32 = 1;
+pub const HAVE_DECL_STRLCPY: u32 = 1;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
+pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -209,11 +210,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
-pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
+pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -223,6 +224,7 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTPTR_T: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
+pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
 pub const HAVE_ISINF: u32 = 1;
@@ -233,6 +235,7 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
 pub const HAVE_LONG_LONG_INT: u32 = 1;
+pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMMOVE: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
@@ -240,11 +243,9 @@ pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
-pub const HAVE_POSIX_FADVISE: u32 = 1;
-pub const HAVE_POSIX_FALLOCATE: u32 = 1;
-pub const HAVE_PPOLL: u32 = 1;
 pub const HAVE_PREAD: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
+pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_PWRITE: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
@@ -255,7 +256,6 @@ pub const HAVE_RINT: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
-pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SPINLOCKS: u32 = 1;
@@ -263,10 +263,11 @@ pub const HAVE_SRANDOM: u32 = 1;
 pub const HAVE_STDBOOL_H: u32 = 1;
 pub const HAVE_STDINT_H: u32 = 1;
 pub const HAVE_STDLIB_H: u32 = 1;
-pub const HAVE_STRCHRNUL: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
+pub const HAVE_STRLCAT: u32 = 1;
+pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOF: u32 = 1;
@@ -274,27 +275,29 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
+pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
+pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
-pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
-pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
-pub const HAVE_SYS_PRCTL_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
+pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
+pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TM_ZONE: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
 pub const HAVE_TZNAME: u32 = 1;
 pub const HAVE_UINTPTR_T: u32 = 1;
+pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNIX_SOCKETS: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
@@ -304,6 +307,7 @@ pub const HAVE_UTIME: u32 = 1;
 pub const HAVE_UTIMES: u32 = 1;
 pub const HAVE_UTIME_H: u32 = 1;
 pub const HAVE_WCHAR_H: u32 = 1;
+pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE_X86_64_POPCNTQ: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
@@ -320,6 +324,7 @@ pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
 pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const INT64_MODIFIER: &'static [u8; 2usize] = b"l\0";
+pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &'static [u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
@@ -332,8 +337,7 @@ pub const PG_KRB_SRVNAM: &'static [u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &'static [u8; 3usize] = b"12\0";
 pub const PG_VERSION: &'static [u8; 5usize] = b"12.6\0";
 pub const PG_VERSION_NUM: u32 = 120006;
-pub const PG_VERSION_STR: &'static [u8; 77usize] =
-    b"PostgreSQL 12.6 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.0, 64-bit\0";
+pub const PG_VERSION_STR : & 'static [u8 ; 113usize] = b"PostgreSQL 12.6 on x86_64-apple-darwin20.3.0, compiled by Apple clang version 12.0.5 (clang-1205.0.22.9), 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -341,13 +345,15 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const STRERROR_R_INT: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
+pub const USE_SYSV_SEMAPHORES: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
+pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -362,211 +368,510 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &'static [u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &'static [u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const _STDIO_H: u32 = 1;
-pub const _FEATURES_H: u32 = 1;
-pub const _DEFAULT_SOURCE: u32 = 1;
-pub const __GLIBC_USE_ISOC2X: u32 = 0;
-pub const __USE_ISOC11: u32 = 1;
-pub const __USE_ISOC99: u32 = 1;
-pub const __USE_ISOC95: u32 = 1;
-pub const __USE_POSIX_IMPLICITLY: u32 = 1;
-pub const _POSIX_SOURCE: u32 = 1;
-pub const _POSIX_C_SOURCE: u32 = 200809;
-pub const __USE_POSIX: u32 = 1;
-pub const __USE_POSIX2: u32 = 1;
-pub const __USE_POSIX199309: u32 = 1;
-pub const __USE_POSIX199506: u32 = 1;
-pub const __USE_XOPEN2K: u32 = 1;
-pub const __USE_XOPEN2K8: u32 = 1;
-pub const _ATFILE_SOURCE: u32 = 1;
-pub const __USE_MISC: u32 = 1;
-pub const __USE_ATFILE: u32 = 1;
-pub const __USE_FORTIFY_LEVEL: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const _STDC_PREDEF_H: u32 = 1;
-pub const __STDC_IEC_559__: u32 = 1;
-pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
-pub const __STDC_ISO_10646__: u32 = 201706;
-pub const __GNU_LIBRARY__: u32 = 6;
-pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 32;
-pub const _SYS_CDEFS_H: u32 = 1;
-pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
-pub const __HAVE_GENERIC_SELECTION: u32 = 1;
-pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const _BITS_TYPES_H: u32 = 1;
-pub const __TIMESIZE: u32 = 64;
-pub const _BITS_TYPESIZES_H: u32 = 1;
-pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
-pub const __INO_T_MATCHES_INO64_T: u32 = 1;
-pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
-pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
-pub const __FD_SETSIZE: u32 = 1024;
-pub const _BITS_TIME64_H: u32 = 1;
-pub const _____fpos_t_defined: u32 = 1;
-pub const ____mbstate_t_defined: u32 = 1;
-pub const _____fpos64_t_defined: u32 = 1;
-pub const ____FILE_defined: u32 = 1;
-pub const __FILE_defined: u32 = 1;
-pub const __struct_FILE_defined: u32 = 1;
-pub const _IO_EOF_SEEN: u32 = 16;
-pub const _IO_ERR_SEEN: u32 = 32;
-pub const _IO_USER_LOCK: u32 = 32768;
+pub const __darwin__: u32 = 1;
+pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
+pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
+pub const __DARWIN_UNIX03: u32 = 1;
+pub const __DARWIN_64_BIT_INO_T: u32 = 1;
+pub const __DARWIN_VERS_1050: u32 = 1;
+pub const __DARWIN_NON_CANCELABLE: u32 = 0;
+pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
+pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
+pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
+pub const __DARWIN_C_ANSI: u32 = 4096;
+pub const __DARWIN_C_FULL: u32 = 900000;
+pub const __DARWIN_C_LEVEL: u32 = 900000;
+pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
+pub const __DARWIN_NO_LONG_LONG: u32 = 0;
+pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
+pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
+pub const __API_TO_BE_DEPRECATED: u32 = 100000;
+pub const __MAC_10_0: u32 = 1000;
+pub const __MAC_10_1: u32 = 1010;
+pub const __MAC_10_2: u32 = 1020;
+pub const __MAC_10_3: u32 = 1030;
+pub const __MAC_10_4: u32 = 1040;
+pub const __MAC_10_5: u32 = 1050;
+pub const __MAC_10_6: u32 = 1060;
+pub const __MAC_10_7: u32 = 1070;
+pub const __MAC_10_8: u32 = 1080;
+pub const __MAC_10_9: u32 = 1090;
+pub const __MAC_10_10: u32 = 101000;
+pub const __MAC_10_10_2: u32 = 101002;
+pub const __MAC_10_10_3: u32 = 101003;
+pub const __MAC_10_11: u32 = 101100;
+pub const __MAC_10_11_2: u32 = 101102;
+pub const __MAC_10_11_3: u32 = 101103;
+pub const __MAC_10_11_4: u32 = 101104;
+pub const __MAC_10_12: u32 = 101200;
+pub const __MAC_10_12_1: u32 = 101201;
+pub const __MAC_10_12_2: u32 = 101202;
+pub const __MAC_10_12_4: u32 = 101204;
+pub const __MAC_10_13: u32 = 101300;
+pub const __MAC_10_13_1: u32 = 101301;
+pub const __MAC_10_13_2: u32 = 101302;
+pub const __MAC_10_13_4: u32 = 101304;
+pub const __MAC_10_14: u32 = 101400;
+pub const __MAC_10_14_1: u32 = 101401;
+pub const __MAC_10_14_4: u32 = 101404;
+pub const __MAC_10_14_6: u32 = 101406;
+pub const __MAC_10_15: u32 = 101500;
+pub const __MAC_10_15_1: u32 = 101501;
+pub const __MAC_10_15_4: u32 = 101504;
+pub const __MAC_10_16: u32 = 101600;
+pub const __MAC_11_0: u32 = 110000;
+pub const __MAC_11_1: u32 = 110100;
+pub const __IPHONE_2_0: u32 = 20000;
+pub const __IPHONE_2_1: u32 = 20100;
+pub const __IPHONE_2_2: u32 = 20200;
+pub const __IPHONE_3_0: u32 = 30000;
+pub const __IPHONE_3_1: u32 = 30100;
+pub const __IPHONE_3_2: u32 = 30200;
+pub const __IPHONE_4_0: u32 = 40000;
+pub const __IPHONE_4_1: u32 = 40100;
+pub const __IPHONE_4_2: u32 = 40200;
+pub const __IPHONE_4_3: u32 = 40300;
+pub const __IPHONE_5_0: u32 = 50000;
+pub const __IPHONE_5_1: u32 = 50100;
+pub const __IPHONE_6_0: u32 = 60000;
+pub const __IPHONE_6_1: u32 = 60100;
+pub const __IPHONE_7_0: u32 = 70000;
+pub const __IPHONE_7_1: u32 = 70100;
+pub const __IPHONE_8_0: u32 = 80000;
+pub const __IPHONE_8_1: u32 = 80100;
+pub const __IPHONE_8_2: u32 = 80200;
+pub const __IPHONE_8_3: u32 = 80300;
+pub const __IPHONE_8_4: u32 = 80400;
+pub const __IPHONE_9_0: u32 = 90000;
+pub const __IPHONE_9_1: u32 = 90100;
+pub const __IPHONE_9_2: u32 = 90200;
+pub const __IPHONE_9_3: u32 = 90300;
+pub const __IPHONE_10_0: u32 = 100000;
+pub const __IPHONE_10_1: u32 = 100100;
+pub const __IPHONE_10_2: u32 = 100200;
+pub const __IPHONE_10_3: u32 = 100300;
+pub const __IPHONE_11_0: u32 = 110000;
+pub const __IPHONE_11_1: u32 = 110100;
+pub const __IPHONE_11_2: u32 = 110200;
+pub const __IPHONE_11_3: u32 = 110300;
+pub const __IPHONE_11_4: u32 = 110400;
+pub const __IPHONE_12_0: u32 = 120000;
+pub const __IPHONE_12_1: u32 = 120100;
+pub const __IPHONE_12_2: u32 = 120200;
+pub const __IPHONE_12_3: u32 = 120300;
+pub const __IPHONE_12_4: u32 = 120400;
+pub const __IPHONE_13_0: u32 = 130000;
+pub const __IPHONE_13_1: u32 = 130100;
+pub const __IPHONE_13_2: u32 = 130200;
+pub const __IPHONE_13_3: u32 = 130300;
+pub const __IPHONE_13_4: u32 = 130400;
+pub const __IPHONE_13_5: u32 = 130500;
+pub const __IPHONE_13_6: u32 = 130600;
+pub const __IPHONE_13_7: u32 = 130700;
+pub const __IPHONE_14_0: u32 = 140000;
+pub const __IPHONE_14_1: u32 = 140100;
+pub const __IPHONE_14_2: u32 = 140200;
+pub const __IPHONE_14_3: u32 = 140300;
+pub const __TVOS_9_0: u32 = 90000;
+pub const __TVOS_9_1: u32 = 90100;
+pub const __TVOS_9_2: u32 = 90200;
+pub const __TVOS_10_0: u32 = 100000;
+pub const __TVOS_10_0_1: u32 = 100001;
+pub const __TVOS_10_1: u32 = 100100;
+pub const __TVOS_10_2: u32 = 100200;
+pub const __TVOS_11_0: u32 = 110000;
+pub const __TVOS_11_1: u32 = 110100;
+pub const __TVOS_11_2: u32 = 110200;
+pub const __TVOS_11_3: u32 = 110300;
+pub const __TVOS_11_4: u32 = 110400;
+pub const __TVOS_12_0: u32 = 120000;
+pub const __TVOS_12_1: u32 = 120100;
+pub const __TVOS_12_2: u32 = 120200;
+pub const __TVOS_12_3: u32 = 120300;
+pub const __TVOS_12_4: u32 = 120400;
+pub const __TVOS_13_0: u32 = 130000;
+pub const __TVOS_13_2: u32 = 130200;
+pub const __TVOS_13_3: u32 = 130300;
+pub const __TVOS_13_4: u32 = 130400;
+pub const __TVOS_14_0: u32 = 140000;
+pub const __TVOS_14_1: u32 = 140100;
+pub const __TVOS_14_2: u32 = 140200;
+pub const __TVOS_14_3: u32 = 140300;
+pub const __WATCHOS_1_0: u32 = 10000;
+pub const __WATCHOS_2_0: u32 = 20000;
+pub const __WATCHOS_2_1: u32 = 20100;
+pub const __WATCHOS_2_2: u32 = 20200;
+pub const __WATCHOS_3_0: u32 = 30000;
+pub const __WATCHOS_3_1: u32 = 30100;
+pub const __WATCHOS_3_1_1: u32 = 30101;
+pub const __WATCHOS_3_2: u32 = 30200;
+pub const __WATCHOS_4_0: u32 = 40000;
+pub const __WATCHOS_4_1: u32 = 40100;
+pub const __WATCHOS_4_2: u32 = 40200;
+pub const __WATCHOS_4_3: u32 = 40300;
+pub const __WATCHOS_5_0: u32 = 50000;
+pub const __WATCHOS_5_1: u32 = 50100;
+pub const __WATCHOS_5_2: u32 = 50200;
+pub const __WATCHOS_5_3: u32 = 50300;
+pub const __WATCHOS_6_0: u32 = 60000;
+pub const __WATCHOS_6_1: u32 = 60100;
+pub const __WATCHOS_6_2: u32 = 60200;
+pub const __WATCHOS_7_0: u32 = 70000;
+pub const __WATCHOS_7_1: u32 = 70100;
+pub const __WATCHOS_7_2: u32 = 70200;
+pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
+pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
+pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
+pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
+pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
+pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
+pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
+pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
+pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
+pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
+pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
+pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
+pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
+pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
+pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
+pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
+pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
+pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
+pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
+pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
+pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
+pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
+pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
+pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
+pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
+pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
+pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
+pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
+pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
+pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
+pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
+pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
+pub const MAC_OS_VERSION_11_0: u32 = 110000;
+pub const __DRIVERKIT_19_0: u32 = 190000;
+pub const __DRIVERKIT_20_0: u32 = 200000;
+pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
+pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
+pub const __PTHREAD_SIZE__: u32 = 8176;
+pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
+pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
+pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_COND_SIZE__: u32 = 40;
+pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
+pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
+pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
+pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
+pub const _FORTIFY_SOURCE: u32 = 2;
+pub const RENAME_SECLUDE: u32 = 1;
+pub const RENAME_SWAP: u32 = 2;
+pub const RENAME_EXCL: u32 = 4;
+pub const __SLBF: u32 = 1;
+pub const __SNBF: u32 = 2;
+pub const __SRD: u32 = 4;
+pub const __SWR: u32 = 8;
+pub const __SRW: u32 = 16;
+pub const __SEOF: u32 = 32;
+pub const __SERR: u32 = 64;
+pub const __SMBF: u32 = 128;
+pub const __SAPP: u32 = 256;
+pub const __SSTR: u32 = 512;
+pub const __SOPT: u32 = 1024;
+pub const __SNPT: u32 = 2048;
+pub const __SOFF: u32 = 4096;
+pub const __SMOD: u32 = 8192;
+pub const __SALC: u32 = 16384;
+pub const __SIGN: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 8192;
+pub const BUFSIZ: u32 = 1024;
 pub const EOF: i32 = -1;
+pub const FOPEN_MAX: u32 = 20;
+pub const FILENAME_MAX: u32 = 1024;
+pub const P_tmpdir: &'static [u8; 10usize] = b"/var/tmp/\0";
+pub const L_tmpnam: u32 = 1024;
+pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const P_tmpdir: &'static [u8; 5usize] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
-pub const L_tmpnam: u32 = 20;
-pub const TMP_MAX: u32 = 238328;
-pub const FILENAME_MAX: u32 = 4096;
-pub const L_ctermid: u32 = 9;
-pub const FOPEN_MAX: u32 = 16;
-pub const __HAVE_FLOAT128: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
-pub const __HAVE_FLOAT64X: u32 = 1;
-pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
-pub const __HAVE_FLOAT16: u32 = 0;
-pub const __HAVE_FLOAT32: u32 = 1;
-pub const __HAVE_FLOAT64: u32 = 1;
-pub const __HAVE_FLOAT32X: u32 = 1;
-pub const __HAVE_FLOAT128X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
-pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
+pub const L_ctermid: u32 = 1024;
+pub const _USE_FORTIFY_LEVEL: u32 = 2;
+pub const __DARWIN_NSIG: u32 = 32;
+pub const NSIG: u32 = 32;
+pub const _I386_SIGNAL_H_: u32 = 1;
+pub const SIGHUP: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGQUIT: u32 = 3;
+pub const SIGILL: u32 = 4;
+pub const SIGTRAP: u32 = 5;
+pub const SIGABRT: u32 = 6;
+pub const SIGIOT: u32 = 6;
+pub const SIGEMT: u32 = 7;
+pub const SIGFPE: u32 = 8;
+pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSEGV: u32 = 11;
+pub const SIGSYS: u32 = 12;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGTERM: u32 = 15;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGIO: u32 = 23;
+pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGWINCH: u32 = 28;
+pub const SIGINFO: u32 = 29;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
+pub const FP_PREC_24B: u32 = 0;
+pub const FP_PREC_53B: u32 = 2;
+pub const FP_PREC_64B: u32 = 3;
+pub const FP_RND_NEAR: u32 = 0;
+pub const FP_RND_DOWN: u32 = 1;
+pub const FP_RND_UP: u32 = 2;
+pub const FP_CHOP: u32 = 3;
+pub const FP_STATE_BYTES: u32 = 512;
+pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
+pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
+pub const __LASTBRANCH_MAX: u32 = 32;
+pub const SIGEV_NONE: u32 = 0;
+pub const SIGEV_SIGNAL: u32 = 1;
+pub const SIGEV_THREAD: u32 = 3;
+pub const ILL_NOOP: u32 = 0;
+pub const ILL_ILLOPC: u32 = 1;
+pub const ILL_ILLTRP: u32 = 2;
+pub const ILL_PRVOPC: u32 = 3;
+pub const ILL_ILLOPN: u32 = 4;
+pub const ILL_ILLADR: u32 = 5;
+pub const ILL_PRVREG: u32 = 6;
+pub const ILL_COPROC: u32 = 7;
+pub const ILL_BADSTK: u32 = 8;
+pub const FPE_NOOP: u32 = 0;
+pub const FPE_FLTDIV: u32 = 1;
+pub const FPE_FLTOVF: u32 = 2;
+pub const FPE_FLTUND: u32 = 3;
+pub const FPE_FLTRES: u32 = 4;
+pub const FPE_FLTINV: u32 = 5;
+pub const FPE_FLTSUB: u32 = 6;
+pub const FPE_INTDIV: u32 = 7;
+pub const FPE_INTOVF: u32 = 8;
+pub const SEGV_NOOP: u32 = 0;
+pub const SEGV_MAPERR: u32 = 1;
+pub const SEGV_ACCERR: u32 = 2;
+pub const BUS_NOOP: u32 = 0;
+pub const BUS_ADRALN: u32 = 1;
+pub const BUS_ADRERR: u32 = 2;
+pub const BUS_OBJERR: u32 = 3;
+pub const TRAP_BRKPT: u32 = 1;
+pub const TRAP_TRACE: u32 = 2;
+pub const CLD_NOOP: u32 = 0;
+pub const CLD_EXITED: u32 = 1;
+pub const CLD_KILLED: u32 = 2;
+pub const CLD_DUMPED: u32 = 3;
+pub const CLD_TRAPPED: u32 = 4;
+pub const CLD_STOPPED: u32 = 5;
+pub const CLD_CONTINUED: u32 = 6;
+pub const POLL_IN: u32 = 1;
+pub const POLL_OUT: u32 = 2;
+pub const POLL_MSG: u32 = 3;
+pub const POLL_ERR: u32 = 4;
+pub const POLL_PRI: u32 = 5;
+pub const POLL_HUP: u32 = 6;
+pub const SA_ONSTACK: u32 = 1;
+pub const SA_RESTART: u32 = 2;
+pub const SA_RESETHAND: u32 = 4;
+pub const SA_NOCLDSTOP: u32 = 8;
+pub const SA_NODEFER: u32 = 16;
+pub const SA_NOCLDWAIT: u32 = 32;
+pub const SA_SIGINFO: u32 = 64;
+pub const SA_USERTRAMP: u32 = 256;
+pub const SA_64REGSET: u32 = 512;
+pub const SA_USERSPACE_MASK: u32 = 127;
+pub const SIG_BLOCK: u32 = 1;
+pub const SIG_UNBLOCK: u32 = 2;
+pub const SIG_SETMASK: u32 = 3;
+pub const SI_USER: u32 = 65537;
+pub const SI_QUEUE: u32 = 65538;
+pub const SI_TIMER: u32 = 65539;
+pub const SI_ASYNCIO: u32 = 65540;
+pub const SI_MESGQ: u32 = 65541;
+pub const SS_ONSTACK: u32 = 1;
+pub const SS_DISABLE: u32 = 4;
+pub const MINSIGSTKSZ: u32 = 32768;
+pub const SIGSTKSZ: u32 = 131072;
+pub const SV_ONSTACK: u32 = 1;
+pub const SV_INTERRUPT: u32 = 2;
+pub const SV_RESETHAND: u32 = 4;
+pub const SV_NODEFER: u32 = 16;
+pub const SV_NOCLDSTOP: u32 = 8;
+pub const SV_SIGINFO: u32 = 64;
+pub const __WORDSIZE: u32 = 64;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const INT64_MAX: u64 = 9223372036854775807;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT64_MIN: i64 = -9223372036854775808;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const UINT64_MAX: i32 = -1;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const UINT_LEAST64_MAX: i32 = -1;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i32 = -32768;
+pub const INT_FAST32_MIN: i32 = -2147483648;
+pub const INT_FAST64_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u32 = 32767;
+pub const INT_FAST32_MAX: u32 = 2147483647;
+pub const INT_FAST64_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: u32 = 65535;
+pub const UINT_FAST32_MAX: u32 = 4294967295;
+pub const UINT_FAST64_MAX: i32 = -1;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const UINTPTR_MAX: i32 = -1;
+pub const SIZE_MAX: i32 = -1;
+pub const RSIZE_MAX: i32 = -1;
+pub const WINT_MIN: i32 = -2147483648;
+pub const WINT_MAX: u32 = 2147483647;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const PRIO_PROCESS: u32 = 0;
+pub const PRIO_PGRP: u32 = 1;
+pub const PRIO_USER: u32 = 2;
+pub const PRIO_DARWIN_THREAD: u32 = 3;
+pub const PRIO_DARWIN_PROCESS: u32 = 4;
+pub const PRIO_MIN: i32 = -20;
+pub const PRIO_MAX: u32 = 20;
+pub const PRIO_DARWIN_BG: u32 = 4096;
+pub const PRIO_DARWIN_NONUI: u32 = 4097;
+pub const RUSAGE_SELF: u32 = 0;
+pub const RUSAGE_CHILDREN: i32 = -1;
+pub const RUSAGE_INFO_V0: u32 = 0;
+pub const RUSAGE_INFO_V1: u32 = 1;
+pub const RUSAGE_INFO_V2: u32 = 2;
+pub const RUSAGE_INFO_V3: u32 = 3;
+pub const RUSAGE_INFO_V4: u32 = 4;
+pub const RUSAGE_INFO_V5: u32 = 5;
+pub const RUSAGE_INFO_CURRENT: u32 = 5;
+pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
+pub const RLIMIT_CPU: u32 = 0;
+pub const RLIMIT_FSIZE: u32 = 1;
+pub const RLIMIT_DATA: u32 = 2;
+pub const RLIMIT_STACK: u32 = 3;
+pub const RLIMIT_CORE: u32 = 4;
+pub const RLIMIT_AS: u32 = 5;
+pub const RLIMIT_RSS: u32 = 5;
+pub const RLIMIT_MEMLOCK: u32 = 6;
+pub const RLIMIT_NPROC: u32 = 7;
+pub const RLIMIT_NOFILE: u32 = 8;
+pub const RLIM_NLIMITS: u32 = 9;
+pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
+pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
+pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
+pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
+pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
+pub const WAKEMON_ENABLE: u32 = 1;
+pub const WAKEMON_DISABLE: u32 = 2;
+pub const WAKEMON_GET_PARAMS: u32 = 4;
+pub const WAKEMON_SET_DEFAULTS: u32 = 8;
+pub const WAKEMON_MAKE_FATAL: u32 = 16;
+pub const CPUMON_MAKE_FATAL: u32 = 4096;
+pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
+pub const IOPOL_TYPE_DISK: u32 = 0;
+pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
+pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
+pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
+pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
+pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
+pub const IOPOL_SCOPE_PROCESS: u32 = 0;
+pub const IOPOL_SCOPE_THREAD: u32 = 1;
+pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
+pub const IOPOL_DEFAULT: u32 = 0;
+pub const IOPOL_IMPORTANT: u32 = 1;
+pub const IOPOL_PASSIVE: u32 = 2;
+pub const IOPOL_THROTTLE: u32 = 3;
+pub const IOPOL_UTILITY: u32 = 4;
+pub const IOPOL_STANDARD: u32 = 5;
+pub const IOPOL_APPLICATION: u32 = 5;
+pub const IOPOL_NORMAL: u32 = 1;
+pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
+pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
+pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
+pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
+pub const WCOREFLAG: u32 = 128;
+pub const _WSTOPPED: u32 = 127;
 pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
-pub const __ldiv_t_defined: u32 = 1;
-pub const __lldiv_t_defined: u32 = 1;
-pub const RAND_MAX: u32 = 2147483647;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const _SYS_TYPES_H: u32 = 1;
-pub const __clock_t_defined: u32 = 1;
-pub const __clockid_t_defined: u32 = 1;
-pub const __time_t_defined: u32 = 1;
-pub const __timer_t_defined: u32 = 1;
-pub const _BITS_STDINT_INTN_H: u32 = 1;
-pub const __BIT_TYPES_DEFINED__: u32 = 1;
-pub const _ENDIAN_H: u32 = 1;
-pub const _BITS_ENDIAN_H: u32 = 1;
-pub const __LITTLE_ENDIAN: u32 = 1234;
-pub const __BIG_ENDIAN: u32 = 4321;
-pub const __PDP_ENDIAN: u32 = 3412;
-pub const _BITS_ENDIANNESS_H: u32 = 1;
-pub const __BYTE_ORDER: u32 = 1234;
-pub const __FLOAT_WORD_ORDER: u32 = 1234;
+pub const WSTOPPED: u32 = 8;
+pub const WCONTINUED: u32 = 16;
+pub const WNOWAIT: u32 = 32;
+pub const WAIT_ANY: i32 = -1;
+pub const WAIT_MYPGRP: u32 = 0;
+pub const _QUAD_HIGHWORD: u32 = 1;
+pub const _QUAD_LOWWORD: u32 = 0;
+pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
+pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
+pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
+pub const __DARWIN_BYTE_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const _BITS_BYTESWAP_H: u32 = 1;
-pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
-pub const _SYS_SELECT_H: u32 = 1;
-pub const __sigset_t_defined: u32 = 1;
-pub const __timeval_defined: u32 = 1;
-pub const _STRUCT_TIMESPEC: u32 = 1;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const RAND_MAX: u32 = 2147483647;
+pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const __DARWIN_FD_SETSIZE: u32 = 1024;
+pub const __DARWIN_NBBY: u32 = 8;
+pub const NBBY: u32 = 8;
 pub const FD_SETSIZE: u32 = 1024;
-pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
-pub const _THREAD_SHARED_TYPES_H: u32 = 1;
-pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
-pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
-pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
-pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
-pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
-pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
-pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
-pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
-pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
-pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
-pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
-pub const __have_pthread_attr_t: u32 = 1;
-pub const _ALLOCA_H: u32 = 1;
-pub const _STRING_H: u32 = 1;
-pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
-pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
-pub const _STRINGS_H: u32 = 1;
-pub const _STDINT_H: u32 = 1;
-pub const _BITS_WCHAR_H: u32 = 1;
-pub const _BITS_STDINT_UINTN_H: u32 = 1;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i64 = -9223372036854775808;
-pub const INT_FAST32_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u64 = 9223372036854775807;
-pub const INT_FAST32_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: i32 = -1;
-pub const UINT_FAST32_MAX: i32 = -1;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const UINTPTR_MAX: i32 = -1;
-pub const PTRDIFF_MIN: i64 = -9223372036854775808;
-pub const PTRDIFF_MAX: u64 = 9223372036854775807;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const SIZE_MAX: i32 = -1;
-pub const WINT_MIN: u32 = 0;
-pub const WINT_MAX: u32 = 4294967295;
-pub const _ERRNO_H: u32 = 1;
-pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -577,7 +882,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EAGAIN: u32 = 11;
+pub const EDEADLK: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -601,147 +906,88 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EDEADLK: u32 = 35;
-pub const ENAMETOOLONG: u32 = 36;
-pub const ENOLCK: u32 = 37;
-pub const ENOSYS: u32 = 38;
-pub const ENOTEMPTY: u32 = 39;
-pub const ELOOP: u32 = 40;
-pub const EWOULDBLOCK: u32 = 11;
-pub const ENOMSG: u32 = 42;
-pub const EIDRM: u32 = 43;
-pub const ECHRNG: u32 = 44;
-pub const EL2NSYNC: u32 = 45;
-pub const EL3HLT: u32 = 46;
-pub const EL3RST: u32 = 47;
-pub const ELNRNG: u32 = 48;
-pub const EUNATCH: u32 = 49;
-pub const ENOCSI: u32 = 50;
-pub const EL2HLT: u32 = 51;
-pub const EBADE: u32 = 52;
-pub const EBADR: u32 = 53;
-pub const EXFULL: u32 = 54;
-pub const ENOANO: u32 = 55;
-pub const EBADRQC: u32 = 56;
-pub const EBADSLT: u32 = 57;
-pub const EDEADLOCK: u32 = 35;
-pub const EBFONT: u32 = 59;
-pub const ENOSTR: u32 = 60;
-pub const ENODATA: u32 = 61;
-pub const ETIME: u32 = 62;
-pub const ENOSR: u32 = 63;
-pub const ENONET: u32 = 64;
-pub const ENOPKG: u32 = 65;
-pub const EREMOTE: u32 = 66;
-pub const ENOLINK: u32 = 67;
-pub const EADV: u32 = 68;
-pub const ESRMNT: u32 = 69;
-pub const ECOMM: u32 = 70;
-pub const EPROTO: u32 = 71;
-pub const EMULTIHOP: u32 = 72;
-pub const EDOTDOT: u32 = 73;
-pub const EBADMSG: u32 = 74;
-pub const EOVERFLOW: u32 = 75;
-pub const ENOTUNIQ: u32 = 76;
-pub const EBADFD: u32 = 77;
-pub const EREMCHG: u32 = 78;
-pub const ELIBACC: u32 = 79;
-pub const ELIBBAD: u32 = 80;
-pub const ELIBSCN: u32 = 81;
-pub const ELIBMAX: u32 = 82;
-pub const ELIBEXEC: u32 = 83;
-pub const EILSEQ: u32 = 84;
-pub const ERESTART: u32 = 85;
-pub const ESTRPIPE: u32 = 86;
-pub const EUSERS: u32 = 87;
-pub const ENOTSOCK: u32 = 88;
-pub const EDESTADDRREQ: u32 = 89;
-pub const EMSGSIZE: u32 = 90;
-pub const EPROTOTYPE: u32 = 91;
-pub const ENOPROTOOPT: u32 = 92;
-pub const EPROTONOSUPPORT: u32 = 93;
-pub const ESOCKTNOSUPPORT: u32 = 94;
-pub const EOPNOTSUPP: u32 = 95;
-pub const EPFNOSUPPORT: u32 = 96;
-pub const EAFNOSUPPORT: u32 = 97;
-pub const EADDRINUSE: u32 = 98;
-pub const EADDRNOTAVAIL: u32 = 99;
-pub const ENETDOWN: u32 = 100;
-pub const ENETUNREACH: u32 = 101;
-pub const ENETRESET: u32 = 102;
-pub const ECONNABORTED: u32 = 103;
-pub const ECONNRESET: u32 = 104;
-pub const ENOBUFS: u32 = 105;
-pub const EISCONN: u32 = 106;
-pub const ENOTCONN: u32 = 107;
-pub const ESHUTDOWN: u32 = 108;
-pub const ETOOMANYREFS: u32 = 109;
-pub const ETIMEDOUT: u32 = 110;
-pub const ECONNREFUSED: u32 = 111;
-pub const EHOSTDOWN: u32 = 112;
-pub const EHOSTUNREACH: u32 = 113;
-pub const EALREADY: u32 = 114;
-pub const EINPROGRESS: u32 = 115;
-pub const ESTALE: u32 = 116;
-pub const EUCLEAN: u32 = 117;
-pub const ENOTNAM: u32 = 118;
-pub const ENAVAIL: u32 = 119;
-pub const EISNAM: u32 = 120;
-pub const EREMOTEIO: u32 = 121;
-pub const EDQUOT: u32 = 122;
-pub const ENOMEDIUM: u32 = 123;
-pub const EMEDIUMTYPE: u32 = 124;
-pub const ECANCELED: u32 = 125;
-pub const ENOKEY: u32 = 126;
-pub const EKEYEXPIRED: u32 = 127;
-pub const EKEYREVOKED: u32 = 128;
-pub const EKEYREJECTED: u32 = 129;
-pub const EOWNERDEAD: u32 = 130;
-pub const ENOTRECOVERABLE: u32 = 131;
-pub const ERFKILL: u32 = 132;
-pub const EHWPOISON: u32 = 133;
-pub const ENOTSUP: u32 = 95;
-pub const _LOCALE_H: u32 = 1;
-pub const _BITS_LOCALE_H: u32 = 1;
-pub const __LC_CTYPE: u32 = 0;
-pub const __LC_NUMERIC: u32 = 1;
-pub const __LC_TIME: u32 = 2;
-pub const __LC_COLLATE: u32 = 3;
-pub const __LC_MONETARY: u32 = 4;
-pub const __LC_MESSAGES: u32 = 5;
-pub const __LC_ALL: u32 = 6;
-pub const __LC_PAPER: u32 = 7;
-pub const __LC_NAME: u32 = 8;
-pub const __LC_ADDRESS: u32 = 9;
-pub const __LC_TELEPHONE: u32 = 10;
-pub const __LC_MEASUREMENT: u32 = 11;
-pub const __LC_IDENTIFICATION: u32 = 12;
-pub const LC_CTYPE: u32 = 0;
-pub const LC_NUMERIC: u32 = 1;
-pub const LC_TIME: u32 = 2;
-pub const LC_COLLATE: u32 = 3;
-pub const LC_MONETARY: u32 = 4;
-pub const LC_MESSAGES: u32 = 5;
-pub const LC_ALL: u32 = 6;
-pub const LC_PAPER: u32 = 7;
-pub const LC_NAME: u32 = 8;
-pub const LC_ADDRESS: u32 = 9;
-pub const LC_TELEPHONE: u32 = 10;
-pub const LC_MEASUREMENT: u32 = 11;
-pub const LC_IDENTIFICATION: u32 = 12;
-pub const LC_CTYPE_MASK: u32 = 1;
-pub const LC_NUMERIC_MASK: u32 = 2;
-pub const LC_TIME_MASK: u32 = 4;
-pub const LC_COLLATE_MASK: u32 = 8;
-pub const LC_MONETARY_MASK: u32 = 16;
-pub const LC_MESSAGES_MASK: u32 = 32;
-pub const LC_PAPER_MASK: u32 = 128;
-pub const LC_NAME_MASK: u32 = 256;
-pub const LC_ADDRESS_MASK: u32 = 512;
-pub const LC_TELEPHONE_MASK: u32 = 1024;
-pub const LC_MEASUREMENT_MASK: u32 = 2048;
-pub const LC_IDENTIFICATION_MASK: u32 = 4096;
-pub const LC_ALL_MASK: u32 = 8127;
+pub const EAGAIN: u32 = 35;
+pub const EWOULDBLOCK: u32 = 35;
+pub const EINPROGRESS: u32 = 36;
+pub const EALREADY: u32 = 37;
+pub const ENOTSOCK: u32 = 38;
+pub const EDESTADDRREQ: u32 = 39;
+pub const EMSGSIZE: u32 = 40;
+pub const EPROTOTYPE: u32 = 41;
+pub const ENOPROTOOPT: u32 = 42;
+pub const EPROTONOSUPPORT: u32 = 43;
+pub const ESOCKTNOSUPPORT: u32 = 44;
+pub const ENOTSUP: u32 = 45;
+pub const EPFNOSUPPORT: u32 = 46;
+pub const EAFNOSUPPORT: u32 = 47;
+pub const EADDRINUSE: u32 = 48;
+pub const EADDRNOTAVAIL: u32 = 49;
+pub const ENETDOWN: u32 = 50;
+pub const ENETUNREACH: u32 = 51;
+pub const ENETRESET: u32 = 52;
+pub const ECONNABORTED: u32 = 53;
+pub const ECONNRESET: u32 = 54;
+pub const ENOBUFS: u32 = 55;
+pub const EISCONN: u32 = 56;
+pub const ENOTCONN: u32 = 57;
+pub const ESHUTDOWN: u32 = 58;
+pub const ETOOMANYREFS: u32 = 59;
+pub const ETIMEDOUT: u32 = 60;
+pub const ECONNREFUSED: u32 = 61;
+pub const ELOOP: u32 = 62;
+pub const ENAMETOOLONG: u32 = 63;
+pub const EHOSTDOWN: u32 = 64;
+pub const EHOSTUNREACH: u32 = 65;
+pub const ENOTEMPTY: u32 = 66;
+pub const EPROCLIM: u32 = 67;
+pub const EUSERS: u32 = 68;
+pub const EDQUOT: u32 = 69;
+pub const ESTALE: u32 = 70;
+pub const EREMOTE: u32 = 71;
+pub const EBADRPC: u32 = 72;
+pub const ERPCMISMATCH: u32 = 73;
+pub const EPROGUNAVAIL: u32 = 74;
+pub const EPROGMISMATCH: u32 = 75;
+pub const EPROCUNAVAIL: u32 = 76;
+pub const ENOLCK: u32 = 77;
+pub const ENOSYS: u32 = 78;
+pub const EFTYPE: u32 = 79;
+pub const EAUTH: u32 = 80;
+pub const ENEEDAUTH: u32 = 81;
+pub const EPWROFF: u32 = 82;
+pub const EDEVERR: u32 = 83;
+pub const EOVERFLOW: u32 = 84;
+pub const EBADEXEC: u32 = 85;
+pub const EBADARCH: u32 = 86;
+pub const ESHLIBVERS: u32 = 87;
+pub const EBADMACHO: u32 = 88;
+pub const ECANCELED: u32 = 89;
+pub const EIDRM: u32 = 90;
+pub const ENOMSG: u32 = 91;
+pub const EILSEQ: u32 = 92;
+pub const ENOATTR: u32 = 93;
+pub const EBADMSG: u32 = 94;
+pub const EMULTIHOP: u32 = 95;
+pub const ENODATA: u32 = 96;
+pub const ENOLINK: u32 = 97;
+pub const ENOSR: u32 = 98;
+pub const ENOSTR: u32 = 99;
+pub const EPROTO: u32 = 100;
+pub const ETIME: u32 = 101;
+pub const EOPNOTSUPP: u32 = 102;
+pub const ENOPOLICY: u32 = 103;
+pub const ENOTRECOVERABLE: u32 = 104;
+pub const EOWNERDEAD: u32 = 105;
+pub const EQFULL: u32 = 106;
+pub const ELAST: u32 = 106;
+pub const LC_ALL: u32 = 0;
+pub const LC_COLLATE: u32 = 1;
+pub const LC_CTYPE: u32 = 2;
+pub const LC_MONETARY: u32 = 3;
+pub const LC_NUMERIC: u32 = 4;
+pub const LC_TIME: u32 = 5;
+pub const LC_MESSAGES: u32 = 6;
+pub const _LC_LAST: u32 = 7;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
@@ -771,355 +1017,375 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &'static [u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &'static [u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &'static [u8; 2usize] = b"w\0";
-pub const _CTYPE_H: u32 = 1;
-pub const _NETDB_H: u32 = 1;
-pub const _NETINET_IN_H: u32 = 1;
-pub const _SYS_SOCKET_H: u32 = 1;
-pub const __iovec_defined: u32 = 1;
+pub const _CACHED_RUNES: u32 = 256;
+pub const _CRMASK: i32 = -256;
+pub const _RUNE_MAGIC_A: &'static [u8; 9usize] = b"RuneMagA\0";
+pub const _CTYPE_A: u32 = 256;
+pub const _CTYPE_C: u32 = 512;
+pub const _CTYPE_D: u32 = 1024;
+pub const _CTYPE_G: u32 = 2048;
+pub const _CTYPE_L: u32 = 4096;
+pub const _CTYPE_P: u32 = 8192;
+pub const _CTYPE_S: u32 = 16384;
+pub const _CTYPE_U: u32 = 32768;
+pub const _CTYPE_X: u32 = 65536;
+pub const _CTYPE_B: u32 = 131072;
+pub const _CTYPE_R: u32 = 262144;
+pub const _CTYPE_I: u32 = 524288;
+pub const _CTYPE_T: u32 = 1048576;
+pub const _CTYPE_Q: u32 = 2097152;
+pub const _CTYPE_SW0: u32 = 536870912;
+pub const _CTYPE_SW1: u32 = 1073741824;
+pub const _CTYPE_SW2: u32 = 2147483648;
+pub const _CTYPE_SW3: u32 = 3221225472;
+pub const _CTYPE_SWM: u32 = 3758096384;
+pub const _CTYPE_SWS: u32 = 30;
+pub const KEV_INET_SUBCLASS: u32 = 1;
+pub const KEV_INET_NEW_ADDR: u32 = 1;
+pub const KEV_INET_CHANGED_ADDR: u32 = 2;
+pub const KEV_INET_ADDR_DELETED: u32 = 3;
+pub const KEV_INET_SIFDSTADDR: u32 = 4;
+pub const KEV_INET_SIFBRDADDR: u32 = 5;
+pub const KEV_INET_SIFNETMASK: u32 = 6;
+pub const KEV_INET_ARPCOLLISION: u32 = 7;
+pub const KEV_INET_PORTINUSE: u32 = 8;
+pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
+pub const KEV_INET_ARPRTRALIVE: u32 = 10;
+pub const KEV_DL_SUBCLASS: u32 = 2;
+pub const KEV_DL_SIFFLAGS: u32 = 1;
+pub const KEV_DL_SIFMETRICS: u32 = 2;
+pub const KEV_DL_SIFMTU: u32 = 3;
+pub const KEV_DL_SIFPHYS: u32 = 4;
+pub const KEV_DL_SIFMEDIA: u32 = 5;
+pub const KEV_DL_SIFGENERIC: u32 = 6;
+pub const KEV_DL_ADDMULTI: u32 = 7;
+pub const KEV_DL_DELMULTI: u32 = 8;
+pub const KEV_DL_IF_ATTACHED: u32 = 9;
+pub const KEV_DL_IF_DETACHING: u32 = 10;
+pub const KEV_DL_IF_DETACHED: u32 = 11;
+pub const KEV_DL_LINK_OFF: u32 = 12;
+pub const KEV_DL_LINK_ON: u32 = 13;
+pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
+pub const KEV_DL_PROTO_DETACHED: u32 = 15;
+pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
+pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
+pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
+pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
+pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
+pub const KEV_DL_NODE_PRESENCE: u32 = 21;
+pub const KEV_DL_NODE_ABSENCE: u32 = 22;
+pub const KEV_DL_MASTER_ELECTED: u32 = 23;
+pub const KEV_DL_ISSUES: u32 = 24;
+pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
+pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
+pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
+pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
+pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
+pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
+pub const KEV_INET6_SUBCLASS: u32 = 6;
+pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
+pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
+pub const KEV_INET6_ADDR_DELETED: u32 = 3;
+pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
+pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
+pub const KEV_INET6_DEFROUTER: u32 = 6;
+pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
+pub const SOCK_STREAM: u32 = 1;
+pub const SOCK_DGRAM: u32 = 2;
+pub const SOCK_RAW: u32 = 3;
+pub const SOCK_RDM: u32 = 4;
+pub const SOCK_SEQPACKET: u32 = 5;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_ACCEPTCONN: u32 = 2;
+pub const SO_REUSEADDR: u32 = 4;
+pub const SO_KEEPALIVE: u32 = 8;
+pub const SO_DONTROUTE: u32 = 16;
+pub const SO_BROADCAST: u32 = 32;
+pub const SO_USELOOPBACK: u32 = 64;
+pub const SO_LINGER: u32 = 128;
+pub const SO_OOBINLINE: u32 = 256;
+pub const SO_REUSEPORT: u32 = 512;
+pub const SO_TIMESTAMP: u32 = 1024;
+pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
+pub const SO_DONTTRUNC: u32 = 8192;
+pub const SO_WANTMORE: u32 = 16384;
+pub const SO_WANTOOBFLAG: u32 = 32768;
+pub const SO_SNDBUF: u32 = 4097;
+pub const SO_RCVBUF: u32 = 4098;
+pub const SO_SNDLOWAT: u32 = 4099;
+pub const SO_RCVLOWAT: u32 = 4100;
+pub const SO_SNDTIMEO: u32 = 4101;
+pub const SO_RCVTIMEO: u32 = 4102;
+pub const SO_ERROR: u32 = 4103;
+pub const SO_TYPE: u32 = 4104;
+pub const SO_LABEL: u32 = 4112;
+pub const SO_PEERLABEL: u32 = 4113;
+pub const SO_NREAD: u32 = 4128;
+pub const SO_NKE: u32 = 4129;
+pub const SO_NOSIGPIPE: u32 = 4130;
+pub const SO_NOADDRERR: u32 = 4131;
+pub const SO_NWRITE: u32 = 4132;
+pub const SO_REUSESHAREUID: u32 = 4133;
+pub const SO_NOTIFYCONFLICT: u32 = 4134;
+pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
+pub const SO_LINGER_SEC: u32 = 4224;
+pub const SO_RANDOMPORT: u32 = 4226;
+pub const SO_NP_EXTENSIONS: u32 = 4227;
+pub const SO_NUMRCVPKT: u32 = 4370;
+pub const SO_NET_SERVICE_TYPE: u32 = 4374;
+pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
+pub const NET_SERVICE_TYPE_BE: u32 = 0;
+pub const NET_SERVICE_TYPE_BK: u32 = 1;
+pub const NET_SERVICE_TYPE_SIG: u32 = 2;
+pub const NET_SERVICE_TYPE_VI: u32 = 3;
+pub const NET_SERVICE_TYPE_VO: u32 = 4;
+pub const NET_SERVICE_TYPE_RV: u32 = 5;
+pub const NET_SERVICE_TYPE_AV: u32 = 6;
+pub const NET_SERVICE_TYPE_OAM: u32 = 7;
+pub const NET_SERVICE_TYPE_RD: u32 = 8;
+pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
+pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
+pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
+pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
+pub const SAE_ASSOCID_ANY: u32 = 0;
+pub const SAE_CONNID_ANY: u32 = 0;
+pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
+pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
+pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
+pub const SONPX_SETOPTSHUT: u32 = 1;
+pub const SOL_SOCKET: u32 = 65535;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_UNIX: u32 = 1;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_IMPLINK: u32 = 3;
+pub const AF_PUP: u32 = 4;
+pub const AF_CHAOS: u32 = 5;
+pub const AF_NS: u32 = 6;
+pub const AF_ISO: u32 = 7;
+pub const AF_OSI: u32 = 7;
+pub const AF_ECMA: u32 = 8;
+pub const AF_DATAKIT: u32 = 9;
+pub const AF_CCITT: u32 = 10;
+pub const AF_SNA: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_DLI: u32 = 13;
+pub const AF_LAT: u32 = 14;
+pub const AF_HYLINK: u32 = 15;
+pub const AF_APPLETALK: u32 = 16;
+pub const AF_ROUTE: u32 = 17;
+pub const AF_LINK: u32 = 18;
+pub const pseudo_AF_XTP: u32 = 19;
+pub const AF_COIP: u32 = 20;
+pub const AF_CNT: u32 = 21;
+pub const pseudo_AF_RTIP: u32 = 22;
+pub const AF_IPX: u32 = 23;
+pub const AF_SIP: u32 = 24;
+pub const pseudo_AF_PIP: u32 = 25;
+pub const AF_NDRV: u32 = 27;
+pub const AF_ISDN: u32 = 28;
+pub const AF_E164: u32 = 28;
+pub const pseudo_AF_KEY: u32 = 29;
+pub const AF_INET6: u32 = 30;
+pub const AF_NATM: u32 = 31;
+pub const AF_SYSTEM: u32 = 32;
+pub const AF_NETBIOS: u32 = 33;
+pub const AF_PPP: u32 = 34;
+pub const pseudo_AF_HDRCMPLT: u32 = 35;
+pub const AF_RESERVED_36: u32 = 36;
+pub const AF_IEEE80211: u32 = 37;
+pub const AF_UTUN: u32 = 38;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_MAX: u32 = 41;
+pub const SOCK_MAXADDRLEN: u32 = 255;
+pub const _SS_MAXSIZE: u32 = 128;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
-pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_AX25: u32 = 3;
-pub const PF_IPX: u32 = 4;
-pub const PF_APPLETALK: u32 = 5;
-pub const PF_NETROM: u32 = 6;
-pub const PF_BRIDGE: u32 = 7;
-pub const PF_ATMPVC: u32 = 8;
-pub const PF_X25: u32 = 9;
-pub const PF_INET6: u32 = 10;
-pub const PF_ROSE: u32 = 11;
+pub const PF_IMPLINK: u32 = 3;
+pub const PF_PUP: u32 = 4;
+pub const PF_CHAOS: u32 = 5;
+pub const PF_NS: u32 = 6;
+pub const PF_ISO: u32 = 7;
+pub const PF_OSI: u32 = 7;
+pub const PF_ECMA: u32 = 8;
+pub const PF_DATAKIT: u32 = 9;
+pub const PF_CCITT: u32 = 10;
+pub const PF_SNA: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_NETBEUI: u32 = 13;
-pub const PF_SECURITY: u32 = 14;
-pub const PF_KEY: u32 = 15;
-pub const PF_NETLINK: u32 = 16;
-pub const PF_ROUTE: u32 = 16;
-pub const PF_PACKET: u32 = 17;
-pub const PF_ASH: u32 = 18;
-pub const PF_ECONET: u32 = 19;
-pub const PF_ATMSVC: u32 = 20;
-pub const PF_RDS: u32 = 21;
-pub const PF_SNA: u32 = 22;
-pub const PF_IRDA: u32 = 23;
-pub const PF_PPPOX: u32 = 24;
-pub const PF_WANPIPE: u32 = 25;
-pub const PF_LLC: u32 = 26;
-pub const PF_IB: u32 = 27;
-pub const PF_MPLS: u32 = 28;
-pub const PF_CAN: u32 = 29;
-pub const PF_TIPC: u32 = 30;
-pub const PF_BLUETOOTH: u32 = 31;
-pub const PF_IUCV: u32 = 32;
-pub const PF_RXRPC: u32 = 33;
-pub const PF_ISDN: u32 = 34;
-pub const PF_PHONET: u32 = 35;
-pub const PF_IEEE802154: u32 = 36;
-pub const PF_CAIF: u32 = 37;
-pub const PF_ALG: u32 = 38;
-pub const PF_NFC: u32 = 39;
+pub const PF_DLI: u32 = 13;
+pub const PF_LAT: u32 = 14;
+pub const PF_HYLINK: u32 = 15;
+pub const PF_APPLETALK: u32 = 16;
+pub const PF_ROUTE: u32 = 17;
+pub const PF_LINK: u32 = 18;
+pub const PF_XTP: u32 = 19;
+pub const PF_COIP: u32 = 20;
+pub const PF_CNT: u32 = 21;
+pub const PF_SIP: u32 = 24;
+pub const PF_IPX: u32 = 23;
+pub const PF_RTIP: u32 = 22;
+pub const PF_PIP: u32 = 25;
+pub const PF_NDRV: u32 = 27;
+pub const PF_ISDN: u32 = 28;
+pub const PF_KEY: u32 = 29;
+pub const PF_INET6: u32 = 30;
+pub const PF_NATM: u32 = 31;
+pub const PF_SYSTEM: u32 = 32;
+pub const PF_NETBIOS: u32 = 33;
+pub const PF_PPP: u32 = 34;
+pub const PF_RESERVED_36: u32 = 36;
+pub const PF_UTUN: u32 = 38;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_KCM: u32 = 41;
-pub const PF_QIPCRTR: u32 = 42;
-pub const PF_SMC: u32 = 43;
-pub const PF_XDP: u32 = 44;
-pub const PF_MAX: u32 = 45;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_UNIX: u32 = 1;
-pub const AF_FILE: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_AX25: u32 = 3;
-pub const AF_IPX: u32 = 4;
-pub const AF_APPLETALK: u32 = 5;
-pub const AF_NETROM: u32 = 6;
-pub const AF_BRIDGE: u32 = 7;
-pub const AF_ATMPVC: u32 = 8;
-pub const AF_X25: u32 = 9;
-pub const AF_INET6: u32 = 10;
-pub const AF_ROSE: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_NETBEUI: u32 = 13;
-pub const AF_SECURITY: u32 = 14;
-pub const AF_KEY: u32 = 15;
-pub const AF_NETLINK: u32 = 16;
-pub const AF_ROUTE: u32 = 16;
-pub const AF_PACKET: u32 = 17;
-pub const AF_ASH: u32 = 18;
-pub const AF_ECONET: u32 = 19;
-pub const AF_ATMSVC: u32 = 20;
-pub const AF_RDS: u32 = 21;
-pub const AF_SNA: u32 = 22;
-pub const AF_IRDA: u32 = 23;
-pub const AF_PPPOX: u32 = 24;
-pub const AF_WANPIPE: u32 = 25;
-pub const AF_LLC: u32 = 26;
-pub const AF_IB: u32 = 27;
-pub const AF_MPLS: u32 = 28;
-pub const AF_CAN: u32 = 29;
-pub const AF_TIPC: u32 = 30;
-pub const AF_BLUETOOTH: u32 = 31;
-pub const AF_IUCV: u32 = 32;
-pub const AF_RXRPC: u32 = 33;
-pub const AF_ISDN: u32 = 34;
-pub const AF_PHONET: u32 = 35;
-pub const AF_IEEE802154: u32 = 36;
-pub const AF_CAIF: u32 = 37;
-pub const AF_ALG: u32 = 38;
-pub const AF_NFC: u32 = 39;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_KCM: u32 = 41;
-pub const AF_QIPCRTR: u32 = 42;
-pub const AF_SMC: u32 = 43;
-pub const AF_XDP: u32 = 44;
-pub const AF_MAX: u32 = 45;
-pub const SOL_RAW: u32 = 255;
-pub const SOL_DECNET: u32 = 261;
-pub const SOL_X25: u32 = 262;
-pub const SOL_PACKET: u32 = 263;
-pub const SOL_ATM: u32 = 264;
-pub const SOL_AAL: u32 = 265;
-pub const SOL_IRDA: u32 = 266;
-pub const SOL_NETBEUI: u32 = 267;
-pub const SOL_LLC: u32 = 268;
-pub const SOL_DCCP: u32 = 269;
-pub const SOL_NETLINK: u32 = 270;
-pub const SOL_TIPC: u32 = 271;
-pub const SOL_RXRPC: u32 = 272;
-pub const SOL_PPPOL2TP: u32 = 273;
-pub const SOL_BLUETOOTH: u32 = 274;
-pub const SOL_PNPIPE: u32 = 275;
-pub const SOL_RDS: u32 = 276;
-pub const SOL_IUCV: u32 = 277;
-pub const SOL_CAIF: u32 = 278;
-pub const SOL_ALG: u32 = 279;
-pub const SOL_NFC: u32 = 280;
-pub const SOL_KCM: u32 = 281;
-pub const SOL_TLS: u32 = 282;
-pub const SOL_XDP: u32 = 283;
-pub const SOMAXCONN: u32 = 4096;
-pub const _BITS_SOCKADDR_H: u32 = 1;
-pub const _SS_SIZE: u32 = 128;
-pub const __BITS_PER_LONG: u32 = 64;
-pub const FIOSETOWN: u32 = 35073;
-pub const SIOCSPGRP: u32 = 35074;
-pub const FIOGETOWN: u32 = 35075;
-pub const SIOCGPGRP: u32 = 35076;
-pub const SIOCATMARK: u32 = 35077;
-pub const SIOCGSTAMP_OLD: u32 = 35078;
-pub const SIOCGSTAMPNS_OLD: u32 = 35079;
-pub const SOL_SOCKET: u32 = 1;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_REUSEADDR: u32 = 2;
-pub const SO_TYPE: u32 = 3;
-pub const SO_ERROR: u32 = 4;
-pub const SO_DONTROUTE: u32 = 5;
-pub const SO_BROADCAST: u32 = 6;
-pub const SO_SNDBUF: u32 = 7;
-pub const SO_RCVBUF: u32 = 8;
-pub const SO_SNDBUFFORCE: u32 = 32;
-pub const SO_RCVBUFFORCE: u32 = 33;
-pub const SO_KEEPALIVE: u32 = 9;
-pub const SO_OOBINLINE: u32 = 10;
-pub const SO_NO_CHECK: u32 = 11;
-pub const SO_PRIORITY: u32 = 12;
-pub const SO_LINGER: u32 = 13;
-pub const SO_BSDCOMPAT: u32 = 14;
-pub const SO_REUSEPORT: u32 = 15;
-pub const SO_PASSCRED: u32 = 16;
-pub const SO_PEERCRED: u32 = 17;
-pub const SO_RCVLOWAT: u32 = 18;
-pub const SO_SNDLOWAT: u32 = 19;
-pub const SO_RCVTIMEO_OLD: u32 = 20;
-pub const SO_SNDTIMEO_OLD: u32 = 21;
-pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
-pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
-pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
-pub const SO_BINDTODEVICE: u32 = 25;
-pub const SO_ATTACH_FILTER: u32 = 26;
-pub const SO_DETACH_FILTER: u32 = 27;
-pub const SO_GET_FILTER: u32 = 26;
-pub const SO_PEERNAME: u32 = 28;
-pub const SO_ACCEPTCONN: u32 = 30;
-pub const SO_PEERSEC: u32 = 31;
-pub const SO_PASSSEC: u32 = 34;
-pub const SO_MARK: u32 = 36;
-pub const SO_PROTOCOL: u32 = 38;
-pub const SO_DOMAIN: u32 = 39;
-pub const SO_RXQ_OVFL: u32 = 40;
-pub const SO_WIFI_STATUS: u32 = 41;
-pub const SCM_WIFI_STATUS: u32 = 41;
-pub const SO_PEEK_OFF: u32 = 42;
-pub const SO_NOFCS: u32 = 43;
-pub const SO_LOCK_FILTER: u32 = 44;
-pub const SO_SELECT_ERR_QUEUE: u32 = 45;
-pub const SO_BUSY_POLL: u32 = 46;
-pub const SO_MAX_PACING_RATE: u32 = 47;
-pub const SO_BPF_EXTENSIONS: u32 = 48;
-pub const SO_INCOMING_CPU: u32 = 49;
-pub const SO_ATTACH_BPF: u32 = 50;
-pub const SO_DETACH_BPF: u32 = 27;
-pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
-pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
-pub const SO_CNX_ADVICE: u32 = 53;
-pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
-pub const SO_MEMINFO: u32 = 55;
-pub const SO_INCOMING_NAPI_ID: u32 = 56;
-pub const SO_COOKIE: u32 = 57;
-pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
-pub const SO_PEERGROUPS: u32 = 59;
-pub const SO_ZEROCOPY: u32 = 60;
-pub const SO_TXTIME: u32 = 61;
-pub const SCM_TXTIME: u32 = 61;
-pub const SO_BINDTOIFINDEX: u32 = 62;
-pub const SO_TIMESTAMP_OLD: u32 = 29;
-pub const SO_TIMESTAMPNS_OLD: u32 = 35;
-pub const SO_TIMESTAMPING_OLD: u32 = 37;
-pub const SO_TIMESTAMP_NEW: u32 = 63;
-pub const SO_TIMESTAMPNS_NEW: u32 = 64;
-pub const SO_TIMESTAMPING_NEW: u32 = 65;
-pub const SO_RCVTIMEO_NEW: u32 = 66;
-pub const SO_SNDTIMEO_NEW: u32 = 67;
-pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_TIMESTAMP: u32 = 29;
-pub const SO_TIMESTAMPNS: u32 = 35;
-pub const SO_TIMESTAMPING: u32 = 37;
-pub const SO_RCVTIMEO: u32 = 20;
-pub const SO_SNDTIMEO: u32 = 21;
-pub const SCM_TIMESTAMP: u32 = 29;
-pub const SCM_TIMESTAMPNS: u32 = 35;
-pub const SCM_TIMESTAMPING: u32 = 37;
-pub const __osockaddr_defined: u32 = 1;
-pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
-pub const IP_OPTIONS: u32 = 4;
-pub const IP_HDRINCL: u32 = 3;
-pub const IP_TOS: u32 = 1;
-pub const IP_TTL: u32 = 2;
-pub const IP_RECVOPTS: u32 = 6;
-pub const IP_RETOPTS: u32 = 7;
-pub const IP_MULTICAST_IF: u32 = 32;
-pub const IP_MULTICAST_TTL: u32 = 33;
-pub const IP_MULTICAST_LOOP: u32 = 34;
-pub const IP_ADD_MEMBERSHIP: u32 = 35;
-pub const IP_DROP_MEMBERSHIP: u32 = 36;
-pub const IP_UNBLOCK_SOURCE: u32 = 37;
-pub const IP_BLOCK_SOURCE: u32 = 38;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
-pub const IP_MSFILTER: u32 = 41;
-pub const MCAST_JOIN_GROUP: u32 = 42;
-pub const MCAST_BLOCK_SOURCE: u32 = 43;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
-pub const MCAST_LEAVE_GROUP: u32 = 45;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
-pub const MCAST_MSFILTER: u32 = 48;
-pub const IP_MULTICAST_ALL: u32 = 49;
-pub const IP_UNICAST_IF: u32 = 50;
-pub const MCAST_EXCLUDE: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const IP_ROUTER_ALERT: u32 = 5;
-pub const IP_PKTINFO: u32 = 8;
-pub const IP_PKTOPTIONS: u32 = 9;
-pub const IP_PMTUDISC: u32 = 10;
-pub const IP_MTU_DISCOVER: u32 = 10;
-pub const IP_RECVERR: u32 = 11;
-pub const IP_RECVTTL: u32 = 12;
-pub const IP_RECVTOS: u32 = 13;
-pub const IP_MTU: u32 = 14;
-pub const IP_FREEBIND: u32 = 15;
-pub const IP_IPSEC_POLICY: u32 = 16;
-pub const IP_XFRM_POLICY: u32 = 17;
-pub const IP_PASSSEC: u32 = 18;
-pub const IP_TRANSPARENT: u32 = 19;
-pub const IP_ORIGDSTADDR: u32 = 20;
-pub const IP_RECVORIGDSTADDR: u32 = 20;
-pub const IP_MINTTL: u32 = 21;
-pub const IP_NODEFRAG: u32 = 22;
-pub const IP_CHECKSUM: u32 = 23;
-pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
-pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_PMTUDISC_DONT: u32 = 0;
-pub const IP_PMTUDISC_WANT: u32 = 1;
-pub const IP_PMTUDISC_DO: u32 = 2;
-pub const IP_PMTUDISC_PROBE: u32 = 3;
-pub const IP_PMTUDISC_INTERFACE: u32 = 4;
-pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const SOL_IP: u32 = 0;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MAX_MEMBERSHIPS: u32 = 20;
-pub const IPV6_ADDRFORM: u32 = 1;
-pub const IPV6_2292PKTINFO: u32 = 2;
-pub const IPV6_2292HOPOPTS: u32 = 3;
-pub const IPV6_2292DSTOPTS: u32 = 4;
-pub const IPV6_2292RTHDR: u32 = 5;
-pub const IPV6_2292PKTOPTIONS: u32 = 6;
-pub const IPV6_CHECKSUM: u32 = 7;
-pub const IPV6_2292HOPLIMIT: u32 = 8;
-pub const IPV6_NEXTHOP: u32 = 9;
-pub const IPV6_AUTHHDR: u32 = 10;
-pub const IPV6_UNICAST_HOPS: u32 = 16;
-pub const IPV6_MULTICAST_IF: u32 = 17;
-pub const IPV6_MULTICAST_HOPS: u32 = 18;
-pub const IPV6_MULTICAST_LOOP: u32 = 19;
-pub const IPV6_JOIN_GROUP: u32 = 20;
-pub const IPV6_LEAVE_GROUP: u32 = 21;
-pub const IPV6_ROUTER_ALERT: u32 = 22;
-pub const IPV6_MTU_DISCOVER: u32 = 23;
-pub const IPV6_MTU: u32 = 24;
-pub const IPV6_RECVERR: u32 = 25;
-pub const IPV6_V6ONLY: u32 = 26;
-pub const IPV6_JOIN_ANYCAST: u32 = 27;
-pub const IPV6_LEAVE_ANYCAST: u32 = 28;
-pub const IPV6_MULTICAST_ALL: u32 = 29;
-pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_IPSEC_POLICY: u32 = 34;
-pub const IPV6_XFRM_POLICY: u32 = 35;
-pub const IPV6_HDRINCL: u32 = 36;
-pub const IPV6_RECVPKTINFO: u32 = 49;
-pub const IPV6_PKTINFO: u32 = 50;
-pub const IPV6_RECVHOPLIMIT: u32 = 51;
-pub const IPV6_HOPLIMIT: u32 = 52;
-pub const IPV6_RECVHOPOPTS: u32 = 53;
-pub const IPV6_HOPOPTS: u32 = 54;
-pub const IPV6_RTHDRDSTOPTS: u32 = 55;
-pub const IPV6_RECVRTHDR: u32 = 56;
-pub const IPV6_RTHDR: u32 = 57;
-pub const IPV6_RECVDSTOPTS: u32 = 58;
-pub const IPV6_DSTOPTS: u32 = 59;
-pub const IPV6_RECVPATHMTU: u32 = 60;
-pub const IPV6_PATHMTU: u32 = 61;
-pub const IPV6_DONTFRAG: u32 = 62;
-pub const IPV6_RECVTCLASS: u32 = 66;
-pub const IPV6_TCLASS: u32 = 67;
-pub const IPV6_AUTOFLOWLABEL: u32 = 70;
-pub const IPV6_ADDR_PREFERENCES: u32 = 72;
-pub const IPV6_MINHOPCOUNT: u32 = 73;
-pub const IPV6_ORIGDSTADDR: u32 = 74;
-pub const IPV6_RECVORIGDSTADDR: u32 = 74;
-pub const IPV6_TRANSPARENT: u32 = 75;
-pub const IPV6_UNICAST_IF: u32 = 76;
-pub const IPV6_RECVFRAGSIZE: u32 = 77;
-pub const IPV6_FREEBIND: u32 = 78;
-pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
-pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
-pub const IPV6_RXHOPOPTS: u32 = 54;
-pub const IPV6_RXDSTOPTS: u32 = 59;
-pub const IPV6_PMTUDISC_DONT: u32 = 0;
-pub const IPV6_PMTUDISC_WANT: u32 = 1;
-pub const IPV6_PMTUDISC_DO: u32 = 2;
-pub const IPV6_PMTUDISC_PROBE: u32 = 3;
-pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
-pub const IPV6_PMTUDISC_OMIT: u32 = 5;
-pub const SOL_IPV6: u32 = 41;
-pub const SOL_ICMPV6: u32 = 58;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
+pub const PF_MAX: u32 = 41;
+pub const NET_MAXID: u32 = 41;
+pub const NET_RT_DUMP: u32 = 1;
+pub const NET_RT_FLAGS: u32 = 2;
+pub const NET_RT_IFLIST: u32 = 3;
+pub const NET_RT_STAT: u32 = 4;
+pub const NET_RT_TRASH: u32 = 5;
+pub const NET_RT_IFLIST2: u32 = 6;
+pub const NET_RT_DUMP2: u32 = 7;
+pub const NET_RT_FLAGS_PRIV: u32 = 10;
+pub const NET_RT_MAXID: u32 = 11;
+pub const SOMAXCONN: u32 = 128;
+pub const MSG_OOB: u32 = 1;
+pub const MSG_PEEK: u32 = 2;
+pub const MSG_DONTROUTE: u32 = 4;
+pub const MSG_EOR: u32 = 8;
+pub const MSG_TRUNC: u32 = 16;
+pub const MSG_CTRUNC: u32 = 32;
+pub const MSG_WAITALL: u32 = 64;
+pub const MSG_DONTWAIT: u32 = 128;
+pub const MSG_EOF: u32 = 256;
+pub const MSG_WAITSTREAM: u32 = 512;
+pub const MSG_FLUSH: u32 = 1024;
+pub const MSG_HOLD: u32 = 2048;
+pub const MSG_SEND: u32 = 4096;
+pub const MSG_HAVEMORE: u32 = 8192;
+pub const MSG_RCVMORE: u32 = 16384;
+pub const MSG_NEEDSA: u32 = 65536;
+pub const MSG_NOSIGNAL: u32 = 524288;
+pub const SCM_RIGHTS: u32 = 1;
+pub const SCM_TIMESTAMP: u32 = 2;
+pub const SCM_CREDS: u32 = 3;
+pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
+pub const SHUT_RD: u32 = 0;
+pub const SHUT_WR: u32 = 1;
+pub const SHUT_RDWR: u32 = 2;
+pub const IPPROTO_IP: u32 = 0;
+pub const IPPROTO_HOPOPTS: u32 = 0;
+pub const IPPROTO_ICMP: u32 = 1;
+pub const IPPROTO_IGMP: u32 = 2;
+pub const IPPROTO_GGP: u32 = 3;
+pub const IPPROTO_IPV4: u32 = 4;
+pub const IPPROTO_IPIP: u32 = 4;
+pub const IPPROTO_TCP: u32 = 6;
+pub const IPPROTO_ST: u32 = 7;
+pub const IPPROTO_EGP: u32 = 8;
+pub const IPPROTO_PIGP: u32 = 9;
+pub const IPPROTO_RCCMON: u32 = 10;
+pub const IPPROTO_NVPII: u32 = 11;
+pub const IPPROTO_PUP: u32 = 12;
+pub const IPPROTO_ARGUS: u32 = 13;
+pub const IPPROTO_EMCON: u32 = 14;
+pub const IPPROTO_XNET: u32 = 15;
+pub const IPPROTO_CHAOS: u32 = 16;
+pub const IPPROTO_UDP: u32 = 17;
+pub const IPPROTO_MUX: u32 = 18;
+pub const IPPROTO_MEAS: u32 = 19;
+pub const IPPROTO_HMP: u32 = 20;
+pub const IPPROTO_PRM: u32 = 21;
+pub const IPPROTO_IDP: u32 = 22;
+pub const IPPROTO_TRUNK1: u32 = 23;
+pub const IPPROTO_TRUNK2: u32 = 24;
+pub const IPPROTO_LEAF1: u32 = 25;
+pub const IPPROTO_LEAF2: u32 = 26;
+pub const IPPROTO_RDP: u32 = 27;
+pub const IPPROTO_IRTP: u32 = 28;
+pub const IPPROTO_TP: u32 = 29;
+pub const IPPROTO_BLT: u32 = 30;
+pub const IPPROTO_NSP: u32 = 31;
+pub const IPPROTO_INP: u32 = 32;
+pub const IPPROTO_SEP: u32 = 33;
+pub const IPPROTO_3PC: u32 = 34;
+pub const IPPROTO_IDPR: u32 = 35;
+pub const IPPROTO_XTP: u32 = 36;
+pub const IPPROTO_DDP: u32 = 37;
+pub const IPPROTO_CMTP: u32 = 38;
+pub const IPPROTO_TPXX: u32 = 39;
+pub const IPPROTO_IL: u32 = 40;
+pub const IPPROTO_IPV6: u32 = 41;
+pub const IPPROTO_SDRP: u32 = 42;
+pub const IPPROTO_ROUTING: u32 = 43;
+pub const IPPROTO_FRAGMENT: u32 = 44;
+pub const IPPROTO_IDRP: u32 = 45;
+pub const IPPROTO_RSVP: u32 = 46;
+pub const IPPROTO_GRE: u32 = 47;
+pub const IPPROTO_MHRP: u32 = 48;
+pub const IPPROTO_BHA: u32 = 49;
+pub const IPPROTO_ESP: u32 = 50;
+pub const IPPROTO_AH: u32 = 51;
+pub const IPPROTO_INLSP: u32 = 52;
+pub const IPPROTO_SWIPE: u32 = 53;
+pub const IPPROTO_NHRP: u32 = 54;
+pub const IPPROTO_ICMPV6: u32 = 58;
+pub const IPPROTO_NONE: u32 = 59;
+pub const IPPROTO_DSTOPTS: u32 = 60;
+pub const IPPROTO_AHIP: u32 = 61;
+pub const IPPROTO_CFTP: u32 = 62;
+pub const IPPROTO_HELLO: u32 = 63;
+pub const IPPROTO_SATEXPAK: u32 = 64;
+pub const IPPROTO_KRYPTOLAN: u32 = 65;
+pub const IPPROTO_RVD: u32 = 66;
+pub const IPPROTO_IPPC: u32 = 67;
+pub const IPPROTO_ADFS: u32 = 68;
+pub const IPPROTO_SATMON: u32 = 69;
+pub const IPPROTO_VISA: u32 = 70;
+pub const IPPROTO_IPCV: u32 = 71;
+pub const IPPROTO_CPNX: u32 = 72;
+pub const IPPROTO_CPHB: u32 = 73;
+pub const IPPROTO_WSN: u32 = 74;
+pub const IPPROTO_PVP: u32 = 75;
+pub const IPPROTO_BRSATMON: u32 = 76;
+pub const IPPROTO_ND: u32 = 77;
+pub const IPPROTO_WBMON: u32 = 78;
+pub const IPPROTO_WBEXPAK: u32 = 79;
+pub const IPPROTO_EON: u32 = 80;
+pub const IPPROTO_VMTP: u32 = 81;
+pub const IPPROTO_SVMTP: u32 = 82;
+pub const IPPROTO_VINES: u32 = 83;
+pub const IPPROTO_TTP: u32 = 84;
+pub const IPPROTO_IGP: u32 = 85;
+pub const IPPROTO_DGP: u32 = 86;
+pub const IPPROTO_TCF: u32 = 87;
+pub const IPPROTO_IGRP: u32 = 88;
+pub const IPPROTO_OSPFIGP: u32 = 89;
+pub const IPPROTO_SRPC: u32 = 90;
+pub const IPPROTO_LARP: u32 = 91;
+pub const IPPROTO_MTP: u32 = 92;
+pub const IPPROTO_AX25: u32 = 93;
+pub const IPPROTO_IPEIP: u32 = 94;
+pub const IPPROTO_MICP: u32 = 95;
+pub const IPPROTO_SCCSP: u32 = 96;
+pub const IPPROTO_ETHERIP: u32 = 97;
+pub const IPPROTO_ENCAP: u32 = 98;
+pub const IPPROTO_APES: u32 = 99;
+pub const IPPROTO_GMTP: u32 = 100;
+pub const IPPROTO_PIM: u32 = 103;
+pub const IPPROTO_IPCOMP: u32 = 108;
+pub const IPPROTO_PGM: u32 = 113;
+pub const IPPROTO_SCTP: u32 = 132;
+pub const IPPROTO_DIVERT: u32 = 254;
+pub const IPPROTO_RAW: u32 = 255;
+pub const IPPROTO_MAX: u32 = 256;
+pub const IPPROTO_DONE: u32 = 257;
+pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
+pub const IPPORT_USERRESERVED: u32 = 5000;
+pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
+pub const IPPORT_HILASTAUTO: u32 = 65535;
+pub const IPPORT_RESERVEDSTART: u32 = 600;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1131,49 +1397,269 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
+pub const IN_CLASSD_NET: u32 = 4026531840;
+pub const IN_CLASSD_NSHIFT: u32 = 28;
+pub const IN_CLASSD_HOST: u32 = 268435455;
+pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
+pub const IP_OPTIONS: u32 = 1;
+pub const IP_HDRINCL: u32 = 2;
+pub const IP_TOS: u32 = 3;
+pub const IP_TTL: u32 = 4;
+pub const IP_RECVOPTS: u32 = 5;
+pub const IP_RECVRETOPTS: u32 = 6;
+pub const IP_RECVDSTADDR: u32 = 7;
+pub const IP_RETOPTS: u32 = 8;
+pub const IP_MULTICAST_IF: u32 = 9;
+pub const IP_MULTICAST_TTL: u32 = 10;
+pub const IP_MULTICAST_LOOP: u32 = 11;
+pub const IP_ADD_MEMBERSHIP: u32 = 12;
+pub const IP_DROP_MEMBERSHIP: u32 = 13;
+pub const IP_MULTICAST_VIF: u32 = 14;
+pub const IP_RSVP_ON: u32 = 15;
+pub const IP_RSVP_OFF: u32 = 16;
+pub const IP_RSVP_VIF_ON: u32 = 17;
+pub const IP_RSVP_VIF_OFF: u32 = 18;
+pub const IP_PORTRANGE: u32 = 19;
+pub const IP_RECVIF: u32 = 20;
+pub const IP_IPSEC_POLICY: u32 = 21;
+pub const IP_FAITH: u32 = 22;
+pub const IP_STRIPHDR: u32 = 23;
+pub const IP_RECVTTL: u32 = 24;
+pub const IP_BOUND_IF: u32 = 25;
+pub const IP_PKTINFO: u32 = 26;
+pub const IP_RECVPKTINFO: u32 = 26;
+pub const IP_RECVTOS: u32 = 27;
+pub const IP_DONTFRAG: u32 = 28;
+pub const IP_FW_ADD: u32 = 40;
+pub const IP_FW_DEL: u32 = 41;
+pub const IP_FW_FLUSH: u32 = 42;
+pub const IP_FW_ZERO: u32 = 43;
+pub const IP_FW_GET: u32 = 44;
+pub const IP_FW_RESETLOG: u32 = 45;
+pub const IP_OLD_FW_ADD: u32 = 50;
+pub const IP_OLD_FW_DEL: u32 = 51;
+pub const IP_OLD_FW_FLUSH: u32 = 52;
+pub const IP_OLD_FW_ZERO: u32 = 53;
+pub const IP_OLD_FW_GET: u32 = 54;
+pub const IP_NAT__XXX: u32 = 55;
+pub const IP_OLD_FW_RESETLOG: u32 = 56;
+pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
+pub const IP_DUMMYNET_DEL: u32 = 61;
+pub const IP_DUMMYNET_FLUSH: u32 = 62;
+pub const IP_DUMMYNET_GET: u32 = 64;
+pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
+pub const IP_MULTICAST_IFINDEX: u32 = 66;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
+pub const IP_BLOCK_SOURCE: u32 = 72;
+pub const IP_UNBLOCK_SOURCE: u32 = 73;
+pub const IP_MSFILTER: u32 = 74;
+pub const MCAST_JOIN_GROUP: u32 = 80;
+pub const MCAST_LEAVE_GROUP: u32 = 81;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
+pub const MCAST_BLOCK_SOURCE: u32 = 84;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MIN_MEMBERSHIPS: u32 = 31;
+pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
+pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
+pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
+pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
+pub const MCAST_UNDEFINED: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const MCAST_EXCLUDE: u32 = 2;
+pub const IP_PORTRANGE_DEFAULT: u32 = 0;
+pub const IP_PORTRANGE_HIGH: u32 = 1;
+pub const IP_PORTRANGE_LOW: u32 = 2;
+pub const IPPROTO_MAXID: u32 = 52;
+pub const IPCTL_FORWARDING: u32 = 1;
+pub const IPCTL_SENDREDIRECTS: u32 = 2;
+pub const IPCTL_DEFTTL: u32 = 3;
+pub const IPCTL_RTEXPIRE: u32 = 5;
+pub const IPCTL_RTMINEXPIRE: u32 = 6;
+pub const IPCTL_RTMAXCACHE: u32 = 7;
+pub const IPCTL_SOURCEROUTE: u32 = 8;
+pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
+pub const IPCTL_INTRQMAXLEN: u32 = 10;
+pub const IPCTL_INTRQDROPS: u32 = 11;
+pub const IPCTL_STATS: u32 = 12;
+pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
+pub const IPCTL_FASTFORWARDING: u32 = 14;
+pub const IPCTL_KEEPFAITH: u32 = 15;
+pub const IPCTL_GIF_TTL: u32 = 16;
+pub const IPCTL_MAXID: u32 = 17;
+pub const __KAME_VERSION: &'static [u8; 18usize] = b"2009/apple-darwin\0";
+pub const IPV6PORT_RESERVED: u32 = 1024;
+pub const IPV6PORT_ANONMIN: u32 = 49152;
+pub const IPV6PORT_ANONMAX: u32 = 65535;
+pub const IPV6PORT_RESERVEDMIN: u32 = 600;
+pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const _RPC_NETDB_H: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
+pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
+pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
+pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
+pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
+pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
+pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
+pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
+pub const IPV6_UNICAST_HOPS: u32 = 4;
+pub const IPV6_MULTICAST_IF: u32 = 9;
+pub const IPV6_MULTICAST_HOPS: u32 = 10;
+pub const IPV6_MULTICAST_LOOP: u32 = 11;
+pub const IPV6_JOIN_GROUP: u32 = 12;
+pub const IPV6_LEAVE_GROUP: u32 = 13;
+pub const IPV6_PORTRANGE: u32 = 14;
+pub const ICMP6_FILTER: u32 = 18;
+pub const IPV6_2292PKTINFO: u32 = 19;
+pub const IPV6_2292HOPLIMIT: u32 = 20;
+pub const IPV6_2292NEXTHOP: u32 = 21;
+pub const IPV6_2292HOPOPTS: u32 = 22;
+pub const IPV6_2292DSTOPTS: u32 = 23;
+pub const IPV6_2292RTHDR: u32 = 24;
+pub const IPV6_2292PKTOPTIONS: u32 = 25;
+pub const IPV6_CHECKSUM: u32 = 26;
+pub const IPV6_V6ONLY: u32 = 27;
+pub const IPV6_BINDV6ONLY: u32 = 27;
+pub const IPV6_IPSEC_POLICY: u32 = 28;
+pub const IPV6_FAITH: u32 = 29;
+pub const IPV6_FW_ADD: u32 = 30;
+pub const IPV6_FW_DEL: u32 = 31;
+pub const IPV6_FW_FLUSH: u32 = 32;
+pub const IPV6_FW_ZERO: u32 = 33;
+pub const IPV6_FW_GET: u32 = 34;
+pub const IPV6_RECVTCLASS: u32 = 35;
+pub const IPV6_TCLASS: u32 = 36;
+pub const IPV6_BOUND_IF: u32 = 125;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
+pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
+pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
+pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
+pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
+pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
+pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
+pub const IPV6_PORTRANGE_HIGH: u32 = 1;
+pub const IPV6_PORTRANGE_LOW: u32 = 2;
+pub const IPV6PROTO_MAXID: u32 = 104;
+pub const IPV6CTL_FORWARDING: u32 = 1;
+pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
+pub const IPV6CTL_DEFHLIM: u32 = 3;
+pub const IPV6CTL_FORWSRCRT: u32 = 5;
+pub const IPV6CTL_STATS: u32 = 6;
+pub const IPV6CTL_MRTSTATS: u32 = 7;
+pub const IPV6CTL_MRTPROTO: u32 = 8;
+pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
+pub const IPV6CTL_SOURCECHECK: u32 = 10;
+pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
+pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
+pub const IPV6CTL_KEEPFAITH: u32 = 13;
+pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
+pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
+pub const IPV6CTL_DAD_COUNT: u32 = 16;
+pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
+pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
+pub const IPV6CTL_GIF_HLIM: u32 = 19;
+pub const IPV6CTL_KAME_VERSION: u32 = 20;
+pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
+pub const IPV6CTL_RR_PRUNE: u32 = 22;
+pub const IPV6CTL_V6ONLY: u32 = 24;
+pub const IPV6CTL_RTEXPIRE: u32 = 25;
+pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
+pub const IPV6CTL_RTMAXCACHE: u32 = 27;
+pub const IPV6CTL_USETEMPADDR: u32 = 32;
+pub const IPV6CTL_TEMPPLTIME: u32 = 33;
+pub const IPV6CTL_TEMPVLTIME: u32 = 34;
+pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
+pub const IPV6CTL_RIP6STATS: u32 = 36;
+pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
+pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
+pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
+pub const IPV6CTL_MAXFRAGS: u32 = 41;
+pub const IPV6CTL_MCAST_PMTU: u32 = 44;
+pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
+pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
+pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
+pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
+pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
+pub const IPV6CTL_MAXID: u32 = 51;
 pub const _PATH_HEQUIV: &'static [u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &'static [u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &'static [u8; 14usize] = b"/etc/networks\0";
-pub const _PATH_NSSWITCH_CONF: &'static [u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &'static [u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &'static [u8; 14usize] = b"/etc/services\0";
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
+pub const EAI_ADDRFAMILY: u32 = 1;
+pub const EAI_AGAIN: u32 = 2;
+pub const EAI_BADFLAGS: u32 = 3;
+pub const EAI_FAIL: u32 = 4;
+pub const EAI_FAMILY: u32 = 5;
+pub const EAI_MEMORY: u32 = 6;
+pub const EAI_NODATA: u32 = 7;
+pub const EAI_NONAME: u32 = 8;
+pub const EAI_SERVICE: u32 = 9;
+pub const EAI_SOCKTYPE: u32 = 10;
+pub const EAI_SYSTEM: u32 = 11;
+pub const EAI_BADHINTS: u32 = 12;
+pub const EAI_PROTOCOL: u32 = 13;
+pub const EAI_OVERFLOW: u32 = 14;
+pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_V4MAPPED: u32 = 8;
-pub const AI_ALL: u32 = 16;
-pub const AI_ADDRCONFIG: u32 = 32;
-pub const AI_NUMERICSERV: u32 = 1024;
-pub const EAI_BADFLAGS: i32 = -1;
-pub const EAI_NONAME: i32 = -2;
-pub const EAI_AGAIN: i32 = -3;
-pub const EAI_FAIL: i32 = -4;
-pub const EAI_FAMILY: i32 = -6;
-pub const EAI_SOCKTYPE: i32 = -7;
-pub const EAI_SERVICE: i32 = -8;
-pub const EAI_MEMORY: i32 = -10;
-pub const EAI_SYSTEM: i32 = -11;
-pub const EAI_OVERFLOW: i32 = -12;
+pub const AI_NUMERICSERV: u32 = 4096;
+pub const AI_ALL: u32 = 256;
+pub const AI_V4MAPPED_CFG: u32 = 512;
+pub const AI_ADDRCONFIG: u32 = 1024;
+pub const AI_V4MAPPED: u32 = 2048;
+pub const AI_DEFAULT: u32 = 1536;
+pub const AI_UNUSABLE: u32 = 268435456;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NUMERICHOST: u32 = 1;
-pub const NI_NUMERICSERV: u32 = 2;
-pub const NI_NOFQDN: u32 = 4;
-pub const NI_NAMEREQD: u32 = 8;
+pub const NI_NOFQDN: u32 = 1;
+pub const NI_NUMERICHOST: u32 = 2;
+pub const NI_NAMEREQD: u32 = 4;
+pub const NI_NUMERICSERV: u32 = 8;
+pub const NI_NUMERICSCOPE: u32 = 256;
 pub const NI_DGRAM: u32 = 16;
-pub const _PWD_H: u32 = 1;
-pub const NSS_BUFLEN_PASSWD: u32 = 1024;
+pub const NI_WITHSCOPEID: u32 = 32;
+pub const SCOPE_DELIMITER: u8 = 37u8;
+pub const _PATH_PWD: &'static [u8; 5usize] = b"/etc\0";
+pub const _PATH_PASSWD: &'static [u8; 12usize] = b"/etc/passwd\0";
+pub const _PASSWD: &'static [u8; 7usize] = b"passwd\0";
+pub const _PATH_MASTERPASSWD: &'static [u8; 19usize] = b"/etc/master.passwd\0";
+pub const _PATH_MASTERPASSWD_LOCK: &'static [u8; 10usize] = b"/etc/ptmp\0";
+pub const _MASTERPASSWD: &'static [u8; 14usize] = b"master.passwd\0";
+pub const _PATH_MP_DB: &'static [u8; 12usize] = b"/etc/pwd.db\0";
+pub const _MP_DB: &'static [u8; 7usize] = b"pwd.db\0";
+pub const _PATH_SMP_DB: &'static [u8; 13usize] = b"/etc/spwd.db\0";
+pub const _SMP_DB: &'static [u8; 8usize] = b"spwd.db\0";
+pub const _PATH_PWD_MKDB: &'static [u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
+pub const _PW_KEYBYNAME: u8 = 49u8;
+pub const _PW_KEYBYNUM: u8 = 50u8;
+pub const _PW_KEYBYUID: u8 = 51u8;
+pub const _PASSWORD_EFMT1: u8 = 95u8;
+pub const _PASSWORD_LEN: u32 = 128;
+pub const _PASSWORD_NOUID: u32 = 1;
+pub const _PASSWORD_NOGID: u32 = 2;
+pub const _PASSWORD_NOCHG: u32 = 4;
+pub const _PASSWORD_NOEXP: u32 = 8;
+pub const _PASSWORD_WARNDAYS: u32 = 14;
+pub const _PASSWORD_CHGNOW: i32 = -1;
 pub const PGINVALID_SOCKET: i32 = -1;
 pub const PG_BACKEND_VERSIONSTR: &'static [u8; 28usize] = b"postgres (PostgreSQL) 12.6\n\0";
 pub const EXE: &'static [u8; 1usize] = b"\0";
@@ -1181,18 +1667,11 @@ pub const DEVNULL: &'static [u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
 pub const PG_STRERROR_R_BUFLEN: u32 = 256;
 pub const PG_IOLBF: u32 = 1;
-pub const _MATH_H: u32 = 1;
-pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
-pub const __FP_LOGB0_IS_MIN: u32 = 1;
-pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
+pub const FP_SUPERNORMAL: u32 = 6;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
-pub const __MATH_DECLARING_DOUBLE: u32 = 1;
-pub const __MATH_DECLARING_FLOATN: u32 = 0;
-pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
-pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1206,8 +1685,13 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const _SETJMP_H: u32 = 1;
-pub const _BITS_SETJMP_H: u32 = 1;
+pub const DOMAIN: u32 = 1;
+pub const SING: u32 = 2;
+pub const OVERFLOW: u32 = 3;
+pub const UNDERFLOW: u32 = 4;
+pub const TLOSS: u32 = 5;
+pub const PLOSS: u32 = 6;
+pub const _JBLEN: u32 = 37;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1292,139 +1776,153 @@ pub const MaxTransactionIdAttributeNumber: i32 = -4;
 pub const MaxCommandIdAttributeNumber: i32 = -5;
 pub const TableOidAttributeNumber: i32 = -6;
 pub const FirstLowInvalidHeapAttributeNumber: i32 = -7;
-pub const _FCNTL_H: u32 = 1;
-pub const __O_LARGEFILE: u32 = 0;
-pub const F_GETLK64: u32 = 5;
-pub const F_SETLK64: u32 = 6;
-pub const F_SETLKW64: u32 = 7;
-pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_CREAT: u32 = 64;
-pub const O_EXCL: u32 = 128;
-pub const O_NOCTTY: u32 = 256;
-pub const O_TRUNC: u32 = 512;
-pub const O_APPEND: u32 = 1024;
-pub const O_NONBLOCK: u32 = 2048;
-pub const O_NDELAY: u32 = 2048;
-pub const O_SYNC: u32 = 1052672;
-pub const O_FSYNC: u32 = 1052672;
-pub const O_ASYNC: u32 = 8192;
-pub const __O_DIRECTORY: u32 = 65536;
-pub const __O_NOFOLLOW: u32 = 131072;
-pub const __O_CLOEXEC: u32 = 524288;
-pub const __O_DIRECT: u32 = 16384;
-pub const __O_NOATIME: u32 = 262144;
-pub const __O_PATH: u32 = 2097152;
-pub const __O_DSYNC: u32 = 4096;
-pub const __O_TMPFILE: u32 = 4259840;
-pub const F_GETLK: u32 = 5;
-pub const F_SETLK: u32 = 6;
-pub const F_SETLKW: u32 = 7;
-pub const O_DIRECTORY: u32 = 65536;
-pub const O_NOFOLLOW: u32 = 131072;
-pub const O_CLOEXEC: u32 = 524288;
-pub const O_DSYNC: u32 = 4096;
-pub const O_RSYNC: u32 = 1052672;
+pub const O_ACCMODE: u32 = 3;
+pub const FREAD: u32 = 1;
+pub const FWRITE: u32 = 2;
+pub const O_NONBLOCK: u32 = 4;
+pub const O_APPEND: u32 = 8;
+pub const O_SYNC: u32 = 128;
+pub const O_SHLOCK: u32 = 16;
+pub const O_EXLOCK: u32 = 32;
+pub const O_ASYNC: u32 = 64;
+pub const O_FSYNC: u32 = 128;
+pub const O_NOFOLLOW: u32 = 256;
+pub const O_CREAT: u32 = 512;
+pub const O_TRUNC: u32 = 1024;
+pub const O_EXCL: u32 = 2048;
+pub const O_EVTONLY: u32 = 32768;
+pub const O_NOCTTY: u32 = 131072;
+pub const O_DIRECTORY: u32 = 1048576;
+pub const O_SYMLINK: u32 = 2097152;
+pub const O_DSYNC: u32 = 4194304;
+pub const O_CLOEXEC: u32 = 16777216;
+pub const O_NOFOLLOW_ANY: u32 = 536870912;
+pub const AT_FDCWD: i32 = -2;
+pub const AT_EACCESS: u32 = 16;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
+pub const AT_SYMLINK_FOLLOW: u32 = 64;
+pub const AT_REMOVEDIR: u32 = 128;
+pub const AT_REALDEV: u32 = 512;
+pub const AT_FDONLY: u32 = 1024;
+pub const O_DP_GETRAWENCRYPTED: u32 = 1;
+pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
+pub const FAPPEND: u32 = 8;
+pub const FASYNC: u32 = 64;
+pub const FFSYNC: u32 = 128;
+pub const FFDSYNC: u32 = 4194304;
+pub const FNONBLOCK: u32 = 4;
+pub const FNDELAY: u32 = 4;
+pub const O_NDELAY: u32 = 4;
+pub const CPF_OVERWRITE: u32 = 1;
+pub const CPF_IGNORE_MODE: u32 = 2;
+pub const CPF_MASK: u32 = 3;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const __F_SETOWN: u32 = 8;
-pub const __F_GETOWN: u32 = 9;
-pub const F_SETOWN: u32 = 8;
-pub const F_GETOWN: u32 = 9;
-pub const __F_SETSIG: u32 = 10;
-pub const __F_GETSIG: u32 = 11;
-pub const __F_SETOWN_EX: u32 = 15;
-pub const __F_GETOWN_EX: u32 = 16;
-pub const F_DUPFD_CLOEXEC: u32 = 1030;
+pub const F_GETOWN: u32 = 5;
+pub const F_SETOWN: u32 = 6;
+pub const F_GETLK: u32 = 7;
+pub const F_SETLK: u32 = 8;
+pub const F_SETLKW: u32 = 9;
+pub const F_SETLKWTIMEOUT: u32 = 10;
+pub const F_FLUSH_DATA: u32 = 40;
+pub const F_CHKCLEAN: u32 = 41;
+pub const F_PREALLOCATE: u32 = 42;
+pub const F_SETSIZE: u32 = 43;
+pub const F_RDADVISE: u32 = 44;
+pub const F_RDAHEAD: u32 = 45;
+pub const F_NOCACHE: u32 = 48;
+pub const F_LOG2PHYS: u32 = 49;
+pub const F_GETPATH: u32 = 50;
+pub const F_FULLFSYNC: u32 = 51;
+pub const F_PATHPKG_CHECK: u32 = 52;
+pub const F_FREEZE_FS: u32 = 53;
+pub const F_THAW_FS: u32 = 54;
+pub const F_GLOBAL_NOCACHE: u32 = 55;
+pub const F_ADDSIGS: u32 = 59;
+pub const F_ADDFILESIGS: u32 = 61;
+pub const F_NODIRECT: u32 = 62;
+pub const F_GETPROTECTIONCLASS: u32 = 63;
+pub const F_SETPROTECTIONCLASS: u32 = 64;
+pub const F_LOG2PHYS_EXT: u32 = 65;
+pub const F_GETLKPID: u32 = 66;
+pub const F_SETBACKINGSTORE: u32 = 70;
+pub const F_GETPATH_MTMINFO: u32 = 71;
+pub const F_GETCODEDIR: u32 = 72;
+pub const F_SETNOSIGPIPE: u32 = 73;
+pub const F_GETNOSIGPIPE: u32 = 74;
+pub const F_TRANSCODEKEY: u32 = 75;
+pub const F_SINGLE_WRITER: u32 = 76;
+pub const F_GETPROTECTIONLEVEL: u32 = 77;
+pub const F_FINDSIGS: u32 = 78;
+pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
+pub const F_BARRIERFSYNC: u32 = 85;
+pub const F_ADDFILESIGS_RETURN: u32 = 97;
+pub const F_CHECK_LV: u32 = 98;
+pub const F_PUNCHHOLE: u32 = 99;
+pub const F_TRIM_ACTIVE_FILE: u32 = 100;
+pub const F_SPECULATIVE_READ: u32 = 101;
+pub const F_GETPATH_NOFIRMLINK: u32 = 102;
+pub const F_ADDFILESIGS_INFO: u32 = 103;
+pub const F_ADDFILESUPPL: u32 = 104;
+pub const F_GETSIGSINFO: u32 = 105;
+pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
+pub const F_DUPFD_CLOEXEC: u32 = 67;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 0;
-pub const F_WRLCK: u32 = 1;
+pub const F_RDLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_EXLCK: u32 = 4;
-pub const F_SHLCK: u32 = 8;
+pub const F_WRLCK: u32 = 3;
+pub const SEEK_HOLE: u32 = 3;
+pub const SEEK_DATA: u32 = 4;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_IFWHT: u32 = 57344;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXG: u32 = 56;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXO: u32 = 7;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_ISTXT: u32 = 512;
+pub const S_IREAD: u32 = 256;
+pub const S_IWRITE: u32 = 128;
+pub const S_IEXEC: u32 = 64;
+pub const F_ALLOCATECONTIG: u32 = 2;
+pub const F_ALLOCATEALL: u32 = 4;
+pub const F_PEOFPOSMODE: u32 = 3;
+pub const F_VOLPOSMODE: u32 = 4;
+pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
+pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const FAPPEND: u32 = 1024;
-pub const FFSYNC: u32 = 1052672;
-pub const FASYNC: u32 = 8192;
-pub const FNONBLOCK: u32 = 2048;
-pub const FNDELAY: u32 = 2048;
-pub const __POSIX_FADV_DONTNEED: u32 = 4;
-pub const __POSIX_FADV_NOREUSE: u32 = 5;
-pub const POSIX_FADV_NORMAL: u32 = 0;
-pub const POSIX_FADV_RANDOM: u32 = 1;
-pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
-pub const POSIX_FADV_WILLNEED: u32 = 3;
-pub const POSIX_FADV_DONTNEED: u32 = 4;
-pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const _BITS_STAT_H: u32 = 1;
-pub const _STAT_VER_KERNEL: u32 = 0;
-pub const _STAT_VER_LINUX: u32 = 1;
-pub const _MKNOD_VER_LINUX: u32 = 0;
-pub const _STAT_VER: u32 = 1;
-pub const __S_IFMT: u32 = 61440;
-pub const __S_IFDIR: u32 = 16384;
-pub const __S_IFCHR: u32 = 8192;
-pub const __S_IFBLK: u32 = 24576;
-pub const __S_IFREG: u32 = 32768;
-pub const __S_IFIFO: u32 = 4096;
-pub const __S_IFLNK: u32 = 40960;
-pub const __S_IFSOCK: u32 = 49152;
-pub const __S_ISUID: u32 = 2048;
-pub const __S_ISGID: u32 = 1024;
-pub const __S_ISVTX: u32 = 512;
-pub const __S_IREAD: u32 = 256;
-pub const __S_IWRITE: u32 = 128;
-pub const __S_IEXEC: u32 = 64;
-pub const UTIME_NOW: u32 = 1073741823;
-pub const UTIME_OMIT: u32 = 1073741822;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXG: u32 = 56;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_IRWXO: u32 = 7;
-pub const R_OK: u32 = 4;
-pub const W_OK: u32 = 2;
-pub const X_OK: u32 = 1;
-pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
-pub const F_ULOCK: u32 = 0;
-pub const F_LOCK: u32 = 1;
-pub const F_TLOCK: u32 = 2;
-pub const F_TEST: u32 = 3;
+pub const O_POPUP: u32 = 2147483648;
+pub const O_ALERT: u32 = 536870912;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 1052672;
-pub const OPEN_DATASYNC_FLAG: u32 = 4096;
+pub const OPEN_SYNC_FLAG: u32 = 128;
+pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
 pub const FirstGenbkiObjectId: u32 = 10000;
 pub const FirstBootstrapObjectId: u32 = 12000;
 pub const FirstNormalObjectId: u32 = 16384;
@@ -1488,24 +1986,8 @@ pub const FIELDNO_HEAPTUPLETABLESLOT_OFF: u32 = 2;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_TUPLE: u32 = 1;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_OFF: u32 = 4;
 pub const BITS_PER_BITMAPWORD: u32 = 64;
-pub const _TIME_H: u32 = 1;
-pub const _BITS_TIME_H: u32 = 1;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_TAI: u32 = 11;
-pub const TIMER_ABSTIME: u32 = 1;
-pub const __struct_tm_defined: u32 = 1;
-pub const __itimerspec_defined: u32 = 1;
+pub const CLOCKS_PER_SEC: u32 = 1000000;
 pub const TIME_UTC: u32 = 1;
-pub const PG_INSTR_CLOCK: u32 = 1;
 pub const PARAM_FLAG_CONST: u32 = 1;
 pub const BTLessStrategyNumber: u32 = 1;
 pub const BTLessEqualStrategyNumber: u32 = 2;
@@ -1564,66 +2046,25 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const _DIRENT_H: u32 = 1;
-pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
-pub const _BITS_POSIX1_LIM_H: u32 = 1;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_ARG_MAX: u32 = 4096;
-pub const _POSIX_CHILD_MAX: u32 = 25;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LINK_MAX: u32 = 8;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_MAX_CANON: u32 = 255;
-pub const _POSIX_MAX_INPUT: u32 = 255;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
-pub const _POSIX_NAME_MAX: u32 = 14;
-pub const _POSIX_NGROUPS_MAX: u32 = 8;
-pub const _POSIX_OPEN_MAX: u32 = 20;
-pub const _POSIX_PATH_MAX: u32 = 256;
-pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_RTSIG_MAX: u32 = 8;
-pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
-pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
-pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_SYMLINK_MAX: u32 = 255;
-pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const NR_OPEN: u32 = 1024;
-pub const NGROUPS_MAX: u32 = 65536;
-pub const ARG_MAX: u32 = 131072;
-pub const LINK_MAX: u32 = 127;
-pub const MAX_CANON: u32 = 255;
-pub const MAX_INPUT: u32 = 255;
-pub const NAME_MAX: u32 = 255;
-pub const PATH_MAX: u32 = 4096;
-pub const PIPE_BUF: u32 = 4096;
-pub const XATTR_NAME_MAX: u32 = 255;
-pub const XATTR_SIZE_MAX: u32 = 65536;
-pub const XATTR_LIST_MAX: u32 = 65536;
-pub const RTSIG_MAX: u32 = 32;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const PTHREAD_KEYS_MAX: u32 = 1024;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const AIO_PRIO_DELTA_MAX: u32 = 20;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const DELAYTIMER_MAX: u32 = 2147483647;
-pub const TTY_NAME_MAX: u32 = 32;
-pub const LOGIN_NAME_MAX: u32 = 256;
-pub const HOST_NAME_MAX: u32 = 64;
-pub const MQ_PRIO_MAX: u32 = 32768;
-pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const __DARWIN_MAXNAMLEN: u32 = 255;
+pub const __DARWIN_MAXPATHLEN: u32 = 1024;
 pub const MAXNAMLEN: u32 = 255;
+pub const DT_UNKNOWN: u32 = 0;
+pub const DT_FIFO: u32 = 1;
+pub const DT_CHR: u32 = 2;
+pub const DT_DIR: u32 = 4;
+pub const DT_BLK: u32 = 6;
+pub const DT_REG: u32 = 8;
+pub const DT_LNK: u32 = 10;
+pub const DT_SOCK: u32 = 12;
+pub const DT_WHT: u32 = 14;
+pub const DIRBLKSIZ: u32 = 1024;
+pub const DTF_HIDEW: u32 = 1;
+pub const DTF_NODUP: u32 = 2;
+pub const DTF_REWIND: u32 = 4;
+pub const __DTF_READALL: u32 = 8;
+pub const __DTF_SKIPREAD: u32 = 16;
+pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const DSM_IMPL_POSIX: u32 = 1;
@@ -1667,27 +2108,121 @@ pub const INDEX_SIZE_MASK: u32 = 8191;
 pub const INDEX_AM_RESERVED_BIT: u32 = 8192;
 pub const INDEX_VAR_MASK: u32 = 16384;
 pub const INDEX_NULL_MASK: u32 = 32768;
-pub const _LIBC_LIMITS_H_: u32 = 1;
-pub const MB_LEN_MAX: u32 = 16;
-pub const _BITS_POSIX2_LIM_H: u32 = 1;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const __DARWIN_CLK_TCK: u32 = 100;
+pub const CHAR_BIT: u32 = 8;
+pub const MB_LEN_MAX: u32 = 6;
+pub const CLK_TCK: u32 = 100;
+pub const SCHAR_MAX: u32 = 127;
+pub const SCHAR_MIN: i32 = -128;
+pub const UCHAR_MAX: u32 = 255;
+pub const CHAR_MAX: u32 = 127;
+pub const CHAR_MIN: i32 = -128;
+pub const USHRT_MAX: u32 = 65535;
+pub const SHRT_MAX: u32 = 32767;
+pub const SHRT_MIN: i32 = -32768;
+pub const UINT_MAX: u32 = 4294967295;
+pub const INT_MAX: u32 = 2147483647;
+pub const INT_MIN: i32 = -2147483648;
+pub const ULONG_MAX: i32 = -1;
+pub const LONG_MAX: u64 = 9223372036854775807;
+pub const LONG_MIN: i64 = -9223372036854775808;
+pub const ULLONG_MAX: i32 = -1;
+pub const LLONG_MAX: u64 = 9223372036854775807;
+pub const LLONG_MIN: i64 = -9223372036854775808;
+pub const LONG_BIT: u32 = 64;
+pub const SSIZE_MAX: u64 = 9223372036854775807;
+pub const WORD_BIT: u32 = 32;
+pub const SIZE_T_MAX: i32 = -1;
+pub const UQUAD_MAX: i32 = -1;
+pub const QUAD_MAX: u64 = 9223372036854775807;
+pub const QUAD_MIN: i64 = -9223372036854775808;
+pub const ARG_MAX: u32 = 1048576;
+pub const CHILD_MAX: u32 = 266;
+pub const GID_MAX: u32 = 2147483647;
+pub const LINK_MAX: u32 = 32767;
+pub const MAX_CANON: u32 = 1024;
+pub const MAX_INPUT: u32 = 1024;
+pub const NAME_MAX: u32 = 255;
+pub const NGROUPS_MAX: u32 = 16;
+pub const UID_MAX: u32 = 2147483647;
+pub const OPEN_MAX: u32 = 10240;
+pub const PATH_MAX: u32 = 1024;
+pub const PIPE_BUF: u32 = 512;
 pub const BC_BASE_MAX: u32 = 99;
 pub const BC_DIM_MAX: u32 = 2048;
 pub const BC_SCALE_MAX: u32 = 99;
 pub const BC_STRING_MAX: u32 = 1000;
-pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const CHARCLASS_NAME_MAX: u32 = 14;
+pub const COLL_WEIGHTS_MAX: u32 = 2;
+pub const EQUIV_CLASS_MAX: u32 = 2;
 pub const EXPR_NEST_MAX: u32 = 32;
 pub const LINE_MAX: u32 = 2048;
-pub const CHARCLASS_NAME_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 32767;
+pub const RE_DUP_MAX: u32 = 255;
+pub const NZERO: u32 = 20;
+pub const _POSIX_ARG_MAX: u32 = 4096;
+pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_MAX_CANON: u32 = 255;
+pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_NAME_MAX: u32 = 14;
+pub const _POSIX_NGROUPS_MAX: u32 = 8;
+pub const _POSIX_OPEN_MAX: u32 = 20;
+pub const _POSIX_PATH_MAX: u32 = 256;
+pub const _POSIX_PIPE_BUF: u32 = 512;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
+pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RTSIG_MAX: u32 = 8;
+pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
+pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
+pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_KEYS_MAX: u32 = 512;
+pub const PTHREAD_STACK_MIN: u32 = 8192;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
+pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SYMLINK_MAX: u32 = 255;
+pub const _POSIX_SYMLOOP_MAX: u32 = 8;
+pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
+pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
+pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
+pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TTY_NAME_MAX: u32 = 9;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
+pub const OFF_MIN: i64 = -9223372036854775808;
+pub const OFF_MAX: u64 = 9223372036854775807;
+pub const PASS_MAX: u32 = 128;
+pub const NL_ARGMAX: u32 = 9;
+pub const NL_LANGMAX: u32 = 14;
+pub const NL_MSGMAX: u32 = 32767;
+pub const NL_NMAX: u32 = 1;
+pub const NL_SETMAX: u32 = 255;
+pub const NL_TEXTMAX: u32 = 2048;
+pub const _XOPEN_IOV_MAX: u32 = 16;
+pub const IOV_MAX: u32 = 1024;
+pub const _XOPEN_NAME_MAX: u32 = 255;
+pub const _XOPEN_PATH_MAX: u32 = 1024;
 pub const SIZEOF_DSA_POINTER: u32 = 8;
 pub const DSA_POINTER_FORMAT: &'static [u8; 7usize] = b"%016lx\0";
 pub const DSA_ALLOC_HUGE: u32 = 1;
@@ -1771,6 +2306,7 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
+pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const REINDEXOPT_REPORT_PROGRESS: u32 = 2;
 pub const MaxAllocHugeSize: u32 = 0;
@@ -1789,85 +2325,6 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
-pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGILL: u32 = 4;
-pub const SIGABRT: u32 = 6;
-pub const SIGFPE: u32 = 8;
-pub const SIGSEGV: u32 = 11;
-pub const SIGTERM: u32 = 15;
-pub const SIGHUP: u32 = 1;
-pub const SIGQUIT: u32 = 3;
-pub const SIGTRAP: u32 = 5;
-pub const SIGKILL: u32 = 9;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGXCPU: u32 = 24;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
-pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
-pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
-pub const __sig_atomic_t_defined: u32 = 1;
-pub const __siginfo_t_defined: u32 = 1;
-pub const __SI_MAX_SIZE: u32 = 128;
-pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
-pub const __SI_ERRNO_THEN_CODE: u32 = 1;
-pub const __SI_HAVE_SIGSYS: u32 = 1;
-pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
-pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
-pub const __sigevent_t_defined: u32 = 1;
-pub const __SIGEV_MAX_SIZE: u32 = 64;
-pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
-pub const _BITS_SIGACTION_H: u32 = 1;
-pub const SA_NOCLDSTOP: u32 = 1;
-pub const SA_NOCLDWAIT: u32 = 2;
-pub const SA_SIGINFO: u32 = 4;
-pub const SA_ONSTACK: u32 = 134217728;
-pub const SA_RESTART: u32 = 268435456;
-pub const SA_NODEFER: u32 = 1073741824;
-pub const SA_RESETHAND: u32 = 2147483648;
-pub const SA_INTERRUPT: u32 = 536870912;
-pub const SA_NOMASK: u32 = 1073741824;
-pub const SA_ONESHOT: u32 = 2147483648;
-pub const SA_STACK: u32 = 134217728;
-pub const SIG_BLOCK: u32 = 0;
-pub const SIG_UNBLOCK: u32 = 1;
-pub const SIG_SETMASK: u32 = 2;
-pub const _BITS_SIGCONTEXT_H: u32 = 1;
-pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
-pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
-pub const __stack_t_defined: u32 = 1;
-pub const _SYS_UCONTEXT_H: u32 = 1;
-pub const __NGREG: u32 = 23;
-pub const NGREG: u32 = 23;
-pub const _BITS_SIGSTACK_H: u32 = 1;
-pub const MINSIGSTKSZ: u32 = 2048;
-pub const SIGSTKSZ: u32 = 8192;
-pub const _BITS_SS_FLAGS_H: u32 = 1;
-pub const __sigstack_defined: u32 = 1;
-pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -1886,7 +2343,13 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const _SYS_UN_H: u32 = 1;
+pub const SOL_LOCAL: u32 = 0;
+pub const LOCAL_PEERCRED: u32 = 1;
+pub const LOCAL_PEERPID: u32 = 2;
+pub const LOCAL_PEEREPID: u32 = 3;
+pub const LOCAL_PEERUUID: u32 = 4;
+pub const LOCAL_PEEREUUID: u32 = 5;
+pub const LOCAL_PEERTOKEN: u32 = 6;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -2071,6 +2534,7 @@ pub const F_HAS_GARBAGE: u32 = 16;
 pub const GIST_PAGE_ID: u32 = 65409;
 pub const EOH_HEADER_MAGIC: i32 = -1;
 pub const EA_MAGIC: u32 = 689375833;
+pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &'static [u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -2928,195 +3392,428 @@ pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
 pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
-pub type va_list = __builtin_va_list;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type __u_char = ::std::os::raw::c_uchar;
-pub type __u_short = ::std::os::raw::c_ushort;
-pub type __u_int = ::std::os::raw::c_uint;
-pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_long;
-pub type __uint64_t = ::std::os::raw::c_ulong;
-pub type __int_least8_t = __int8_t;
-pub type __uint_least8_t = __uint8_t;
-pub type __int_least16_t = __int16_t;
-pub type __uint_least16_t = __uint16_t;
-pub type __int_least32_t = __int32_t;
-pub type __uint_least32_t = __uint32_t;
-pub type __int_least64_t = __int64_t;
-pub type __uint_least64_t = __uint64_t;
-pub type __quad_t = ::std::os::raw::c_long;
-pub type __u_quad_t = ::std::os::raw::c_ulong;
-pub type __intmax_t = ::std::os::raw::c_long;
-pub type __uintmax_t = ::std::os::raw::c_ulong;
-pub type __dev_t = ::std::os::raw::c_ulong;
-pub type __uid_t = ::std::os::raw::c_uint;
-pub type __gid_t = ::std::os::raw::c_uint;
-pub type __ino_t = ::std::os::raw::c_ulong;
-pub type __ino64_t = ::std::os::raw::c_ulong;
-pub type __mode_t = ::std::os::raw::c_uint;
-pub type __nlink_t = ::std::os::raw::c_ulong;
-pub type __off_t = ::std::os::raw::c_long;
-pub type __off64_t = ::std::os::raw::c_long;
-pub type __pid_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __fsid_t {
-    pub __val: [::std::os::raw::c_int; 2usize],
-}
-pub type __clock_t = ::std::os::raw::c_long;
-pub type __rlim_t = ::std::os::raw::c_ulong;
-pub type __rlim64_t = ::std::os::raw::c_ulong;
-pub type __id_t = ::std::os::raw::c_uint;
-pub type __time_t = ::std::os::raw::c_long;
-pub type __useconds_t = ::std::os::raw::c_uint;
-pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
-pub type __daddr_t = ::std::os::raw::c_int;
-pub type __key_t = ::std::os::raw::c_int;
-pub type __clockid_t = ::std::os::raw::c_int;
-pub type __timer_t = *mut ::std::os::raw::c_void;
-pub type __blksize_t = ::std::os::raw::c_long;
-pub type __blkcnt_t = ::std::os::raw::c_long;
-pub type __blkcnt64_t = ::std::os::raw::c_long;
-pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
-pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsword_t = ::std::os::raw::c_long;
-pub type __ssize_t = ::std::os::raw::c_long;
-pub type __syscall_slong_t = ::std::os::raw::c_long;
-pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
-pub type __loff_t = __off64_t;
-pub type __caddr_t = *mut ::std::os::raw::c_char;
-pub type __intptr_t = ::std::os::raw::c_long;
-pub type __socklen_t = ::std::os::raw::c_uint;
-pub type __sig_atomic_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_longlong;
+pub type __uint64_t = ::std::os::raw::c_ulonglong;
+pub type __darwin_intptr_t = ::std::os::raw::c_long;
+pub type __darwin_natural_t = ::std::os::raw::c_uint;
+pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct __mbstate_t {
-    pub __count: ::std::os::raw::c_int,
-    pub __value: __mbstate_t__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __mbstate_t__bindgen_ty_1 {
-    pub __wch: ::std::os::raw::c_uint,
-    pub __wchb: [::std::os::raw::c_char; 4usize],
-    _bindgen_union_align: u32,
-}
-impl Default for __mbstate_t__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+pub union __mbstate_t {
+    pub __mbstate8: [::std::os::raw::c_char; 128usize],
+    pub _mbstateL: ::std::os::raw::c_longlong,
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub type __darwin_mbstate_t = __mbstate_t;
+pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
+pub type __darwin_size_t = ::std::os::raw::c_ulong;
+pub type __darwin_va_list = __builtin_va_list;
+pub type __darwin_wchar_t = ::std::os::raw::c_int;
+pub type __darwin_rune_t = __darwin_wchar_t;
+pub type __darwin_wint_t = ::std::os::raw::c_int;
+pub type __darwin_clock_t = ::std::os::raw::c_ulong;
+pub type __darwin_socklen_t = __uint32_t;
+pub type __darwin_ssize_t = ::std::os::raw::c_long;
+pub type __darwin_time_t = ::std::os::raw::c_long;
+pub type __darwin_blkcnt_t = __int64_t;
+pub type __darwin_blksize_t = __int32_t;
+pub type __darwin_dev_t = __int32_t;
+pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_gid_t = __uint32_t;
+pub type __darwin_id_t = __uint32_t;
+pub type __darwin_ino64_t = __uint64_t;
+pub type __darwin_ino_t = __darwin_ino64_t;
+pub type __darwin_mach_port_name_t = __darwin_natural_t;
+pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
+pub type __darwin_mode_t = __uint16_t;
+pub type __darwin_off_t = __int64_t;
+pub type __darwin_pid_t = __int32_t;
+pub type __darwin_sigset_t = __uint32_t;
+pub type __darwin_suseconds_t = __int32_t;
+pub type __darwin_uid_t = __uint32_t;
+pub type __darwin_useconds_t = __uint32_t;
+pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
+pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_pthread_handler_rec {
+    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+    pub __arg: *mut ::std::os::raw::c_void,
+    pub __next: *mut __darwin_pthread_handler_rec,
+}
+impl Default for __darwin_pthread_handler_rec {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _G_fpos_t {
-    pub __pos: __off_t,
-    pub __state: __mbstate_t,
+pub struct _opaque_pthread_attr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
 }
-impl Default for _G_fpos_t {
+impl Default for _opaque_pthread_attr_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _G_fpos64_t {
-    pub __pos: __off64_t,
-    pub __state: __mbstate_t,
+pub struct _opaque_pthread_cond_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 40usize],
 }
-impl Default for _G_fpos64_t {
+impl Default for _opaque_pthread_cond_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __fpos64_t = _G_fpos64_t;
-pub type __FILE = _IO_FILE;
-pub type FILE = _IO_FILE;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_condattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_mutex_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
-    _unused: [u8; 0],
-}
-pub type _IO_lock_t = ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_FILE {
-    pub _flags: ::std::os::raw::c_int,
-    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    pub _IO_read_end: *mut ::std::os::raw::c_char,
-    pub _IO_read_base: *mut ::std::os::raw::c_char,
-    pub _IO_write_base: *mut ::std::os::raw::c_char,
-    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    pub _IO_write_end: *mut ::std::os::raw::c_char,
-    pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    pub _IO_save_base: *mut ::std::os::raw::c_char,
-    pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    pub _IO_save_end: *mut ::std::os::raw::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::std::os::raw::c_int,
-    pub _flags2: ::std::os::raw::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::std::os::raw::c_ushort,
-    pub _vtable_offset: ::std::os::raw::c_schar,
-    pub _shortbuf: [::std::os::raw::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::std::os::raw::c_void,
-    pub __pad5: usize,
-    pub _mode: ::std::os::raw::c_int,
-    pub _unused2: [::std::os::raw::c_char; 20usize],
-}
-impl Default for _IO_FILE {
+impl Default for _opaque_pthread_mutex_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type off_t = __off_t;
-pub type fpos_t = __fpos_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_mutexattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_once_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_rwlock_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 192usize],
+}
+impl Default for _opaque_pthread_rwlock_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_rwlockattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 16usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
+    pub __opaque: [::std::os::raw::c_char; 8176usize],
+}
+impl Default for _opaque_pthread_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
+pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
+pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
+pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
+pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
+pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
+pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
+pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
+pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
+pub type __darwin_pthread_t = *mut _opaque_pthread_t;
+pub type __darwin_nl_item = ::std::os::raw::c_int;
+pub type __darwin_wctrans_t = ::std::os::raw::c_int;
+pub type __darwin_wctype_t = __uint32_t;
+pub type u_int8_t = ::std::os::raw::c_uchar;
+pub type u_int16_t = ::std::os::raw::c_ushort;
+pub type u_int32_t = ::std::os::raw::c_uint;
+pub type u_int64_t = ::std::os::raw::c_ulonglong;
+pub type register_t = i64;
+pub type user_addr_t = u_int64_t;
+pub type user_size_t = u_int64_t;
+pub type user_ssize_t = i64;
+pub type user_long_t = i64;
+pub type user_ulong_t = u_int64_t;
+pub type user_time_t = i64;
+pub type user_off_t = i64;
+pub type syscall_arg_t = u_int64_t;
+pub type va_list = __darwin_va_list;
 #[pg_guard]
 extern "C" {
-    pub static mut stdin: *mut FILE;
+    pub fn renameat(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut stdout: *mut FILE;
+    pub fn renamex_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut stderr: *mut FILE;
+    pub fn renameatx_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fpos_t = __darwin_off_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sbuf {
+    pub _base: *mut ::std::os::raw::c_uchar,
+    pub _size: ::std::os::raw::c_int,
+}
+impl Default for __sbuf {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sFILEX {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sFILE {
+    pub _p: *mut ::std::os::raw::c_uchar,
+    pub _r: ::std::os::raw::c_int,
+    pub _w: ::std::os::raw::c_int,
+    pub _flags: ::std::os::raw::c_short,
+    pub _file: ::std::os::raw::c_short,
+    pub _bf: __sbuf,
+    pub _lbfsize: ::std::os::raw::c_int,
+    pub _cookie: *mut ::std::os::raw::c_void,
+    pub _close: ::std::option::Option<
+        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+    >,
+    pub _read: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: *mut ::std::os::raw::c_char,
+            arg3: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub _seek: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: fpos_t,
+            arg3: ::std::os::raw::c_int,
+        ) -> fpos_t,
+    >,
+    pub _write: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: *const ::std::os::raw::c_char,
+            arg3: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub _ub: __sbuf,
+    pub _extra: *mut __sFILEX,
+    pub _ur: ::std::os::raw::c_int,
+    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
+    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
+    pub _lb: __sbuf,
+    pub _blksize: ::std::os::raw::c_int,
+    pub _offset: fpos_t,
+}
+impl Default for __sFILE {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type FILE = __sFILE;
+#[pg_guard]
+extern "C" {
+    pub static mut __stdinp: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub static mut __stdoutp: *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __stderrp: *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr(arg1: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgets(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __mode: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fprintf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __nitems: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freopen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut FILE,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fscanf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseek(
+        arg1: *mut FILE,
+        arg2: ::std::os::raw::c_long,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __nitems: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn perror(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3127,11 +3824,39 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn renameat(
-        __oldfd: ::std::os::raw::c_int,
-        __old: *const ::std::os::raw::c_char,
-        __newfd: ::std::os::raw::c_int,
-        __new: *const ::std::os::raw::c_char,
+    pub fn rewind(arg1: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setvbuf(
+        arg1: *mut FILE,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sprintf(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sscanf(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3140,275 +3865,89 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tempnam(
-        __dir: *const ::std::os::raw::c_char,
-        __pfx: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freopen(
-        __filename: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
-        __stream: *mut FILE,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
-        -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmemopen(
-        __s: *mut ::std::os::raw::c_void,
-        __len: usize,
-        __modes: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn open_memstream(
-        __bufloc: *mut *mut ::std::os::raw::c_char,
-        __sizeloc: *mut usize,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setvbuf(
-        __stream: *mut FILE,
-        __buf: *mut ::std::os::raw::c_char,
-        __modes: ::std::os::raw::c_int,
-        __n: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setlinebuf(__stream: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn fprintf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vfprintf(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vprintf(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vsprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn snprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __maxlen: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        ...
+    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn popen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __svfscanf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vsnprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __maxlen: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
+    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vdprintf(
-        __fd: ::std::os::raw::c_int,
-        __fmt: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
+    pub fn flockfile(arg1: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn dprintf(
-        __fd: ::std::os::raw::c_int,
-        __fmt: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fscanf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn funlockfile(arg1: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sscanf(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_fscanf"]
-    pub fn fscanf1(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_scanf"]
-    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_sscanf"]
-    pub fn sscanf1(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vfscanf(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vscanf(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsscanf(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vfscanf"]
-    pub fn vfscanf1(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vscanf"]
-    pub fn vscanf1(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vsscanf"]
-    pub fn vsscanf1(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3416,231 +3955,2080 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgets(
-        __s: *mut ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_int,
-        __stream: *mut FILE,
+    pub fn tempnam(
+        __dir: *const ::std::os::raw::c_char,
+        __prefix: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-#[pg_guard]
-extern "C" {
-    pub fn __getdelim(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getdelim(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getline(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __n: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __n: ::std::os::raw::c_ulong,
-        __s: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread_unlocked(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
-        __n: usize,
-        __stream: *mut FILE,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite_unlocked(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: usize,
-        __n: usize,
-        __stream: *mut FILE,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fseek(
-        __stream: *mut FILE,
-        __off: ::std::os::raw::c_long,
-        __whence: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rewind(__stream: *mut FILE);
-}
+pub type off_t = __darwin_off_t;
 #[pg_guard]
 extern "C" {
     pub fn fseeko(
         __stream: *mut FILE,
-        __off: __off_t,
+        __offset: off_t,
         __whence: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> __off_t;
+    pub fn ftello(__stream: *mut FILE) -> off_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+    pub fn snprintf(
+        __str: *mut ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+    pub fn vfscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr(__stream: *mut FILE);
+    pub fn vscanf(
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vsnprintf(
+        __str: *mut ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vsscanf(
+        __str: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr_unlocked(__stream: *mut FILE);
+    pub fn dprintf(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vdprintf(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getdelim(
+        __linep: *mut *mut ::std::os::raw::c_char,
+        __linecapp: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn perror(__s: *const ::std::os::raw::c_char);
+    pub fn getline(
+        __linep: *mut *mut ::std::os::raw::c_char,
+        __linecapp: *mut usize,
+        __stream: *mut FILE,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn popen(
-        __command: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
+    pub fn fmemopen(
+        __buf: *mut ::std::os::raw::c_void,
+        __size: usize,
+        __mode: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn open_memstream(
+        __bufp: *mut *mut ::std::os::raw::c_char,
+        __sizep: *mut usize,
+    ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub static sys_nerr: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn flockfile(__stream: *mut FILE);
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn asprintf(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn funlockfile(__stream: *mut FILE);
+    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn fmtcheck(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *const ::std::os::raw::c_char;
 }
-pub type wchar_t = ::std::os::raw::c_int;
+#[pg_guard]
+extern "C" {
+    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuffer(
+        arg1: *mut FILE,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vasprintf(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn zopen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn funopen(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *mut ::std::os::raw::c_char,
+                arg3: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int,
+        >,
+        arg3: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_char,
+                arg3: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int,
+        >,
+        arg4: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: fpos_t,
+                arg3: ::std::os::raw::c_int,
+            ) -> fpos_t,
+        >,
+        arg5: ::std::option::Option<
+            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+        >,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __snprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+        arg5: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __vsprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __vsnprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+        arg5: *const ::std::os::raw::c_char,
+        arg6: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type pid_t = __darwin_pid_t;
+pub type id_t = __darwin_id_t;
+pub type sig_atomic_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_i386_thread_state {
+    pub __eax: ::std::os::raw::c_uint,
+    pub __ebx: ::std::os::raw::c_uint,
+    pub __ecx: ::std::os::raw::c_uint,
+    pub __edx: ::std::os::raw::c_uint,
+    pub __edi: ::std::os::raw::c_uint,
+    pub __esi: ::std::os::raw::c_uint,
+    pub __ebp: ::std::os::raw::c_uint,
+    pub __esp: ::std::os::raw::c_uint,
+    pub __ss: ::std::os::raw::c_uint,
+    pub __eflags: ::std::os::raw::c_uint,
+    pub __eip: ::std::os::raw::c_uint,
+    pub __cs: ::std::os::raw::c_uint,
+    pub __ds: ::std::os::raw::c_uint,
+    pub __es: ::std::os::raw::c_uint,
+    pub __fs: ::std::os::raw::c_uint,
+    pub __gs: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_fp_control {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+}
+impl __darwin_fp_control {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __pc: ::std::os::raw::c_ushort,
+        __rc: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 2u8, {
+            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
+            __pc as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 2u8, {
+            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
+            __rc as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_control_t = __darwin_fp_control;
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_fp_status {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+}
+impl __darwin_fp_status {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(6usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(9usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
+    }
+    #[inline]
+    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(11usize, 3u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(14usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(15usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __stkflt: ::std::os::raw::c_ushort,
+        __errsumm: ::std::os::raw::c_ushort,
+        __c0: ::std::os::raw::c_ushort,
+        __c1: ::std::os::raw::c_ushort,
+        __c2: ::std::os::raw::c_ushort,
+        __tos: ::std::os::raw::c_ushort,
+        __c3: ::std::os::raw::c_ushort,
+        __busy: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(6usize, 1u8, {
+            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
+            __stkflt as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
+            __errsumm as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 1u8, {
+            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
+            __c0 as u64
+        });
+        __bindgen_bitfield_unit.set(9usize, 1u8, {
+            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
+            __c1 as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 1u8, {
+            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
+            __c2 as u64
+        });
+        __bindgen_bitfield_unit.set(11usize, 3u8, {
+            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
+            __tos as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 1u8, {
+            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
+            __c3 as u64
+        });
+        __bindgen_bitfield_unit.set(15usize, 1u8, {
+            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
+            __busy as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_status_t = __darwin_fp_status;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_mmst_reg {
+    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
+    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_xmm_reg {
+    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_ymm_reg {
+    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_zmm_reg {
+    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
+}
+impl Default for __darwin_zmm_reg {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_opmask_reg {
+    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_float_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+impl Default for __darwin_i386_float_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_avx_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+}
+impl Default for __darwin_i386_avx_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_avx512_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+}
+impl Default for __darwin_i386_avx512_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_i386_exception_state {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_debug_state32 {
+    pub __dr0: ::std::os::raw::c_uint,
+    pub __dr1: ::std::os::raw::c_uint,
+    pub __dr2: ::std::os::raw::c_uint,
+    pub __dr3: ::std::os::raw::c_uint,
+    pub __dr4: ::std::os::raw::c_uint,
+    pub __dr5: ::std::os::raw::c_uint,
+    pub __dr6: ::std::os::raw::c_uint,
+    pub __dr7: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __x86_instruction_state {
+    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
+    pub __insn_offset: ::std::os::raw::c_int,
+    pub __out_of_synch: ::std::os::raw::c_int,
+    pub __insn_bytes: [__uint8_t; 2380usize],
+    pub __insn_cacheline: [__uint8_t; 64usize],
+}
+impl Default for __x86_instruction_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __last_branch_record {
+    pub __from_ip: __uint64_t,
+    pub __to_ip: __uint64_t,
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __bindgen_padding_0: u32,
+}
+impl __last_branch_record {
+    #[inline]
+    pub fn __mispredict(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___mispredict(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tsx_abort(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __in_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___in_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set___cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(19usize, 13u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __mispredict: __uint32_t,
+        __tsx_abort: __uint32_t,
+        __in_tsx: __uint32_t,
+        __cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
+            __mispredict as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
+            __tsx_abort as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
+            __in_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 16u8, {
+            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
+            __cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(19usize, 13u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __last_branch_state {
+    pub __lbr_count: ::std::os::raw::c_int,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __lbrs: [__last_branch_record; 32usize],
+}
+impl __last_branch_state {
+    #[inline]
+    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 30u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __lbr_supported_tsx: __uint32_t,
+        __lbr_supported_cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
+            __lbr_supported_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __lbr_supported_cycle_count: u32 =
+                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
+            __lbr_supported_cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 30u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __x86_pagein_state {
+    pub __pagein_error: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_thread_state64 {
+    pub __rax: __uint64_t,
+    pub __rbx: __uint64_t,
+    pub __rcx: __uint64_t,
+    pub __rdx: __uint64_t,
+    pub __rdi: __uint64_t,
+    pub __rsi: __uint64_t,
+    pub __rbp: __uint64_t,
+    pub __rsp: __uint64_t,
+    pub __r8: __uint64_t,
+    pub __r9: __uint64_t,
+    pub __r10: __uint64_t,
+    pub __r11: __uint64_t,
+    pub __r12: __uint64_t,
+    pub __r13: __uint64_t,
+    pub __r14: __uint64_t,
+    pub __r15: __uint64_t,
+    pub __rip: __uint64_t,
+    pub __rflags: __uint64_t,
+    pub __cs: __uint64_t,
+    pub __fs: __uint64_t,
+    pub __gs: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_thread_full_state64 {
+    pub __ss64: __darwin_x86_thread_state64,
+    pub __ds: __uint64_t,
+    pub __es: __uint64_t,
+    pub __ss: __uint64_t,
+    pub __gsbase: __uint64_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_float_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+impl Default for __darwin_x86_float_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_avx_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+}
+impl Default for __darwin_x86_avx_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_avx512_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+    pub __fpu_zmmh8: __darwin_ymm_reg,
+    pub __fpu_zmmh9: __darwin_ymm_reg,
+    pub __fpu_zmmh10: __darwin_ymm_reg,
+    pub __fpu_zmmh11: __darwin_ymm_reg,
+    pub __fpu_zmmh12: __darwin_ymm_reg,
+    pub __fpu_zmmh13: __darwin_ymm_reg,
+    pub __fpu_zmmh14: __darwin_ymm_reg,
+    pub __fpu_zmmh15: __darwin_ymm_reg,
+    pub __fpu_zmm16: __darwin_zmm_reg,
+    pub __fpu_zmm17: __darwin_zmm_reg,
+    pub __fpu_zmm18: __darwin_zmm_reg,
+    pub __fpu_zmm19: __darwin_zmm_reg,
+    pub __fpu_zmm20: __darwin_zmm_reg,
+    pub __fpu_zmm21: __darwin_zmm_reg,
+    pub __fpu_zmm22: __darwin_zmm_reg,
+    pub __fpu_zmm23: __darwin_zmm_reg,
+    pub __fpu_zmm24: __darwin_zmm_reg,
+    pub __fpu_zmm25: __darwin_zmm_reg,
+    pub __fpu_zmm26: __darwin_zmm_reg,
+    pub __fpu_zmm27: __darwin_zmm_reg,
+    pub __fpu_zmm28: __darwin_zmm_reg,
+    pub __fpu_zmm29: __darwin_zmm_reg,
+    pub __fpu_zmm30: __darwin_zmm_reg,
+    pub __fpu_zmm31: __darwin_zmm_reg,
+}
+impl Default for __darwin_x86_avx512_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_exception_state64 {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_debug_state64 {
+    pub __dr0: __uint64_t,
+    pub __dr1: __uint64_t,
+    pub __dr2: __uint64_t,
+    pub __dr3: __uint64_t,
+    pub __dr4: __uint64_t,
+    pub __dr5: __uint64_t,
+    pub __dr6: __uint64_t,
+    pub __dr7: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_cpmu_state64 {
+    pub __ctrs: [__uint64_t; 16usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_float_state,
+}
+impl Default for __darwin_mcontext32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx_state,
+}
+impl Default for __darwin_mcontext_avx32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx512_state,
+}
+impl Default for __darwin_mcontext_avx512_32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+impl Default for __darwin_mcontext64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+impl Default for __darwin_mcontext64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+impl Default for __darwin_mcontext_avx64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+impl Default for __darwin_mcontext_avx64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+impl Default for __darwin_mcontext_avx512_64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+impl Default for __darwin_mcontext_avx512_64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type mcontext_t = *mut __darwin_mcontext64;
+pub type pthread_attr_t = __darwin_pthread_attr_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_sigaltstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_size: __darwin_size_t,
+    pub ss_flags: ::std::os::raw::c_int,
+}
+impl Default for __darwin_sigaltstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type stack_t = __darwin_sigaltstack;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_ucontext {
+    pub uc_onstack: ::std::os::raw::c_int,
+    pub uc_sigmask: __darwin_sigset_t,
+    pub uc_stack: __darwin_sigaltstack,
+    pub uc_link: *mut __darwin_ucontext,
+    pub uc_mcsize: __darwin_size_t,
+    pub uc_mcontext: *mut __darwin_mcontext64,
+}
+impl Default for __darwin_ucontext {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type ucontext_t = __darwin_ucontext;
+pub type sigset_t = __darwin_sigset_t;
+pub type uid_t = __darwin_uid_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
+}
+impl Default for sigval {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_value: sigval,
+    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
+    pub sigev_notify_attributes: *mut pthread_attr_t,
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __siginfo {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub si_pid: pid_t,
+    pub si_uid: uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_value: sigval,
+    pub si_band: ::std::os::raw::c_long,
+    pub __pad: [::std::os::raw::c_ulong; 7usize],
+}
+impl Default for __siginfo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type siginfo_t = __siginfo;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __sigaction_u {
+    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub __sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut __siginfo,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for __sigaction_u {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __sigaction {
+    pub __sigaction_u: __sigaction_u,
+    pub sa_tramp: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: ::std::os::raw::c_int,
+            arg3: ::std::os::raw::c_int,
+            arg4: *mut siginfo_t,
+            arg5: *mut ::std::os::raw::c_void,
+        ),
+    >,
+    pub sa_mask: sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+}
+impl Default for __sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_u: __sigaction_u,
+    pub sa_mask: sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sigvec {
+    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub sv_mask: ::std::os::raw::c_int,
+    pub sv_flags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_char,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn signal(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+        ),
+    >;
+}
+pub type int_least8_t = i8;
+pub type int_least16_t = i16;
+pub type int_least32_t = i32;
+pub type int_least64_t = i64;
+pub type uint_least8_t = u8;
+pub type uint_least16_t = u16;
+pub type uint_least32_t = u32;
+pub type uint_least64_t = u64;
+pub type int_fast8_t = i8;
+pub type int_fast16_t = i16;
+pub type int_fast32_t = i32;
+pub type int_fast64_t = i64;
+pub type uint_fast8_t = u8;
+pub type uint_fast16_t = u16;
+pub type uint_fast32_t = u32;
+pub type uint_fast64_t = u64;
+pub type intmax_t = ::std::os::raw::c_long;
+pub type uintmax_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __darwin_time_t,
+    pub tv_usec: __darwin_suseconds_t,
+}
+pub type rlim_t = __uint64_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage {
+    pub ru_utime: timeval,
+    pub ru_stime: timeval,
+    pub ru_maxrss: ::std::os::raw::c_long,
+    pub ru_ixrss: ::std::os::raw::c_long,
+    pub ru_idrss: ::std::os::raw::c_long,
+    pub ru_isrss: ::std::os::raw::c_long,
+    pub ru_minflt: ::std::os::raw::c_long,
+    pub ru_majflt: ::std::os::raw::c_long,
+    pub ru_nswap: ::std::os::raw::c_long,
+    pub ru_inblock: ::std::os::raw::c_long,
+    pub ru_oublock: ::std::os::raw::c_long,
+    pub ru_msgsnd: ::std::os::raw::c_long,
+    pub ru_msgrcv: ::std::os::raw::c_long,
+    pub ru_nsignals: ::std::os::raw::c_long,
+    pub ru_nvcsw: ::std::os::raw::c_long,
+    pub ru_nivcsw: ::std::os::raw::c_long,
+}
+pub type rusage_info_t = *mut ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v0 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v1 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v2 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v3 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v4 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v5 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+    pub ri_flags: u64,
+}
+pub type rusage_info_current = rusage_info_v5;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rlimit {
+    pub rlim_cur: rlim_t,
+    pub rlim_max: rlim_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct proc_rlimit_control_wakeupmon {
+    pub wm_flags: u32,
+    pub wm_rate: i32,
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getiopolicy_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setpriority(
+        arg1: ::std::os::raw::c_int,
+        arg2: id_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setiopolicy_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union wait {
+    pub w_status: ::std::os::raw::c_int,
+    pub w_T: wait__bindgen_ty_1,
+    pub w_S: wait__bindgen_ty_2,
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct wait__bindgen_ty_1 {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+impl wait__bindgen_ty_1 {
+    #[inline]
+    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 7u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        w_Termsig: ::std::os::raw::c_uint,
+        w_Coredump: ::std::os::raw::c_uint,
+        w_Retcode: ::std::os::raw::c_uint,
+        w_Filler: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 7u8, {
+            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
+            w_Termsig as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
+            w_Coredump as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 8u8, {
+            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
+            w_Retcode as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
+            w_Filler as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct wait__bindgen_ty_2 {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+impl wait__bindgen_ty_2 {
+    #[inline]
+    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        w_Stopval: ::std::os::raw::c_uint,
+        w_Stopsig: ::std::os::raw::c_uint,
+        w_Filler: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 8u8, {
+            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
+            w_Stopval as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 8u8, {
+            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
+            w_Stopsig as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
+            w_Filler as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+impl Default for wait {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn waitpid(
+        arg1: pid_t,
+        arg2: *mut ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn waitid(
+        arg1: idtype_t,
+        arg2: id_t,
+        arg3: *mut siginfo_t,
+        arg4: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait3(
+        arg1: *mut ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut rusage,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait4(
+        arg1: pid_t,
+        arg2: *mut ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut rusage,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+}
+pub type ct_rune_t = __darwin_ct_rune_t;
+pub type rune_t = __darwin_rune_t;
+pub type wchar_t = __darwin_wchar_t;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -3661,595 +6049,7 @@ pub struct lldiv_t {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_get_mb_cur_max() -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtod(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtof(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtold(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtol(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoul(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoq(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtouq(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoll(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoull(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-pub type u_char = __u_char;
-pub type u_short = __u_short;
-pub type u_int = __u_int;
-pub type u_long = __u_long;
-pub type quad_t = __quad_t;
-pub type u_quad_t = __u_quad_t;
-pub type fsid_t = __fsid_t;
-pub type loff_t = __loff_t;
-pub type ino_t = __ino_t;
-pub type dev_t = __dev_t;
-pub type gid_t = __gid_t;
-pub type mode_t = __mode_t;
-pub type nlink_t = __nlink_t;
-pub type uid_t = __uid_t;
-pub type pid_t = __pid_t;
-pub type id_t = __id_t;
-pub type daddr_t = __daddr_t;
-pub type caddr_t = __caddr_t;
-pub type key_t = __key_t;
-pub type clock_t = __clock_t;
-pub type clockid_t = __clockid_t;
-pub type time_t = __time_t;
-pub type timer_t = __timer_t;
-pub type ulong = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_int8_t = __uint8_t;
-pub type u_int16_t = __uint16_t;
-pub type u_int32_t = __uint32_t;
-pub type u_int64_t = __uint64_t;
-pub type register_t = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sigset_t {
-    pub __val: [::std::os::raw::c_ulong; 16usize],
-}
-pub type sigset_t = __sigset_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __time_t,
-    pub tv_usec: __suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __time_t,
-    pub tv_nsec: __syscall_slong_t,
-}
-pub type suseconds_t = __suseconds_t;
-pub type __fd_mask = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub __fds_bits: [__fd_mask; 16usize],
-}
-pub type fd_mask = __fd_mask;
-#[pg_guard]
-extern "C" {
-    pub fn select(
-        __nfds: ::std::os::raw::c_int,
-        __readfds: *mut fd_set,
-        __writefds: *mut fd_set,
-        __exceptfds: *mut fd_set,
-        __timeout: *mut timeval,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pselect(
-        __nfds: ::std::os::raw::c_int,
-        __readfds: *mut fd_set,
-        __writefds: *mut fd_set,
-        __exceptfds: *mut fd_set,
-        __timeout: *const timespec,
-        __sigmask: *const __sigset_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type blksize_t = __blksize_t;
-pub type blkcnt_t = __blkcnt_t;
-pub type fsblkcnt_t = __fsblkcnt_t;
-pub type fsfilcnt_t = __fsfilcnt_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_internal_list {
-    pub __prev: *mut __pthread_internal_list,
-    pub __next: *mut __pthread_internal_list,
-}
-impl Default for __pthread_internal_list {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __pthread_list_t = __pthread_internal_list;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_internal_slist {
-    pub __next: *mut __pthread_internal_slist,
-}
-impl Default for __pthread_internal_slist {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __pthread_slist_t = __pthread_internal_slist;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_mutex_s {
-    pub __lock: ::std::os::raw::c_int,
-    pub __count: ::std::os::raw::c_uint,
-    pub __owner: ::std::os::raw::c_int,
-    pub __nusers: ::std::os::raw::c_uint,
-    pub __kind: ::std::os::raw::c_int,
-    pub __spins: ::std::os::raw::c_short,
-    pub __elision: ::std::os::raw::c_short,
-    pub __list: __pthread_list_t,
-}
-impl Default for __pthread_mutex_s {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_rwlock_arch_t {
-    pub __readers: ::std::os::raw::c_uint,
-    pub __writers: ::std::os::raw::c_uint,
-    pub __wrphase_futex: ::std::os::raw::c_uint,
-    pub __writers_futex: ::std::os::raw::c_uint,
-    pub __pad3: ::std::os::raw::c_uint,
-    pub __pad4: ::std::os::raw::c_uint,
-    pub __cur_writer: ::std::os::raw::c_int,
-    pub __shared: ::std::os::raw::c_int,
-    pub __rwelision: ::std::os::raw::c_schar,
-    pub __pad1: [::std::os::raw::c_uchar; 7usize],
-    pub __pad2: ::std::os::raw::c_ulong,
-    pub __flags: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __pthread_cond_s {
-    pub __bindgen_anon_1: __pthread_cond_s__bindgen_ty_1,
-    pub __bindgen_anon_2: __pthread_cond_s__bindgen_ty_2,
-    pub __g_refs: [::std::os::raw::c_uint; 2usize],
-    pub __g_size: [::std::os::raw::c_uint; 2usize],
-    pub __g1_orig_size: ::std::os::raw::c_uint,
-    pub __wrefs: ::std::os::raw::c_uint,
-    pub __g_signals: [::std::os::raw::c_uint; 2usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __pthread_cond_s__bindgen_ty_1 {
-    pub __wseq: ::std::os::raw::c_ulonglong,
-    pub __wseq32: __pthread_cond_s__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_cond_s__bindgen_ty_1__bindgen_ty_1 {
-    pub __low: ::std::os::raw::c_uint,
-    pub __high: ::std::os::raw::c_uint,
-}
-impl Default for __pthread_cond_s__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __pthread_cond_s__bindgen_ty_2 {
-    pub __g1_start: ::std::os::raw::c_ulonglong,
-    pub __g1_start32: __pthread_cond_s__bindgen_ty_2__bindgen_ty_1,
-    _bindgen_union_align: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_cond_s__bindgen_ty_2__bindgen_ty_1 {
-    pub __low: ::std::os::raw::c_uint,
-    pub __high: ::std::os::raw::c_uint,
-}
-impl Default for __pthread_cond_s__bindgen_ty_2 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for __pthread_cond_s {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
-}
-pub type pthread_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_mutexattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_mutexattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_condattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_condattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type pthread_key_t = ::std::os::raw::c_uint;
-pub type pthread_once_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_attr_t {
-    pub __size: [::std::os::raw::c_char; 56usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 7usize],
-}
-impl Default for pthread_attr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_mutex_t {
-    pub __data: __pthread_mutex_s,
-    pub __size: [::std::os::raw::c_char; 40usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 5usize],
-}
-impl Default for pthread_mutex_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_cond_t {
-    pub __data: __pthread_cond_s,
-    pub __size: [::std::os::raw::c_char; 48usize],
-    pub __align: ::std::os::raw::c_longlong,
-    _bindgen_union_align: [u64; 6usize],
-}
-impl Default for pthread_cond_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_rwlock_t {
-    pub __data: __pthread_rwlock_arch_t,
-    pub __size: [::std::os::raw::c_char; 56usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 7usize],
-}
-impl Default for pthread_rwlock_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_rwlockattr_t {
-    pub __size: [::std::os::raw::c_char; 8usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: u64,
-}
-impl Default for pthread_rwlockattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type pthread_spinlock_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_barrier_t {
-    pub __size: [::std::os::raw::c_char; 32usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 4usize],
-}
-impl Default for pthread_barrier_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_barrierattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_barrierattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom(__seed: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn initstate(
-        __seed: ::std::os::raw::c_uint,
-        __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct random_data {
-    pub fptr: *mut i32,
-    pub rptr: *mut i32,
-    pub state: *mut i32,
-    pub rand_type: ::std::os::raw::c_int,
-    pub rand_deg: ::std::os::raw::c_int,
-    pub rand_sep: ::std::os::raw::c_int,
-    pub end_ptr: *mut i32,
-}
-impl Default for random_data {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom_r(
-        __seed: ::std::os::raw::c_uint,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn initstate_r(
-        __seed: ::std::os::raw::c_uint,
-        __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: usize,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate_r(
-        __statebuf: *mut ::std::os::raw::c_char,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand(__seed: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48(__seedval: ::std::os::raw::c_long);
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct drand48_data {
-    pub __x: [::std::os::raw::c_ushort; 3usize],
-    pub __old_x: [::std::os::raw::c_ushort; 3usize],
-    pub __c: ::std::os::raw::c_ushort,
-    pub __init: ::std::os::raw::c_ushort,
-    pub __a: ::std::os::raw::c_ulonglong,
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut f64,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48_r(
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48_r(
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48_r(
-        __seedval: ::std::os::raw::c_long,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48_r(
-        __seed16v: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48_r(
-        __param: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
+    pub static mut __mb_cur_max: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -4258,9 +6058,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn calloc(
-        __nmemb: ::std::os::raw::c_ulong,
+        __count: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4271,23 +6075,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn reallocarray(
-        __ptr: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
-    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -4299,247 +6091,74 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
     pub fn abort();
 }
 #[pg_guard]
 extern "C" {
-    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn at_quick_exit(
-        __func: ::std::option::Option<unsafe extern "C" fn()>,
-    ) -> ::std::os::raw::c_int;
+    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn on_exit(
-        __func: ::std::option::Option<
-            unsafe extern "C" fn(
-                __status: ::std::os::raw::c_int,
-                __arg: *mut ::std::os::raw::c_void,
-            ),
-        >,
-        __arg: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
+    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exit(__status: ::std::os::raw::c_int);
+    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn quick_exit(__status: ::std::os::raw::c_int);
+    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _Exit(__status: ::std::os::raw::c_int);
+    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
 }
-#[pg_guard]
-extern "C" {
-    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __replace: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn clearenv() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemps(
-        __template: *mut ::std::os::raw::c_char,
-        __suffixlen: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn realpath(
-        __name: *const ::std::os::raw::c_char,
-        __resolved: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-pub type __compar_fn_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int,
->;
 #[pg_guard]
 extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-        __compar: __compar_fn_t,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-        __compar: __compar_fn_t,
-    );
+    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn exit(arg1: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
+    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
+    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lldiv(
-        __numer: ::std::os::raw::c_longlong,
-        __denom: ::std::os::raw::c_longlong,
-    ) -> lldiv_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gcvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qecvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qfcvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qgcvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt_r(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt_r(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qecvt_r(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qfcvt_r(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
 }
 #[pg_guard]
 extern "C" {
@@ -4547,70 +6166,594 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
     pub fn mbtowc(
-        __pwc: *mut wchar_t,
-        __s: *const ::std::os::raw::c_char,
-        __n: usize,
+        arg1: *mut wchar_t,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn rand() -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
+    pub fn srand(arg1: ::std::os::raw::c_uint);
 }
 #[pg_guard]
 extern "C" {
-    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn strtod(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtof(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtol(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtold(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoll(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoul(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoull(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _Exit(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gcvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn getsubopt(
-        __optionp: *mut *mut ::std::os::raw::c_char,
-        __tokens: *const *mut ::std::os::raw::c_char,
-        __valuep: *mut *mut ::std::os::raw::c_char,
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const *mut ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
+    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memcpy(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+    pub fn initstate(
+        arg1: ::std::os::raw::c_uint,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ptsname_r(
+        fildes: ::std::os::raw::c_int,
+        buffer: *mut ::std::os::raw::c_char,
+        buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn random() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
+    pub fn realpath(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setenv(
+        __name: *const ::std::os::raw::c_char,
+        __value: *const ::std::os::raw::c_char,
+        __overwrite: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setkey(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48(arg1: ::std::os::raw::c_long);
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom(arg1: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+pub type dev_t = __darwin_dev_t;
+pub type mode_t = __darwin_mode_t;
+#[pg_guard]
+extern "C" {
+    pub fn arc4random() -> u32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_stir();
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bsearch_b(
+        __key: *const ::std::os::raw::c_void,
+        __base: *const ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmove(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+    pub fn cgetcap(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetclose() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetent(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+        arg3: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetfirst(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetmatch(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetnext(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetnum(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetstr(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetustr(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_daemon$1050"]
+    pub fn daemon(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn devname_r(
+        arg1: dev_t,
+        arg2: mode_t,
+        buf: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getbsize(
+        arg1: *mut ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_long,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprogname() -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn heapsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn heapsort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mergesort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mergesort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort_r(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        arg1: *mut ::std::os::raw::c_void,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+                arg3: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn qsort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn qsort_r(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        arg1: *mut ::std::os::raw::c_void,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+                arg3: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn radixsort(
+        __base: *mut *const ::std::os::raw::c_uchar,
+        __nel: ::std::os::raw::c_int,
+        __table: *const ::std::os::raw::c_uchar,
+        __endbyte: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sradixsort(
+        __base: *mut *const ::std::os::raw::c_uchar,
+        __nel: ::std::os::raw::c_int,
+        __table: *const ::std::os::raw::c_uchar,
+        __endbyte: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sranddev();
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandomdev();
+}
+#[pg_guard]
+extern "C" {
+    pub fn reallocf(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memccpy(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __n: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn strtonum(
+        __numstr: *const ::std::os::raw::c_char,
+        __minval: ::std::os::raw::c_longlong,
+        __maxval: ::std::os::raw::c_longlong,
+        __errstrp: *mut *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memset(
-        __s: *mut ::std::os::raw::c_void,
+    pub fn strtoq(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtouq(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut suboptarg: *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -4625,114 +6768,33 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
+    pub fn memcpy(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn memmove(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __len: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn memset(
+        __b: *mut ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __len: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
     pub fn strcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcmp(
-        __s1: *const ::std::os::raw::c_char,
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncmp(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strxfrm(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __locale_struct {
-    pub __locales: [*mut __locale_data; 13usize],
-    pub __ctype_b: *const ::std::os::raw::c_ushort,
-    pub __ctype_tolower: *const ::std::os::raw::c_int,
-    pub __ctype_toupper: *const ::std::os::raw::c_int,
-    pub __names: [*const ::std::os::raw::c_char; 13usize],
-}
-impl Default for __locale_struct {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __locale_t = *mut __locale_struct;
-pub type locale_t = __locale_t;
-#[pg_guard]
-extern "C" {
-    pub fn strcoll_l(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __l: locale_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strxfrm_l(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: usize,
-        __l: locale_t,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strndup(
-        __string: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -4744,69 +6806,31 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strrchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strcmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strcspn(
         __s: *const ::std::os::raw::c_char,
-        __reject: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strspn(
-        __s: *const ::std::os::raw::c_char,
-        __accept: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strpbrk(
-        __s: *const ::std::os::raw::c_char,
-        __accept: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strstr(
-        __haystack: *const ::std::os::raw::c_char,
-        __needle: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtok(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __strtok_r(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-        __save_ptr: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtok_r(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-        __save_ptr: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
@@ -4814,76 +6838,19 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}__xpg_strerror_r"]
-    pub fn strerror_r(
-        __errnum: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strerror_l(
-        __errnum: ::std::os::raw::c_int,
-        __l: locale_t,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcmp(
-        __s1: *const ::std::os::raw::c_void,
-        __s2: *const ::std::os::raw::c_void,
-        __n: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcopy(
-        __src: *const ::std::os::raw::c_void,
-        __dest: *mut ::std::os::raw::c_void,
-        __n: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
-}
-#[pg_guard]
-extern "C" {
-    pub fn index(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rindex(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcasecmp(
-        __s1: *const ::std::os::raw::c_char,
+    pub fn strncat(
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncasecmp(
+    pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
@@ -4891,24 +6858,192 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcasecmp_l(
-        __s1: *const ::std::os::raw::c_char,
+    pub fn strncpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strrchr(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strstr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtok(
+        __str: *mut ::std::os::raw::c_char,
+        __sep: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm(
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-        __loc: locale_t,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtok_r(
+        __str: *mut ::std::os::raw::c_char,
+        __sep: *const ::std::os::raw::c_char,
+        __lasts: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strerror_r(
+        __errnum: ::std::os::raw::c_int,
+        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncasecmp_l(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: usize,
-        __loc: locale_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+    pub fn memccpy(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn stpcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn stpncpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strndup(
+        __s1: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+pub type rsize_t = __darwin_size_t;
+pub type errno_t = ::std::os::raw::c_int;
+#[pg_guard]
+extern "C" {
+    pub fn memset_s(
+        __s: *mut ::std::os::raw::c_void,
+        __smax: rsize_t,
+        __c: ::std::os::raw::c_int,
+        __n: rsize_t,
+    ) -> errno_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memmem(
+        __big: *const ::std::os::raw::c_void,
+        __big_len: usize,
+        __little: *const ::std::os::raw::c_void,
+        __little_len: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern4(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern4: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern8(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern8: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern16(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern16: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcasestr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnstr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+        __len: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dst: *mut ::std::os::raw::c_char,
+        __source: *const ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __source: *const ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
@@ -4919,67 +7054,158 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+    pub fn swab(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: isize,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn __stpcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
+    pub fn timingsafe_bcmp(
+        __b1: *const ::std::os::raw::c_void,
+        __b2: *const ::std::os::raw::c_void,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strsignal_r(
+        __sig: ::std::os::raw::c_int,
+        __strsignalbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcmp(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcopy(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
+}
+#[pg_guard]
+extern "C" {
+    pub fn index(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
+    pub fn rindex(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __stpncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: usize,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn strcasecmp(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
 }
+#[pg_guard]
+extern "C" {
+    pub fn strncasecmp(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+pub type max_align_t = u128;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type u_char = ::std::os::raw::c_uchar;
+pub type u_short = ::std::os::raw::c_ushort;
+pub type u_int = ::std::os::raw::c_uint;
+pub type u_long = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_quad_t = u_int64_t;
+pub type quad_t = i64;
+pub type qaddr_t = *mut quad_t;
+pub type caddr_t = *mut ::std::os::raw::c_char;
+pub type daddr_t = i32;
+pub type fixpt_t = u_int32_t;
+pub type blkcnt_t = __darwin_blkcnt_t;
+pub type blksize_t = __darwin_blksize_t;
+pub type gid_t = __darwin_gid_t;
+pub type in_addr_t = __uint32_t;
+pub type in_port_t = __uint16_t;
+pub type ino_t = __darwin_ino_t;
+pub type ino64_t = __darwin_ino64_t;
+pub type key_t = __int32_t;
+pub type nlink_t = __uint16_t;
+pub type segsz_t = i32;
+pub type swblk_t = i32;
+pub type clock_t = __darwin_clock_t;
+pub type time_t = __darwin_time_t;
+pub type useconds_t = __darwin_useconds_t;
+pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
-#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct max_align_t {
-    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
-    pub __bindgen_padding_0: u64,
-    pub __clang_max_align_nonce2: u128,
+pub struct fd_set {
+    pub fds_bits: [__int32_t; 32usize],
 }
-pub type int_least8_t = __int_least8_t;
-pub type int_least16_t = __int_least16_t;
-pub type int_least32_t = __int_least32_t;
-pub type int_least64_t = __int_least64_t;
-pub type uint_least8_t = __uint_least8_t;
-pub type uint_least16_t = __uint_least16_t;
-pub type uint_least32_t = __uint_least32_t;
-pub type uint_least64_t = __uint_least64_t;
-pub type int_fast8_t = ::std::os::raw::c_schar;
-pub type int_fast16_t = ::std::os::raw::c_long;
-pub type int_fast32_t = ::std::os::raw::c_long;
-pub type int_fast64_t = ::std::os::raw::c_long;
-pub type uint_fast8_t = ::std::os::raw::c_uchar;
-pub type uint_fast16_t = ::std::os::raw::c_ulong;
-pub type uint_fast32_t = ::std::os::raw::c_ulong;
-pub type uint_fast64_t = ::std::os::raw::c_ulong;
-pub type intmax_t = __intmax_t;
-pub type uintmax_t = __uintmax_t;
 #[pg_guard]
 extern "C" {
-    pub fn __errno_location() -> *mut ::std::os::raw::c_int;
+    pub fn __darwin_check_fd_set_overflow(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fd_mask = __int32_t;
+pub type pthread_cond_t = __darwin_pthread_cond_t;
+pub type pthread_condattr_t = __darwin_pthread_condattr_t;
+pub type pthread_mutex_t = __darwin_pthread_mutex_t;
+pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
+pub type pthread_once_t = __darwin_pthread_once_t;
+pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
+pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
+pub type pthread_t = __darwin_pthread_t;
+pub type pthread_key_t = __darwin_pthread_key_t;
+pub type fsblkcnt_t = __darwin_fsblkcnt_t;
+pub type fsfilcnt_t = __darwin_fsfilcnt_t;
+#[pg_guard]
+extern "C" {
+    pub fn __error() -> *mut ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5003,8 +7229,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_p_sep_by_space: ::std::os::raw::c_char,
     pub int_n_cs_precedes: ::std::os::raw::c_char,
+    pub int_p_sep_by_space: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -5016,34 +7242,14 @@ impl Default for lconv {
 }
 #[pg_guard]
 extern "C" {
-    pub fn setlocale(
-        __category: ::std::os::raw::c_int,
-        __locale: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
     pub fn localeconv() -> *mut lconv;
 }
 #[pg_guard]
 extern "C" {
-    pub fn newlocale(
-        __category_mask: ::std::os::raw::c_int,
-        __locale: *const ::std::os::raw::c_char,
-        __base: locale_t,
-    ) -> locale_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn duplocale(__dataset: locale_t) -> locale_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freelocale(__dataset: locale_t);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uselocale(__dataset: locale_t) -> locale_t;
+    pub fn setlocale(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
 pub type int8 = ::std::os::raw::c_schar;
@@ -5136,7 +7342,6 @@ pub union PGAlignedBlock {
     pub data: [::std::os::raw::c_char; 8192usize],
     pub force_align_d: f64,
     pub force_align_i64: int64,
-    _bindgen_union_align: [u64; 1024usize],
 }
 impl Default for PGAlignedBlock {
     fn default() -> Self {
@@ -5149,174 +7354,121 @@ pub union PGAlignedXLogBlock {
     pub data: [::std::os::raw::c_char; 8192usize],
     pub force_align_d: f64,
     pub force_align_i64: int64,
-    _bindgen_union_align: [u64; 1024usize],
 }
 impl Default for PGAlignedXLogBlock {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub const _ISupper: ::std::os::raw::c_uint = 256;
-pub const _ISlower: ::std::os::raw::c_uint = 512;
-pub const _ISalpha: ::std::os::raw::c_uint = 1024;
-pub const _ISdigit: ::std::os::raw::c_uint = 2048;
-pub const _ISxdigit: ::std::os::raw::c_uint = 4096;
-pub const _ISspace: ::std::os::raw::c_uint = 8192;
-pub const _ISprint: ::std::os::raw::c_uint = 16384;
-pub const _ISgraph: ::std::os::raw::c_uint = 32768;
-pub const _ISblank: ::std::os::raw::c_uint = 1;
-pub const _IScntrl: ::std::os::raw::c_uint = 2;
-pub const _ISpunct: ::std::os::raw::c_uint = 4;
-pub const _ISalnum: ::std::os::raw::c_uint = 8;
-pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
+    pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+pub type wint_t = __darwin_wint_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _RuneEntry {
+    pub __min: __darwin_rune_t,
+    pub __max: __darwin_rune_t,
+    pub __map: __darwin_rune_t,
+    pub __types: *mut __uint32_t,
+}
+impl Default for _RuneEntry {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _RuneRange {
+    pub __nranges: ::std::os::raw::c_int,
+    pub __ranges: *mut _RuneEntry,
+}
+impl Default for _RuneRange {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _RuneCharClass {
+    pub __name: [::std::os::raw::c_char; 14usize],
+    pub __mask: __uint32_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _RuneLocale {
+    pub __magic: [::std::os::raw::c_char; 8usize],
+    pub __encoding: [::std::os::raw::c_char; 32usize],
+    pub __sgetrune: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *const ::std::os::raw::c_char,
+            arg2: __darwin_size_t,
+            arg3: *mut *const ::std::os::raw::c_char,
+        ) -> __darwin_rune_t,
+    >,
+    pub __sputrune: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: __darwin_rune_t,
+            arg2: *mut ::std::os::raw::c_char,
+            arg3: __darwin_size_t,
+            arg4: *mut *mut ::std::os::raw::c_char,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub __invalid_rune: __darwin_rune_t,
+    pub __runetype: [__uint32_t; 256usize],
+    pub __maplower: [__darwin_rune_t; 256usize],
+    pub __mapupper: [__darwin_rune_t; 256usize],
+    pub __runetype_ext: _RuneRange,
+    pub __maplower_ext: _RuneRange,
+    pub __mapupper_ext: _RuneRange,
+    pub __variable: *mut ::std::os::raw::c_void,
+    pub __variable_len: ::std::os::raw::c_int,
+    pub __ncharclasses: ::std::os::raw::c_int,
+    pub __charclasses: *mut _RuneCharClass,
+}
+impl Default for _RuneLocale {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
+    pub static mut _DefaultRuneLocale: _RuneLocale;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
+    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __maskrune(
+        arg1: __darwin_ct_rune_t,
+        arg2: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
-#[pg_guard]
-extern "C" {
-    pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
+pub type socklen_t = __darwin_socklen_t;
+pub type sa_family_t = __uint8_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -5328,131 +7480,23 @@ impl Default for iovec {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type socklen_t = __socklen_t;
-pub const __socket_type_SOCK_STREAM: __socket_type = 1;
-pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
-pub const __socket_type_SOCK_RAW: __socket_type = 3;
-pub const __socket_type_SOCK_RDM: __socket_type = 4;
-pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
-pub const __socket_type_SOCK_DCCP: __socket_type = 6;
-pub const __socket_type_SOCK_PACKET: __socket_type = 10;
-pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
-pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
-pub type __socket_type = ::std::os::raw::c_uint;
-pub type sa_family_t = ::std::os::raw::c_ushort;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr {
-    pub sa_family: sa_family_t,
-    pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_storage {
-    pub ss_family: sa_family_t,
-    pub __ss_padding: [::std::os::raw::c_char; 118usize],
-    pub __ss_align: ::std::os::raw::c_ulong,
-}
-impl Default for sockaddr_storage {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub const MSG_OOB: ::std::os::raw::c_uint = 1;
-pub const MSG_PEEK: ::std::os::raw::c_uint = 2;
-pub const MSG_DONTROUTE: ::std::os::raw::c_uint = 4;
-pub const MSG_CTRUNC: ::std::os::raw::c_uint = 8;
-pub const MSG_PROXY: ::std::os::raw::c_uint = 16;
-pub const MSG_TRUNC: ::std::os::raw::c_uint = 32;
-pub const MSG_DONTWAIT: ::std::os::raw::c_uint = 64;
-pub const MSG_EOR: ::std::os::raw::c_uint = 128;
-pub const MSG_WAITALL: ::std::os::raw::c_uint = 256;
-pub const MSG_FIN: ::std::os::raw::c_uint = 512;
-pub const MSG_SYN: ::std::os::raw::c_uint = 1024;
-pub const MSG_CONFIRM: ::std::os::raw::c_uint = 2048;
-pub const MSG_RST: ::std::os::raw::c_uint = 4096;
-pub const MSG_ERRQUEUE: ::std::os::raw::c_uint = 8192;
-pub const MSG_NOSIGNAL: ::std::os::raw::c_uint = 16384;
-pub const MSG_MORE: ::std::os::raw::c_uint = 32768;
-pub const MSG_WAITFORONE: ::std::os::raw::c_uint = 65536;
-pub const MSG_BATCH: ::std::os::raw::c_uint = 262144;
-pub const MSG_ZEROCOPY: ::std::os::raw::c_uint = 67108864;
-pub const MSG_FASTOPEN: ::std::os::raw::c_uint = 536870912;
-pub const MSG_CMSG_CLOEXEC: ::std::os::raw::c_uint = 1073741824;
-pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
+pub type sae_associd_t = __uint32_t;
+pub type sae_connid_t = __uint32_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct msghdr {
-    pub msg_name: *mut ::std::os::raw::c_void,
-    pub msg_namelen: socklen_t,
-    pub msg_iov: *mut iovec,
-    pub msg_iovlen: usize,
-    pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: usize,
-    pub msg_flags: ::std::os::raw::c_int,
+pub struct sa_endpoints {
+    pub sae_srcif: ::std::os::raw::c_uint,
+    pub sae_srcaddr: *const sockaddr,
+    pub sae_srcaddrlen: socklen_t,
+    pub sae_dstaddr: *const sockaddr,
+    pub sae_dstaddrlen: socklen_t,
 }
-impl Default for msghdr {
+impl Default for sa_endpoints {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct cmsghdr {
-    pub cmsg_len: usize,
-    pub cmsg_level: ::std::os::raw::c_int,
-    pub cmsg_type: ::std::os::raw::c_int,
-    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
-}
-pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
-pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __kernel_fd_set {
-    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
-}
-pub type __kernel_sighandler_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
-pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = __kernel_ulong_t;
-pub type __kernel_ssize_t = __kernel_long_t;
-pub type __kernel_ptrdiff_t = __kernel_long_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __kernel_fsid_t {
-    pub val: [::std::os::raw::c_int; 2usize],
-}
-pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
-pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
-pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type sa_endpoints_t = sa_endpoints;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct linger {
@@ -5461,175 +7505,273 @@ pub struct linger {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct osockaddr {
-    pub sa_family: ::std::os::raw::c_ushort,
-    pub sa_data: [::std::os::raw::c_uchar; 14usize],
+pub struct so_np_extensions {
+    pub npx_flags: u_int32_t,
+    pub npx_mask: u_int32_t,
 }
-pub const SHUT_RD: ::std::os::raw::c_uint = 0;
-pub const SHUT_WR: ::std::os::raw::c_uint = 1;
-pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
-pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr {
+    pub sa_len: __uint8_t,
+    pub sa_family: sa_family_t,
+    pub sa_data: [::std::os::raw::c_char; 14usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockproto {
+    pub sp_family: __uint16_t,
+    pub sp_protocol: __uint16_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_storage {
+    pub ss_len: __uint8_t,
+    pub ss_family: sa_family_t,
+    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
+    pub __ss_align: __int64_t,
+    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+}
+impl Default for sockaddr_storage {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct msghdr {
+    pub msg_name: *mut ::std::os::raw::c_void,
+    pub msg_namelen: socklen_t,
+    pub msg_iov: *mut iovec,
+    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_control: *mut ::std::os::raw::c_void,
+    pub msg_controllen: socklen_t,
+    pub msg_flags: ::std::os::raw::c_int,
+}
+impl Default for msghdr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct cmsghdr {
+    pub cmsg_len: socklen_t,
+    pub cmsg_level: ::std::os::raw::c_int,
+    pub cmsg_type: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sf_hdtr {
+    pub headers: *mut iovec,
+    pub hdr_cnt: ::std::os::raw::c_int,
+    pub trailers: *mut iovec,
+    pub trl_cnt: ::std::os::raw::c_int,
+}
+impl Default for sf_hdtr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[pg_guard]
 extern "C" {
-    pub fn socket(
-        __domain: ::std::os::raw::c_int,
-        __type: ::std::os::raw::c_int,
-        __protocol: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn socketpair(
-        __domain: ::std::os::raw::c_int,
-        __type: ::std::os::raw::c_int,
-        __protocol: ::std::os::raw::c_int,
-        __fds: *mut ::std::os::raw::c_int,
+    pub fn accept(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn bind(
-        __fd: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __len: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockname(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sockaddr,
+        arg3: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn connect(
-        __fd: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __len: socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sockaddr,
+        arg3: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn getpeername(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn send(
-        __fd: ::std::os::raw::c_int,
-        __buf: *const ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-    ) -> isize;
+    pub fn getsockname(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsockopt(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_void,
+        arg5: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn listen(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn recv(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendto(
-        __fd: ::std::os::raw::c_int,
-        __buf: *const ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __addr_len: socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn recvfrom(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __addr_len: *mut socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendmsg(
-        __fd: ::std::os::raw::c_int,
-        __message: *const msghdr,
-        __flags: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+        arg5: *mut sockaddr,
+        arg6: *mut socklen_t,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn recvmsg(
-        __fd: ::std::os::raw::c_int,
-        __message: *mut msghdr,
-        __flags: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut msghdr,
+        arg3: ::std::os::raw::c_int,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getsockopt(
-        __fd: ::std::os::raw::c_int,
-        __level: ::std::os::raw::c_int,
-        __optname: ::std::os::raw::c_int,
-        __optval: *mut ::std::os::raw::c_void,
-        __optlen: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn send(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendmsg(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const msghdr,
+        arg3: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendto(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+        arg5: *const sockaddr,
+        arg6: socklen_t,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn setsockopt(
-        __fd: ::std::os::raw::c_int,
-        __level: ::std::os::raw::c_int,
-        __optname: ::std::os::raw::c_int,
-        __optval: *const ::std::os::raw::c_void,
-        __optlen: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn accept(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __addr_len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_void,
+        arg5: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn shutdown(
-        __fd: ::std::os::raw::c_int,
-        __how: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isfdtype(
-        __fd: ::std::os::raw::c_int,
-        __fdtype: ::std::os::raw::c_int,
+    pub fn socket(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
-pub type in_addr_t = u32;
+#[pg_guard]
+extern "C" {
+    pub fn socketpair(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendfile(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: off_t,
+        arg4: *mut off_t,
+        arg5: *mut sf_hdtr,
+        arg6: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
+}
+#[pg_guard]
+extern "C" {
+    pub fn connectx(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sa_endpoints_t,
+        arg3: sae_associd_t,
+        arg4: ::std::os::raw::c_uint,
+        arg5: *const iovec,
+        arg6: ::std::os::raw::c_uint,
+        arg7: *mut usize,
+        arg8: *mut sae_connid_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn disconnectx(
+        arg1: ::std::os::raw::c_int,
+        arg2: sae_associd_t,
+        arg3: sae_connid_t,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_len: __uint8_t,
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5644,6 +7786,12 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -5651,88 +7799,113 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_sourceaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
+}
+impl Default for group_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
+}
+impl Default for group_source_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct __msfilterreq {
+    pub msfr_ifindex: u32,
+    pub msfr_fmode: u32,
+    pub msfr_nsrcs: u32,
+    pub __msfr_align: u32,
+    pub msfr_group: sockaddr_storage,
+    pub msfr_srcs: *mut sockaddr_storage,
+}
+impl Default for __msfilterreq {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setipv4sourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: in_addr,
+        arg3: in_addr,
+        arg4: u32,
+        arg5: u32,
+        arg6: *mut in_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipv4sourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: in_addr,
+        arg3: in_addr,
+        arg4: *mut u32,
+        arg5: *mut u32,
+        arg6: *mut in_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setsourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: u32,
+        arg3: *mut sockaddr,
+        arg4: socklen_t,
+        arg5: u32,
+        arg6: u32,
+        arg7: *mut sockaddr_storage,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: u32,
+        arg3: *mut sockaddr,
+        arg4: socklen_t,
+        arg5: *mut u32,
+        arg6: *mut u32,
+        arg7: *mut sockaddr_storage,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_int,
+    pub ipi_ifindex: ::std::os::raw::c_uint,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
-pub const IPPROTO_IP: ::std::os::raw::c_uint = 0;
-pub const IPPROTO_ICMP: ::std::os::raw::c_uint = 1;
-pub const IPPROTO_IGMP: ::std::os::raw::c_uint = 2;
-pub const IPPROTO_IPIP: ::std::os::raw::c_uint = 4;
-pub const IPPROTO_TCP: ::std::os::raw::c_uint = 6;
-pub const IPPROTO_EGP: ::std::os::raw::c_uint = 8;
-pub const IPPROTO_PUP: ::std::os::raw::c_uint = 12;
-pub const IPPROTO_UDP: ::std::os::raw::c_uint = 17;
-pub const IPPROTO_IDP: ::std::os::raw::c_uint = 22;
-pub const IPPROTO_TP: ::std::os::raw::c_uint = 29;
-pub const IPPROTO_DCCP: ::std::os::raw::c_uint = 33;
-pub const IPPROTO_IPV6: ::std::os::raw::c_uint = 41;
-pub const IPPROTO_RSVP: ::std::os::raw::c_uint = 46;
-pub const IPPROTO_GRE: ::std::os::raw::c_uint = 47;
-pub const IPPROTO_ESP: ::std::os::raw::c_uint = 50;
-pub const IPPROTO_AH: ::std::os::raw::c_uint = 51;
-pub const IPPROTO_MTP: ::std::os::raw::c_uint = 92;
-pub const IPPROTO_BEETPH: ::std::os::raw::c_uint = 94;
-pub const IPPROTO_ENCAP: ::std::os::raw::c_uint = 98;
-pub const IPPROTO_PIM: ::std::os::raw::c_uint = 103;
-pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
-pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
-pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
-pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
-pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
-pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
-pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
-pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
-pub const IPPROTO_FRAGMENT: ::std::os::raw::c_uint = 44;
-pub const IPPROTO_ICMPV6: ::std::os::raw::c_uint = 58;
-pub const IPPROTO_NONE: ::std::os::raw::c_uint = 59;
-pub const IPPROTO_DSTOPTS: ::std::os::raw::c_uint = 60;
-pub const IPPROTO_MH: ::std::os::raw::c_uint = 135;
-pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
-pub type in_port_t = u16;
-pub const IPPORT_ECHO: ::std::os::raw::c_uint = 7;
-pub const IPPORT_DISCARD: ::std::os::raw::c_uint = 9;
-pub const IPPORT_SYSTAT: ::std::os::raw::c_uint = 11;
-pub const IPPORT_DAYTIME: ::std::os::raw::c_uint = 13;
-pub const IPPORT_NETSTAT: ::std::os::raw::c_uint = 15;
-pub const IPPORT_FTP: ::std::os::raw::c_uint = 21;
-pub const IPPORT_TELNET: ::std::os::raw::c_uint = 23;
-pub const IPPORT_SMTP: ::std::os::raw::c_uint = 25;
-pub const IPPORT_TIMESERVER: ::std::os::raw::c_uint = 37;
-pub const IPPORT_NAMESERVER: ::std::os::raw::c_uint = 42;
-pub const IPPORT_WHOIS: ::std::os::raw::c_uint = 43;
-pub const IPPORT_MTP: ::std::os::raw::c_uint = 57;
-pub const IPPORT_TFTP: ::std::os::raw::c_uint = 69;
-pub const IPPORT_RJE: ::std::os::raw::c_uint = 77;
-pub const IPPORT_FINGER: ::std::os::raw::c_uint = 79;
-pub const IPPORT_TTYLINK: ::std::os::raw::c_uint = 87;
-pub const IPPORT_SUPDUP: ::std::os::raw::c_uint = 95;
-pub const IPPORT_EXECSERVER: ::std::os::raw::c_uint = 512;
-pub const IPPORT_LOGINSERVER: ::std::os::raw::c_uint = 513;
-pub const IPPORT_CMDSERVER: ::std::os::raw::c_uint = 514;
-pub const IPPORT_EFSSERVER: ::std::os::raw::c_uint = 520;
-pub const IPPORT_BIFFUDP: ::std::os::raw::c_uint = 512;
-pub const IPPORT_WHOSERVER: ::std::os::raw::c_uint = 513;
-pub const IPPORT_ROUTESERVER: ::std::os::raw::c_uint = 520;
-pub const IPPORT_RESERVED: ::std::os::raw::c_uint = 1024;
-pub const IPPORT_USERRESERVED: ::std::os::raw::c_uint = 5000;
-pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __in6_u: in6_addr__bindgen_ty_1,
+    pub __u6_addr: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [u8; 16usize],
-    pub __u6_addr16: [u16; 8usize],
-    pub __u6_addr32: [u32; 4usize],
-    _bindgen_union_align: [u32; 4usize],
+    pub __u6_addr8: [__uint8_t; 16usize],
+    pub __u6_addr16: [__uint16_t; 8usize],
+    pub __u6_addr32: [__uint32_t; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -5740,6 +7913,22 @@ impl Default for in6_addr__bindgen_ty_1 {
     }
 }
 impl Default for in6_addr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type in6_addr_t = in6_addr;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_len: __uint8_t,
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: __uint32_t,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: __uint32_t,
+}
+impl Default for sockaddr_in6 {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
@@ -5752,40 +7941,21 @@ extern "C" {
 extern "C" {
     pub static in6addr_loopback: in6_addr;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+#[pg_guard]
+extern "C" {
+    pub static in6addr_nodelocal_allnodes: in6_addr;
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_in6 {
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: u32,
-    pub sin6_addr: in6_addr,
-    pub sin6_scope_id: u32,
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allnodes: in6_addr;
 }
-impl Default for sockaddr_in6 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allrouters: in6_addr;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-    pub imr_sourceaddr: in_addr,
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allv2routers: in6_addr;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5800,165 +7970,234 @@ impl Default for ipv6_mreq {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
+pub struct in6_pktinfo {
+    pub ipi6_addr: in6_addr,
+    pub ipi6_ifindex: ::std::os::raw::c_uint,
 }
-impl Default for group_req {
+impl Default for in6_pktinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
+pub struct ip6_mtuinfo {
+    pub ip6m_addr: sockaddr_in6,
+    pub ip6m_mtu: u32,
 }
-impl Default for group_source_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_msfilter {
-    pub imsf_multiaddr: in_addr,
-    pub imsf_interface: in_addr,
-    pub imsf_fmode: u32,
-    pub imsf_numsrc: u32,
-    pub imsf_slist: [in_addr; 1usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct group_filter {
-    pub gf_interface: u32,
-    pub gf_group: sockaddr_storage,
-    pub gf_fmode: u32,
-    pub gf_numsrc: u32,
-    pub gf_slist: [sockaddr_storage; 1usize],
-}
-impl Default for group_filter {
+impl Default for ip6_mtuinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn ntohl(__netlong: u32) -> u32;
+    pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ntohs(__netshort: u16) -> u16;
+    pub fn inet6_option_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *mut *mut cmsghdr,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn htonl(__hostlong: u32) -> u32;
+    pub fn inet6_option_append(
+        arg1: *mut cmsghdr,
+        arg2: *const __uint8_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn htons(__hostshort: u16) -> u16;
+    pub fn inet6_option_alloc(
+        arg1: *mut cmsghdr,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> *mut __uint8_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_option_next(
+        arg1: *const cmsghdr,
+        arg2: *mut *mut __uint8_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_option_find(
+        arg1: *const cmsghdr,
+        arg2: *mut *mut __uint8_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut cmsghdr;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_add(
+        arg1: *mut cmsghdr,
+        arg2: *const in6_addr,
+        arg3: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_lasthop(
+        arg1: *mut cmsghdr,
+        arg2: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_getaddr(arg1: *mut cmsghdr, arg2: ::std::os::raw::c_int) -> *mut in6_addr;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_getflags(
+        arg1: *const cmsghdr,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_append(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: __uint8_t,
+        arg5: socklen_t,
+        arg6: __uint8_t,
+        arg7: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_finish(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_set_val(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_next(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut __uint8_t,
+        arg5: *mut socklen_t,
+        arg6: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_find(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: __uint8_t,
+        arg5: *mut socklen_t,
+        arg6: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_get_val(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> socklen_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_add(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *const in6_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_reverse(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_getaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut in6_addr;
 }
 #[pg_guard]
 extern "C" {
     pub fn bindresvport(
-        __sockfd: ::std::os::raw::c_int,
-        __sock_in: *mut sockaddr_in,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr_in,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bindresvport6(
-        __sockfd: ::std::os::raw::c_int,
-        __sock_in: *mut sockaddr_in6,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endrpcent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent() -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
+    pub fn bindresvport_sa(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getrpcbynumber_r(
-        __number: ::std::os::raw::c_int,
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent_r(
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn herror(__str: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub static mut h_errno: ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5974,135 +8213,18 @@ impl Default for hostent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn sethostent(__stay_open: ::std::os::raw::c_int);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
 }
-#[pg_guard]
-extern "C" {
-    pub fn endhostent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent() -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr(
-        __addr: *const ::std::os::raw::c_void,
-        __len: __socklen_t,
-        __type: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2(
-        __name: *const ::std::os::raw::c_char,
-        __af: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent_r(
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr_r(
-        __addr: *const ::std::os::raw::c_void,
-        __len: __socklen_t,
-        __type: ::std::os::raw::c_int,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2_r(
-        __name: *const ::std::os::raw::c_char,
-        __af: ::std::os::raw::c_int,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent() -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent_r(
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr_r(
-        __net: u32,
-        __type: ::std::os::raw::c_int,
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+impl Default for netent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6117,63 +8239,6 @@ impl Default for servent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn setservent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endservent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent() -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname(
-        __name: *const ::std::os::raw::c_char,
-        __proto: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport(
-        __port: ::std::os::raw::c_int,
-        __proto: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent_r(
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __proto: *const ::std::os::raw::c_char,
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport_r(
-        __port: ::std::os::raw::c_int,
-        __proto: *const ::std::os::raw::c_char,
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -6186,185 +8251,6 @@ impl Default for protoent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endprotoent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent() -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent_r(
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber_r(
-        __proto: ::std::os::raw::c_int,
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetgrent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetgrent(
-        __hostp: *mut *mut ::std::os::raw::c_char,
-        __userp: *mut *mut ::std::os::raw::c_char,
-        __domainp: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn innetgr(
-        __netgroup: *const ::std::os::raw::c_char,
-        __host: *const ::std::os::raw::c_char,
-        __user: *const ::std::os::raw::c_char,
-        __domain: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetgrent_r(
-        __hostp: *mut *mut ::std::os::raw::c_char,
-        __userp: *mut *mut ::std::os::raw::c_char,
-        __domainp: *mut *mut ::std::os::raw::c_char,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rcmd(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_ushort,
-        __locuser: *const ::std::os::raw::c_char,
-        __remuser: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rcmd_af(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_ushort,
-        __locuser: *const ::std::os::raw::c_char,
-        __remuser: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rexec(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_int,
-        __name: *const ::std::os::raw::c_char,
-        __pass: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rexec_af(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_int,
-        __name: *const ::std::os::raw::c_char,
-        __pass: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ruserok(
-        __rhost: *const ::std::os::raw::c_char,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ruserok_af(
-        __rhost: *const ::std::os::raw::c_char,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iruserok(
-        __raddr: u32,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iruserok_af(
-        __raddr: *const ::std::os::raw::c_void,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rresvport_af(
-        __alport: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct addrinfo {
@@ -6373,8 +8259,8 @@ pub struct addrinfo {
     pub ai_socktype: ::std::os::raw::c_int,
     pub ai_protocol: ::std::os::raw::c_int,
     pub ai_addrlen: socklen_t,
-    pub ai_addr: *mut sockaddr,
     pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_addr: *mut sockaddr,
     pub ai_next: *mut addrinfo,
 }
 impl Default for addrinfo {
@@ -6382,50 +8268,269 @@ impl Default for addrinfo {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn endhostent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endprotoent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endservent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn freeaddrinfo(arg1: *mut addrinfo);
+}
+#[pg_guard]
+extern "C" {
+    pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
 #[pg_guard]
 extern "C" {
     pub fn getaddrinfo(
-        __name: *const ::std::os::raw::c_char,
-        __service: *const ::std::os::raw::c_char,
-        __req: *const addrinfo,
-        __pai: *mut *mut addrinfo,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *const addrinfo,
+        arg4: *mut *mut addrinfo,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn freeaddrinfo(__ai: *mut addrinfo);
+    pub fn gethostbyaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut hostent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent() -> *mut hostent;
 }
 #[pg_guard]
 extern "C" {
     pub fn getnameinfo(
-        __sa: *const sockaddr,
-        __salen: socklen_t,
-        __host: *mut ::std::os::raw::c_char,
-        __hostlen: socklen_t,
-        __serv: *mut ::std::os::raw::c_char,
-        __servlen: socklen_t,
-        __flags: ::std::os::raw::c_int,
+        arg1: *const sockaddr,
+        arg2: socklen_t,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: socklen_t,
+        arg5: *mut ::std::os::raw::c_char,
+        arg6: socklen_t,
+        arg7: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent() -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent() -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent() -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sethostent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprotoent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setservent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn freehostent(arg1: *mut hostent);
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipnodebyaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipnodebyname(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcent() -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setrpcent(stayopen: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endrpcent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn herror(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn innetgr(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *const ::std::os::raw::c_char,
+        arg4: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetgrent(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetgrent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct passwd {
     pub pw_name: *mut ::std::os::raw::c_char,
     pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: __uid_t,
-    pub pw_gid: __gid_t,
+    pub pw_uid: uid_t,
+    pub pw_gid: gid_t,
+    pub pw_change: __darwin_time_t,
+    pub pw_class: *mut ::std::os::raw::c_char,
     pub pw_gecos: *mut ::std::os::raw::c_char,
     pub pw_dir: *mut ::std::os::raw::c_char,
     pub pw_shell: *mut ::std::os::raw::c_char,
+    pub pw_expire: __darwin_time_t,
 }
 impl Default for passwd {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid(arg1: uid_t) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid_r(
+        arg1: uid_t,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam_r(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwent() -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
@@ -6435,63 +8540,86 @@ extern "C" {
 extern "C" {
     pub fn endpwent();
 }
+pub type uuid_t = __darwin_uuid_t;
+pub type uuid_string_t = __darwin_uuid_string_t;
 #[pg_guard]
 extern "C" {
-    pub fn getpwent() -> *mut passwd;
+    pub static UUID_NULL: uuid_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
+    pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
 }
 #[pg_guard]
 extern "C" {
-    pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwent_r(
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_compare(
+        uu1: *mut ::std::os::raw::c_uchar,
+        uu2: *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwuid_r(
-        __uid: __uid_t,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_early_random(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_parse(
+        in_: *mut ::std::os::raw::c_char,
+        uu: *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwnam_r(
-        __name: *const ::std::os::raw::c_char,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
-    ) -> ::std::os::raw::c_int;
+    pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpwent_r(
-        __stream: *mut FILE,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_unparse_lower(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_unparse_upper(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn user_from_uid(arg1: uid_t, arg2: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuuid_r(
+        arg1: *mut ::std::os::raw::c_uchar,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -6838,979 +8966,407 @@ extern "C" {
 extern "C" {
     pub fn pg_srand48(seed: ::std::os::raw::c_long);
 }
-#[pg_guard]
-extern "C" {
-    pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpeereid(
-        sock: ::std::os::raw::c_int,
-        uid: *mut uid_t,
-        gid: *mut gid_t,
-    ) -> ::std::os::raw::c_int;
-}
 pub type float_t = f32;
 pub type double_t = f64;
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __math_errhandling() -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
+    pub fn acosf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
+    pub fn acos(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
+    pub fn acosl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acos(__x: f64) -> f64;
+    pub fn asinf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __acos(__x: f64) -> f64;
+    pub fn asin(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asin(__x: f64) -> f64;
+    pub fn asinl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __asin(__x: f64) -> f64;
+    pub fn atanf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan(__x: f64) -> f64;
+    pub fn atan(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atan(__x: f64) -> f64;
+    pub fn atanl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2(__y: f64, __x: f64) -> f64;
+    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atan2(__y: f64, __x: f64) -> f64;
+    pub fn atan2(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cos(__x: f64) -> f64;
+    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cos(__x: f64) -> f64;
+    pub fn cosf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sin(__x: f64) -> f64;
+    pub fn cos(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sin(__x: f64) -> f64;
+    pub fn cosl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tan(__x: f64) -> f64;
+    pub fn sinf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tan(__x: f64) -> f64;
+    pub fn sin(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosh(__x: f64) -> f64;
+    pub fn sinl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cosh(__x: f64) -> f64;
+    pub fn tanf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinh(__x: f64) -> f64;
+    pub fn tan(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sinh(__x: f64) -> f64;
+    pub fn tanl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanh(__x: f64) -> f64;
+    pub fn acoshf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tanh(__x: f64) -> f64;
+    pub fn acosh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosh(__x: f64) -> f64;
+    pub fn acoshl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __acosh(__x: f64) -> f64;
+    pub fn asinhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinh(__x: f64) -> f64;
+    pub fn asinh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __asinh(__x: f64) -> f64;
+    pub fn asinhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanh(__x: f64) -> f64;
+    pub fn atanhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atanh(__x: f64) -> f64;
+    pub fn atanh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp(__x: f64) -> f64;
+    pub fn atanhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __exp(__x: f64) -> f64;
+    pub fn coshf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
+    pub fn cosh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
+    pub fn coshl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
+    pub fn sinhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
+    pub fn sinh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log(__x: f64) -> f64;
+    pub fn sinhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log(__x: f64) -> f64;
+    pub fn tanhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10(__x: f64) -> f64;
+    pub fn tanh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log10(__x: f64) -> f64;
+    pub fn tanhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
+    pub fn expf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
+    pub fn exp(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1(__x: f64) -> f64;
+    pub fn expl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __expm1(__x: f64) -> f64;
+    pub fn exp2f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1p(__x: f64) -> f64;
+    pub fn exp2(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log1p(__x: f64) -> f64;
+    pub fn exp2l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logb(__x: f64) -> f64;
+    pub fn expm1f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __logb(__x: f64) -> f64;
+    pub fn expm1(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2(__x: f64) -> f64;
+    pub fn expm1l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __exp2(__x: f64) -> f64;
+    pub fn logf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2(__x: f64) -> f64;
+    pub fn log(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log2(__x: f64) -> f64;
+    pub fn logl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pow(__x: f64, __y: f64) -> f64;
+    pub fn log10f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __pow(__x: f64, __y: f64) -> f64;
+    pub fn log10(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sqrt(__x: f64) -> f64;
+    pub fn log10l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sqrt(__x: f64) -> f64;
+    pub fn log2f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn hypot(__x: f64, __y: f64) -> f64;
+    pub fn log2(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __hypot(__x: f64, __y: f64) -> f64;
+    pub fn log2l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cbrt(__x: f64) -> f64;
+    pub fn log1pf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cbrt(__x: f64) -> f64;
+    pub fn log1p(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ceil(__x: f64) -> f64;
+    pub fn log1pl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ceil(__x: f64) -> f64;
+    pub fn logbf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fabs(__x: f64) -> f64;
+    pub fn logb(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fabs(__x: f64) -> f64;
+    pub fn logbl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn floor(__x: f64) -> f64;
+    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __floor(__x: f64) -> f64;
+    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmod(__x: f64, __y: f64) -> f64;
+    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmod(__x: f64, __y: f64) -> f64;
+    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
+    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
+    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn drem(__x: f64, __y: f64) -> f64;
+    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __drem(__x: f64, __y: f64) -> f64;
+    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn significand(__x: f64) -> f64;
+    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __significand(__x: f64) -> f64;
+    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn copysign(__x: f64, __y: f64) -> f64;
+    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __copysign(__x: f64, __y: f64) -> f64;
+    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
+    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
+    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
+    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn j0(arg1: f64) -> f64;
+    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __j0(arg1: f64) -> f64;
+    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn j1(arg1: f64) -> f64;
+    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __j1(arg1: f64) -> f64;
+    pub fn fabsf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn fabs(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn fabsl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn y0(arg1: f64) -> f64;
+    pub fn cbrtf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __y0(arg1: f64) -> f64;
+    pub fn cbrt(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn y1(arg1: f64) -> f64;
+    pub fn cbrtl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __y1(arg1: f64) -> f64;
+    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn hypot(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn erf(arg1: f64) -> f64;
+    pub fn powf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erf(arg1: f64) -> f64;
+    pub fn pow(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
+    pub fn powl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfc(arg1: f64) -> f64;
+    pub fn sqrtf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
+    pub fn sqrt(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __gamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __rint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafter(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nextafter(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttoward(__x: f64, __y: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainder(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remainder(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nearbyint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn round(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __round(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn trunc(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __trunc(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdim(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fdim(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmax(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmax(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmin(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmin(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalb(__x: f64, __n: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalb(__x: f64, __n: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atan2f(__y: f32, __x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atan2f(__y: f32, __x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn coshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __coshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acoshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acoshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log10f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log10f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expm1f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expm1f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log1pf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log1pf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logbf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logbf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn exp2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __powf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sqrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __hypotf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cbrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceilf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ceilf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fabsf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __floorf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmodf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dremf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __dremf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn significandf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __significandf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __copysignf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+    pub fn sqrtl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
@@ -7818,583 +9374,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erff(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __gammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __rintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remainderf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nearbyintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __roundf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __truncf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdimf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fdimf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fminf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbf(__x: f32, __n: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbf(__x: f32, __n: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atan2l(__y: u128, __x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atan2l(__y: u128, __x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn coshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __coshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acoshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acoshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log10l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log10l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expm1l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expm1l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log1pl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log1pl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logbl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logbl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn exp2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __powl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sqrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __hypotl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cbrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceill(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ceill(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fabsl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __floorl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmodl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dreml(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __dreml(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn significandl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __significandl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __copysignl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+    pub fn erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8402,7 +9382,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfl(arg1: u128) -> u128;
+    pub fn erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8410,7 +9394,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfcl(arg1: u128) -> u128;
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8418,7 +9406,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgammal(arg1: u128) -> u128;
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8426,209 +9418,401 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tgammal(arg1: u128) -> u128;
+    pub fn ceilf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gammal(arg1: u128) -> u128;
+    pub fn ceil(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __gammal(arg1: u128) -> u128;
+    pub fn ceill(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+    pub fn floorf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+    pub fn floor(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rintl(__x: u128) -> u128;
+    pub fn floorl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __rintl(__x: u128) -> u128;
+    pub fn nearbyintf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+    pub fn nearbyint(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+    pub fn nearbyintl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+    pub fn rintf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+    pub fn rint(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remainderl(__x: u128, __y: u128) -> u128;
+    pub fn rintl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+    pub fn roundf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+    pub fn round(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+    pub fn roundl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nearbyintl(__x: u128) -> u128;
+    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nearbyintl(__x: u128) -> u128;
+    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn roundl(__x: u128) -> u128;
+    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __roundl(__x: u128) -> u128;
+    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn truncl(__x: u128) -> u128;
+    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __truncl(__x: u128) -> u128;
+    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn truncf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn trunc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn truncl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn fmod(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn remainder(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fdiml(__x: u128, __y: u128) -> u128;
+    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fminl(__x: u128, __y: u128) -> u128;
+    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fminl(__x: u128, __y: u128) -> u128;
+    pub fn copysign(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbl(__x: u128, __n: u128) -> u128;
+    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdim(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmax(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmin(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __inff() -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __inf() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __infl() -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nan() -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp10f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp10(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cospif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cospi(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinpif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinpi(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanpif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanpi(arg1: f64) -> f64;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __float2 {
+    pub __sinval: f32,
+    pub __cosval: f32,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __double2 {
+    pub __sinval: f64,
+    pub __cosval: f64,
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincosf_stret(arg1: f32) -> __float2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincos_stret(arg1: f64) -> __double2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincospif_stret(arg1: f32) -> __float2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincospi_stret(arg1: f64) -> __double2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalb(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-pub const FP_NAN: ::std::os::raw::c_uint = 0;
-pub const FP_INFINITE: ::std::os::raw::c_uint = 1;
-pub const FP_ZERO: ::std::os::raw::c_uint = 2;
-pub const FP_SUBNORMAL: ::std::os::raw::c_uint = 3;
-pub const FP_NORMAL: ::std::os::raw::c_uint = 4;
-pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drem(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significand(arg1: f64) -> f64;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct exception {
+    pub type_: ::std::os::raw::c_int,
+    pub name: *mut ::std::os::raw::c_char,
+    pub arg1: f64,
+    pub arg2: f64,
+    pub retval: f64,
+}
+impl Default for exception {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
@@ -8750,39 +9934,28 @@ extern "C" {
         include_command_not_found: bool,
     ) -> bool;
 }
-pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __jmp_buf_tag {
-    pub __jmpbuf: __jmp_buf,
-    pub __mask_was_saved: ::std::os::raw::c_int,
-    pub __saved_mask: __sigset_t,
-}
-pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type jmp_buf = [::std::os::raw::c_int; 37usize];
+pub type sigjmp_buf = [::std::os::raw::c_int; 38usize];
 #[pg_guard]
 extern "C" {
-    pub fn setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
+    pub fn setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sigsetjmp(
-        __env: *mut __jmp_buf_tag,
-        __savemask: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn _setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
+    pub fn _setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
+    pub fn _longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn _longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
+    pub fn longjmperror();
 }
-pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
     pub fn errstart(
@@ -10478,7 +11651,6 @@ pub union ListCell__bindgen_ty_1 {
     pub ptr_value: *mut ::std::os::raw::c_void,
     pub int_value: ::std::os::raw::c_int,
     pub oid_value: Oid,
-    _bindgen_union_align: u64,
 }
 impl Default for ListCell__bindgen_ty_1 {
     fn default() -> Self {
@@ -10977,83 +12149,239 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
+    pub l_start: off_t,
+    pub l_len: off_t,
+    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
-    pub l_start: __off_t,
-    pub l_len: __off_t,
-    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct stat {
-    pub st_dev: __dev_t,
-    pub st_ino: __ino_t,
-    pub st_nlink: __nlink_t,
-    pub st_mode: __mode_t,
-    pub st_uid: __uid_t,
-    pub st_gid: __gid_t,
-    pub __pad0: ::std::os::raw::c_int,
-    pub st_rdev: __dev_t,
-    pub st_size: __off_t,
-    pub st_blksize: __blksize_t,
-    pub st_blocks: __blkcnt_t,
-    pub st_atim: timespec,
-    pub st_mtim: timespec,
-    pub st_ctim: timespec,
-    pub __glibc_reserved: [__syscall_slong_t; 3usize],
+pub struct timespec {
+    pub tv_sec: __darwin_time_t,
+    pub tv_nsec: ::std::os::raw::c_long,
 }
-#[pg_guard]
-extern "C" {
-    pub fn fcntl(
-        __fd: ::std::os::raw::c_int,
-        __cmd: ::std::os::raw::c_int,
-        ...
-    ) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct flocktimeout {
+    pub fl: flock,
+    pub timeout: timespec,
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct radvisory {
+    pub ra_offset: off_t,
+    pub ra_count: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsignatures {
+    pub fs_file_start: off_t,
+    pub fs_blob_start: *mut ::std::os::raw::c_void,
+    pub fs_blob_size: usize,
+    pub fs_fsignatures_size: usize,
+    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
+    pub fs_hash_type: ::std::os::raw::c_int,
+}
+impl Default for fsignatures {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fsignatures_t = fsignatures;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fsupplement {
+    pub fs_file_start: off_t,
+    pub fs_blob_start: off_t,
+    pub fs_blob_size: usize,
+    pub fs_orig_fd: ::std::os::raw::c_int,
+}
+pub type fsupplement_t = fsupplement;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fchecklv {
+    pub lv_file_start: off_t,
+    pub lv_error_message_size: usize,
+    pub lv_error_message: *mut ::std::os::raw::c_void,
+}
+impl Default for fchecklv {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fchecklv_t = fchecklv;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fgetsigsinfo {
+    pub fg_file_start: off_t,
+    pub fg_info_request: ::std::os::raw::c_int,
+    pub fg_sig_is_platform: ::std::os::raw::c_int,
+}
+pub type fgetsigsinfo_t = fgetsigsinfo;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fstore {
+    pub fst_flags: ::std::os::raw::c_uint,
+    pub fst_posmode: ::std::os::raw::c_int,
+    pub fst_offset: off_t,
+    pub fst_length: off_t,
+    pub fst_bytesalloc: off_t,
+}
+pub type fstore_t = fstore;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fpunchhole {
+    pub fp_flags: ::std::os::raw::c_uint,
+    pub reserved: ::std::os::raw::c_uint,
+    pub fp_offset: off_t,
+    pub fp_length: off_t,
+}
+pub type fpunchhole_t = fpunchhole;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ftrimactivefile {
+    pub fta_offset: off_t,
+    pub fta_length: off_t,
+}
+pub type ftrimactivefile_t = ftrimactivefile;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fspecread {
+    pub fsr_flags: ::std::os::raw::c_uint,
+    pub reserved: ::std::os::raw::c_uint,
+    pub fsr_offset: off_t,
+    pub fsr_length: off_t,
+}
+pub type fspecread_t = fspecread;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fbootstraptransfer {
+    pub fbt_offset: off_t,
+    pub fbt_length: usize,
+    pub fbt_buffer: *mut ::std::os::raw::c_void,
+}
+impl Default for fbootstraptransfer {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fbootstraptransfer_t = fbootstraptransfer;
+#[repr(C, packed(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct log2phys {
+    pub l2p_flags: ::std::os::raw::c_uint,
+    pub l2p_contigbytes: off_t,
+    pub l2p_devoffset: off_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _filesec {
+    _unused: [u8; 0],
+}
+pub type filesec_t = *mut _filesec;
+pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
+pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
+pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
+pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
+pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
+pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
+pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
+pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
+pub type filesec_property_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn open(
-        __file: *const ::std::os::raw::c_char,
-        __oflag: ::std::os::raw::c_int,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn openat(
-        __fd: ::std::os::raw::c_int,
-        __file: *const ::std::os::raw::c_char,
-        __oflag: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn creat(__file: *const ::std::os::raw::c_char, __mode: mode_t) -> ::std::os::raw::c_int;
+    pub fn creat(arg1: *const ::std::os::raw::c_char, arg2: mode_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lockf(
-        __fd: ::std::os::raw::c_int,
-        __cmd: ::std::os::raw::c_int,
-        __len: off_t,
+    pub fn fcntl(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix_fadvise(
-        __fd: ::std::os::raw::c_int,
-        __offset: off_t,
-        __len: off_t,
-        __advise: ::std::os::raw::c_int,
+    pub fn openx_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: filesec_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix_fallocate(
-        __fd: ::std::os::raw::c_int,
-        __offset: off_t,
-        __len: off_t,
+    pub fn open_dprotected_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flock(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_init() -> filesec_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_free(arg1: filesec_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_get_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_query_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_set_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_unset_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
     ) -> ::std::os::raw::c_int;
 }
 pub type XLogRecPtr = uint64;
@@ -11318,7 +12646,6 @@ pub struct HeapTupleFields {
 pub union HeapTupleFields__bindgen_ty_1 {
     pub t_cid: CommandId,
     pub t_xvac: TransactionId,
-    _bindgen_union_align: u32,
 }
 impl Default for HeapTupleFields__bindgen_ty_1 {
     fn default() -> Self {
@@ -11351,7 +12678,6 @@ pub struct HeapTupleHeaderData {
 pub union HeapTupleHeaderData__bindgen_ty_1 {
     pub t_heap: HeapTupleFields,
     pub t_datum: DatumTupleFields,
-    _bindgen_union_align: [u32; 3usize],
 }
 impl Default for HeapTupleHeaderData__bindgen_ty_1 {
     fn default() -> Self {
@@ -11988,115 +13314,20 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *const ::std::os::raw::c_char,
+    pub tm_zone: *mut ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct itimerspec {
-    pub it_interval: timespec,
-    pub it_value: timespec,
+#[pg_guard]
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock() -> clock_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn time(__timer: *mut time_t) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktime(__tp: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strftime(
-        __s: *mut ::std::os::raw::c_char,
-        __maxsize: usize,
-        __format: *const ::std::os::raw::c_char,
-        __tp: *const tm,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strftime_l(
-        __s: *mut ::std::os::raw::c_char,
-        __maxsize: usize,
-        __format: *const ::std::os::raw::c_char,
-        __tp: *const tm,
-        __loc: locale_t,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime(__timer: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime(__timer: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime_r(
-        __tp: *const tm,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctime_r(
-        __timer: *const time_t,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __daylight: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __timezone: ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
-}
-#[pg_guard]
-extern "C" {
-    pub fn tzset();
-}
-#[pg_guard]
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
+    pub static mut getdate_err: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -12104,23 +13335,120 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn timegm(__tp: *mut tm) -> time_t;
+    pub static mut daylight: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timelocal(__tp: *mut tm) -> time_t;
+    pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn clock() -> clock_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nanosleep(
-        __requested_time: *const timespec,
-        __remaining: *mut timespec,
-    ) -> ::std::os::raw::c_int;
+    pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
 }
+#[pg_guard]
+extern "C" {
+    pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime(arg1: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime(arg1: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktime(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strftime(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: *const ::std::os::raw::c_char,
+        arg4: *const tm,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strptime(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut tm,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn time(arg1: *mut time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tzset();
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime_r(
+        arg1: *const tm,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ctime_r(
+        arg1: *const time_t,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn posix2time(arg1: time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tzsetwall();
+}
+#[pg_guard]
+extern "C" {
+    pub fn time2posix(arg1: time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timelocal(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timegm(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanosleep(__rqtp: *const timespec, __rmtp: *mut timespec) -> ::std::os::raw::c_int;
+}
+pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
+pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
+pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
+pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
+pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
+pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
+pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
+pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
+pub type clockid_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn clock_getres(__clock_id: clockid_t, __res: *mut timespec) -> ::std::os::raw::c_int;
@@ -12131,56 +13459,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
+}
+#[pg_guard]
+extern "C" {
     pub fn clock_settime(__clock_id: clockid_t, __tp: *const timespec) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock_nanosleep(
-        __clock_id: clockid_t,
-        __flags: ::std::os::raw::c_int,
-        __req: *const timespec,
-        __rem: *mut timespec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn clock_getcpuclockid(__pid: pid_t, __clock_id: *mut clockid_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_create(
-        __clock_id: clockid_t,
-        __evp: *mut sigevent,
-        __timerid: *mut timer_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_settime(
-        __timerid: timer_t,
-        __flags: ::std::os::raw::c_int,
-        __value: *const itimerspec,
-        __ovalue: *mut itimerspec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_gettime(__timerid: timer_t, __value: *mut itimerspec) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timespec_get(
-        __ts: *mut timespec,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn timespec_get(ts: *mut timespec, base: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type instr_time = timespec;
 #[repr(C)]
@@ -14458,82 +15745,104 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __ino_t,
-    pub d_off: __off_t,
-    pub d_reclen: ::std::os::raw::c_ushort,
-    pub d_type: ::std::os::raw::c_uchar,
-    pub d_name: [::std::os::raw::c_char; 256usize],
+    pub d_ino: __uint64_t,
+    pub d_seekoff: __uint64_t,
+    pub d_reclen: __uint16_t,
+    pub d_namlen: __uint16_t,
+    pub d_type: __uint8_t,
+    pub d_name: [::std::os::raw::c_char; 1024usize],
 }
 impl Default for dirent {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub const DT_UNKNOWN: ::std::os::raw::c_uint = 0;
-pub const DT_FIFO: ::std::os::raw::c_uint = 1;
-pub const DT_CHR: ::std::os::raw::c_uint = 2;
-pub const DT_DIR: ::std::os::raw::c_uint = 4;
-pub const DT_BLK: ::std::os::raw::c_uint = 6;
-pub const DT_REG: ::std::os::raw::c_uint = 8;
-pub const DT_LNK: ::std::os::raw::c_uint = 10;
-pub const DT_SOCK: ::std::os::raw::c_uint = 12;
-pub const DT_WHT: ::std::os::raw::c_uint = 14;
-pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __dirstream {
+pub struct _telldir {
     _unused: [u8; 0],
 }
-pub type DIR = __dirstream;
-#[pg_guard]
-extern "C" {
-    pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct DIR {
+    pub __dd_fd: ::std::os::raw::c_int,
+    pub __dd_loc: ::std::os::raw::c_long,
+    pub __dd_size: ::std::os::raw::c_long,
+    pub __dd_buf: *mut ::std::os::raw::c_char,
+    pub __dd_len: ::std::os::raw::c_int,
+    pub __dd_seek: ::std::os::raw::c_long,
+    pub __padding: ::std::os::raw::c_long,
+    pub __dd_flags: ::std::os::raw::c_int,
+    pub __dd_lock: __darwin_pthread_mutex_t,
+    pub __dd_td: *mut _telldir,
+}
+impl Default for DIR {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
-    pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
+    pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_opendir$INODE64"]
+    pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+    #[link_name = "\u{1}_readdir$INODE64"]
+    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_readdir_r$INODE64"]
     pub fn readdir_r(
-        __dirp: *mut DIR,
-        __entry: *mut dirent,
-        __result: *mut *mut dirent,
+        arg1: *mut DIR,
+        arg2: *mut dirent,
+        arg3: *mut *mut dirent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rewinddir(__dirp: *mut DIR);
+    #[link_name = "\u{1}_rewinddir$INODE64"]
+    pub fn rewinddir(arg1: *mut DIR);
 }
 #[pg_guard]
 extern "C" {
-    pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
+    #[link_name = "\u{1}_seekdir$INODE64"]
+    pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
 }
 #[pg_guard]
 extern "C" {
-    pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
+    #[link_name = "\u{1}_telldir$INODE64"]
+    pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_fdopendir$INODE64"]
+    pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_alphasort$INODE64"]
+    pub fn alphasort(arg1: *mut *const dirent, arg2: *mut *const dirent) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_scandir$INODE64"]
     pub fn scandir(
-        __dir: *const ::std::os::raw::c_char,
-        __namelist: *mut *mut *mut dirent,
-        __selector: ::std::option::Option<
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut *mut dirent,
+        arg3: ::std::option::Option<
             unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
         >,
-        __cmp: ::std::option::Option<
+        arg4: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut *const dirent,
                 arg2: *mut *const dirent,
@@ -14543,16 +15852,29 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn alphasort(__e1: *mut *const dirent, __e2: *mut *const dirent) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_scandir_b$INODE64"]
+    pub fn scandir_b(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut *mut dirent,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
     pub fn getdirentries(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-        __basep: *mut __off_t,
-    ) -> __ssize_t;
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}___opendir2$INODE64"]
+    pub fn __opendir2(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int)
+        -> *mut DIR;
 }
 pub type File = ::std::os::raw::c_int;
 #[pg_guard]
@@ -17731,7 +19053,6 @@ pub struct Value {
 pub union Value_ValUnion {
     pub ival: ::std::os::raw::c_int,
     pub str_: *mut ::std::os::raw::c_char,
-    _bindgen_union_align: u64,
 }
 impl Default for Value_ValUnion {
     fn default() -> Self {
@@ -21807,651 +23128,160 @@ extern "C" {
         nulls: *mut *mut bool,
     ) -> ::std::os::raw::c_int;
 }
-pub type sig_atomic_t = __sig_atomic_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-    _bindgen_union_align: u64,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __sigval_t = sigval;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub __pad0: ::std::os::raw::c_int,
-    pub _sifields: siginfo_t__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union siginfo_t__bindgen_ty_1 {
-    pub _pad: [::std::os::raw::c_int; 28usize],
-    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
-    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
-    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
-    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
-    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
-    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
-    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
-    _bindgen_union_align: [u64; 14usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
-    pub si_tid: ::std::os::raw::c_int,
-    pub si_overrun: ::std::os::raw::c_int,
-    pub si_sigval: __sigval_t,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-    pub si_sigval: __sigval_t,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_utime: __clock_t,
-    pub si_stime: __clock_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_addr_lsb: ::std::os::raw::c_short,
-    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
-    pub _pkey: __uint32_t,
-    _bindgen_union_align: [u64; 2usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-    pub _lower: *mut ::std::os::raw::c_void,
-    pub _upper: *mut ::std::os::raw::c_void,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
-    pub si_band: ::std::os::raw::c_long,
-    pub si_fd: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
-    pub _call_addr: *mut ::std::os::raw::c_void,
-    pub _syscall: ::std::os::raw::c_int,
-    pub _arch: ::std::os::raw::c_uint,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub const SI_ASYNCNL: ::std::os::raw::c_int = -60;
-pub const SI_DETHREAD: ::std::os::raw::c_int = -7;
-pub const SI_TKILL: ::std::os::raw::c_int = -6;
-pub const SI_SIGIO: ::std::os::raw::c_int = -5;
-pub const SI_ASYNCIO: ::std::os::raw::c_int = -4;
-pub const SI_MESGQ: ::std::os::raw::c_int = -3;
-pub const SI_TIMER: ::std::os::raw::c_int = -2;
-pub const SI_QUEUE: ::std::os::raw::c_int = -1;
-pub const SI_USER: ::std::os::raw::c_int = 0;
-pub const SI_KERNEL: ::std::os::raw::c_int = 128;
-pub type _bindgen_ty_10 = ::std::os::raw::c_int;
-pub const ILL_ILLOPC: ::std::os::raw::c_uint = 1;
-pub const ILL_ILLOPN: ::std::os::raw::c_uint = 2;
-pub const ILL_ILLADR: ::std::os::raw::c_uint = 3;
-pub const ILL_ILLTRP: ::std::os::raw::c_uint = 4;
-pub const ILL_PRVOPC: ::std::os::raw::c_uint = 5;
-pub const ILL_PRVREG: ::std::os::raw::c_uint = 6;
-pub const ILL_COPROC: ::std::os::raw::c_uint = 7;
-pub const ILL_BADSTK: ::std::os::raw::c_uint = 8;
-pub const ILL_BADIADDR: ::std::os::raw::c_uint = 9;
-pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
-pub const FPE_INTDIV: ::std::os::raw::c_uint = 1;
-pub const FPE_INTOVF: ::std::os::raw::c_uint = 2;
-pub const FPE_FLTDIV: ::std::os::raw::c_uint = 3;
-pub const FPE_FLTOVF: ::std::os::raw::c_uint = 4;
-pub const FPE_FLTUND: ::std::os::raw::c_uint = 5;
-pub const FPE_FLTRES: ::std::os::raw::c_uint = 6;
-pub const FPE_FLTINV: ::std::os::raw::c_uint = 7;
-pub const FPE_FLTSUB: ::std::os::raw::c_uint = 8;
-pub const FPE_FLTUNK: ::std::os::raw::c_uint = 14;
-pub const FPE_CONDTRAP: ::std::os::raw::c_uint = 15;
-pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
-pub const SEGV_MAPERR: ::std::os::raw::c_uint = 1;
-pub const SEGV_ACCERR: ::std::os::raw::c_uint = 2;
-pub const SEGV_BNDERR: ::std::os::raw::c_uint = 3;
-pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
-pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
-pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
-pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
-pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
-pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
-pub const BUS_OBJERR: ::std::os::raw::c_uint = 3;
-pub const BUS_MCEERR_AR: ::std::os::raw::c_uint = 4;
-pub const BUS_MCEERR_AO: ::std::os::raw::c_uint = 5;
-pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
-pub const CLD_EXITED: ::std::os::raw::c_uint = 1;
-pub const CLD_KILLED: ::std::os::raw::c_uint = 2;
-pub const CLD_DUMPED: ::std::os::raw::c_uint = 3;
-pub const CLD_TRAPPED: ::std::os::raw::c_uint = 4;
-pub const CLD_STOPPED: ::std::os::raw::c_uint = 5;
-pub const CLD_CONTINUED: ::std::os::raw::c_uint = 6;
-pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
-pub const POLL_IN: ::std::os::raw::c_uint = 1;
-pub const POLL_OUT: ::std::os::raw::c_uint = 2;
-pub const POLL_MSG: ::std::os::raw::c_uint = 3;
-pub const POLL_ERR: ::std::os::raw::c_uint = 4;
-pub const POLL_PRI: ::std::os::raw::c_uint = 5;
-pub const POLL_HUP: ::std::os::raw::c_uint = 6;
-pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
-pub type sigval_t = __sigval_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_value: __sigval_t,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub _sigev_un: sigevent__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigevent__bindgen_ty_1 {
-    pub _pad: [::std::os::raw::c_int; 12usize],
-    pub _tid: __pid_t,
-    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: [u64; 6usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
-    pub _attribute: *mut pthread_attr_t,
-}
-impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigevent__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sigevent_t = sigevent;
-pub const SIGEV_SIGNAL: ::std::os::raw::c_uint = 0;
-pub const SIGEV_NONE: ::std::os::raw::c_uint = 1;
-pub const SIGEV_THREAD: ::std::os::raw::c_uint = 2;
-pub const SIGEV_THREAD_ID: ::std::os::raw::c_uint = 4;
-pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
-pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[pg_guard]
 extern "C" {
-    pub fn __sysv_signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t)
-        -> __sighandler_t;
+    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ssignal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn siggetmask() -> ::std::os::raw::c_int;
-}
-pub type sig_t = __sighandler_t;
-#[pg_guard]
-extern "C" {
-    pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigaddset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigdelset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigismember(
-        __set: *const sigset_t,
-        __signo: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_handler: sigaction__bindgen_ty_1,
-    pub sa_mask: __sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigaction__bindgen_ty_1 {
-    pub sa_handler: __sighandler_t,
-    pub sa_sigaction: ::std::option::Option<
+    pub fn bsd_signal(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
-            arg2: *mut siginfo_t,
-            arg3: *mut ::std::os::raw::c_void,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
         ),
-    >,
-    _bindgen_union_align: u64,
-}
-impl Default for sigaction__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    >;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigprocmask(
-        __how: ::std::os::raw::c_int,
-        __set: *const sigset_t,
-        __oset: *mut sigset_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
+    pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaction(
-        __sig: ::std::os::raw::c_int,
-        __act: *const sigaction,
-        __oact: *mut sigaction,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigwait(
-        __set: *const sigset_t,
-        __sig: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigwaitinfo(__set: *const sigset_t, __info: *mut siginfo_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigtimedwait(
-        __set: *const sigset_t,
-        __info: *mut siginfo_t,
-        __timeout: *const timespec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigqueue(
-        __pid: __pid_t,
-        __sig: ::std::os::raw::c_int,
-        __val: sigval,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpx_sw_bytes {
-    pub magic1: __uint32_t,
-    pub extended_size: __uint32_t,
-    pub xstate_bv: __uint64_t,
-    pub xstate_size: __uint32_t,
-    pub __glibc_reserved1: [__uint32_t; 7usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpxreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _xmmreg {
-    pub element: [__uint32_t; 4usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpstate {
-    pub cwd: __uint16_t,
-    pub swd: __uint16_t,
-    pub ftw: __uint16_t,
-    pub fop: __uint16_t,
-    pub rip: __uint64_t,
-    pub rdp: __uint64_t,
-    pub mxcsr: __uint32_t,
-    pub mxcr_mask: __uint32_t,
-    pub _st: [_fpxreg; 8usize],
-    pub _xmm: [_xmmreg; 16usize],
-    pub __glibc_reserved1: [__uint32_t; 24usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigcontext {
-    pub r8: __uint64_t,
-    pub r9: __uint64_t,
-    pub r10: __uint64_t,
-    pub r11: __uint64_t,
-    pub r12: __uint64_t,
-    pub r13: __uint64_t,
-    pub r14: __uint64_t,
-    pub r15: __uint64_t,
-    pub rdi: __uint64_t,
-    pub rsi: __uint64_t,
-    pub rbp: __uint64_t,
-    pub rbx: __uint64_t,
-    pub rdx: __uint64_t,
-    pub rax: __uint64_t,
-    pub rcx: __uint64_t,
-    pub rsp: __uint64_t,
-    pub rip: __uint64_t,
-    pub eflags: __uint64_t,
-    pub cs: ::std::os::raw::c_ushort,
-    pub gs: ::std::os::raw::c_ushort,
-    pub fs: ::std::os::raw::c_ushort,
-    pub __pad0: ::std::os::raw::c_ushort,
-    pub err: __uint64_t,
-    pub trapno: __uint64_t,
-    pub oldmask: __uint64_t,
-    pub cr2: __uint64_t,
-    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
-    pub __reserved1: [__uint64_t; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigcontext__bindgen_ty_1 {
-    pub fpstate: *mut _fpstate,
-    pub __fpstate_word: __uint64_t,
-    _bindgen_union_align: u64,
-}
-impl Default for sigcontext__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigcontext {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _xsave_hdr {
-    pub xstate_bv: __uint64_t,
-    pub __glibc_reserved1: [__uint64_t; 2usize],
-    pub __glibc_reserved2: [__uint64_t; 5usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _ymmh_state {
-    pub ymmh_space: [__uint32_t; 64usize],
-}
-impl Default for _ymmh_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _xstate {
-    pub fpstate: _fpstate,
-    pub xstate_hdr: _xsave_hdr,
-    pub ymmh: _ymmh_state,
-}
-impl Default for _xstate {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigreturn(__scp: *mut sigcontext) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct stack_t {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_flags: ::std::os::raw::c_int,
-    pub ss_size: usize,
-}
-impl Default for stack_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type greg_t = ::std::os::raw::c_longlong;
-pub type gregset_t = [greg_t; 23usize];
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_fpxreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_xmmreg {
-    pub element: [__uint32_t; 4usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_fpstate {
-    pub cwd: __uint16_t,
-    pub swd: __uint16_t,
-    pub ftw: __uint16_t,
-    pub fop: __uint16_t,
-    pub rip: __uint64_t,
-    pub rdp: __uint64_t,
-    pub mxcsr: __uint32_t,
-    pub mxcr_mask: __uint32_t,
-    pub _st: [_libc_fpxreg; 8usize],
-    pub _xmm: [_libc_xmmreg; 16usize],
-    pub __glibc_reserved1: [__uint32_t; 24usize],
-}
-pub type fpregset_t = *mut _libc_fpstate;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct mcontext_t {
-    pub gregs: gregset_t,
-    pub fpregs: fpregset_t,
-    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
-}
-impl Default for mcontext_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ucontext_t {
-    pub uc_flags: ::std::os::raw::c_ulong,
-    pub uc_link: *mut ucontext_t,
-    pub uc_stack: stack_t,
-    pub uc_mcontext: mcontext_t,
-    pub uc_sigmask: sigset_t,
-    pub __fpregs_mem: _libc_fpstate,
-    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
-}
-impl Default for ucontext_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn siginterrupt(
-        __sig: ::std::os::raw::c_int,
-        __interrupt: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-pub const SS_ONSTACK: ::std::os::raw::c_uint = 1;
-pub const SS_DISABLE: ::std::os::raw::c_uint = 2;
-pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
-#[pg_guard]
-extern "C" {
-    pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigstack(__ss: *mut sigstack, __oss: *mut sigstack) -> ::std::os::raw::c_int;
+    pub fn pthread_kill(arg1: pthread_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn pthread_sigmask(
-        __how: ::std::os::raw::c_int,
-        __newmask: *const __sigset_t,
-        __oldmask: *mut __sigset_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigset_t,
+        arg3: *mut sigset_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_kill(
-        __threadid: pthread_t,
-        __signo: ::std::os::raw::c_int,
+    pub fn sigaction(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigaction,
+        arg3: *mut sigaction,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+    pub fn sigaddset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+    pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigdelset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn siginterrupt(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigismember(arg1: *const sigset_t, arg2: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigprocmask(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigset_t,
+        arg3: *mut sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigset(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+        ),
+    >;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigwait(
+        arg1: *const sigset_t,
+        arg2: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigvec(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sigvec,
+        arg3: *mut sigvec,
+    ) -> ::std::os::raw::c_int;
 }
 pub type pg_time_t = int64;
 #[repr(C)]
@@ -23072,8 +23902,9 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_un {
+    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 108usize],
+    pub sun_path: [::std::os::raw::c_char; 104usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -23712,7 +24543,6 @@ pub struct LWLock {
 pub union LWLockPadded {
     pub lock: LWLock,
     pub pad: [::std::os::raw::c_char; 128usize],
-    _bindgen_union_align: [u32; 32usize],
 }
 impl Default for LWLockPadded {
     fn default() -> Self {
@@ -23724,7 +24554,6 @@ impl Default for LWLockPadded {
 pub union LWLockMinimallyPadded {
     pub lock: LWLock,
     pub pad: [::std::os::raw::c_char; 32usize],
-    _bindgen_union_align: [u32; 8usize],
 }
 impl Default for LWLockMinimallyPadded {
     fn default() -> Self {
@@ -25074,7 +25903,6 @@ pub union PgStat_Msg {
     pub msg_deadlock: PgStat_MsgDeadlock,
     pub msg_tempfile: PgStat_MsgTempFile,
     pub msg_checksumfailure: PgStat_MsgChecksumFailure,
-    _bindgen_union_align: [u64; 125usize],
 }
 impl Default for PgStat_Msg {
     fn default() -> Self {
@@ -27173,7 +28001,6 @@ impl Default for ExpandedArrayHeader {
 pub union AnyArrayType {
     pub flt: ArrayType,
     pub xpn: ExpandedArrayHeader,
-    _bindgen_union_align: [u64; 17usize],
 }
 impl Default for AnyArrayType {
     fn default() -> Self {
@@ -30163,7 +30990,6 @@ pub union relopt_value__bindgen_ty_1 {
     pub int_val: ::std::os::raw::c_int,
     pub real_val: f64,
     pub string_val: *mut ::std::os::raw::c_char,
-    _bindgen_union_align: u64,
 }
 impl Default for relopt_value__bindgen_ty_1 {
     fn default() -> Self {
@@ -30425,7 +31251,6 @@ pub union SharedInvalidationMessage {
     pub sm: SharedInvalSmgrMsg,
     pub rm: SharedInvalRelmapMsg,
     pub sn: SharedInvalSnapshotMsg,
-    _bindgen_union_align: [u32; 4usize],
 }
 impl Default for SharedInvalidationMessage {
     fn default() -> Self {
@@ -33124,7 +33949,6 @@ pub union CollectedCommand__bindgen_ty_1 {
     pub createopc: CollectedCommand__bindgen_ty_1__bindgen_ty_5,
     pub atscfg: CollectedCommand__bindgen_ty_1__bindgen_ty_6,
     pub defprivs: CollectedCommand__bindgen_ty_1__bindgen_ty_7,
-    _bindgen_union_align: [u64; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -40452,7 +41276,6 @@ pub union ReorderBufferChange__bindgen_ty_1 {
     pub snapshot: Snapshot,
     pub command_id: CommandId,
     pub tuplecid: ReorderBufferChange__bindgen_ty_1__bindgen_ty_4,
-    _bindgen_union_align: [u64; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -52879,7 +53702,6 @@ pub union JsonbValue__bindgen_ty_1 {
     pub array: JsonbValue__bindgen_ty_1__bindgen_ty_2,
     pub object: JsonbValue__bindgen_ty_1__bindgen_ty_3,
     pub binary: JsonbValue__bindgen_ty_1__bindgen_ty_4,
-    _bindgen_union_align: [u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -54359,11 +55181,6 @@ impl Default for __va_list_tag {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __locale_data {
-    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -178,29 +178,30 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & 'static [u8 ; 842usize] = b" '--prefix=/home/ana/.pgx/13.2/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert' 'CC=gcc' 'CXX=g++' 'PKG_CONFIG=pkg-config' 'PKG_CONFIG_PATH=/nix/store/sarpzwx0p98frys3ck7201cpnzvsg03z-zlib-1.2.11-dev/lib/pkgconfig:/nix/store/28mf2sqki1dmrlzikwpikrhwyhp3xd31-ncurses-6.2-dev/lib/pkgconfig:/nix/store/apxpi7w14qkvbkpiy89lryarxv9svngy-openssl-1.1.1k-dev/lib/pkgconfig:/nix/store/gss20qxmklmwarli44nfjjbnwhjnng2d-libxml2-2.9.10-dev/lib/pkgconfig:/nix/store/gz0fp1iyi55asghp725spxqnx2x1q0cw-icu4c-67.1-dev/lib/pkgconfig:/nix/store/11sbip0qhqzmw1k0vlxs6nm4ivqzchyn-systemd-247.6-dev/lib/pkgconfig:/nix/store/11sbip0qhqzmw1k0vlxs6nm4ivqzchyn-systemd-247.6-dev/share/pkgconfig:/nix/store/j6ff2y31l0vrz389z5rxb65rhz8j51xj-libossp-uuid-1.6.2/lib/pkgconfig:/nix/store/7c28s5fvha37hn3cx8w35619lsh63d9g-icu4c-68.2-dev/lib/pkgconfig'\0" ;
+pub const CONFIGURE_ARGS : & 'static [u8 ; 107usize] = b" '--prefix=/Users/e_ridge/.pgx/13.2/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &'static [u8; 6usize] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
-pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_BACKTRACE_SYMBOLS: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 1;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
+pub const HAVE_COPYFILE: u32 = 1;
+pub const HAVE_COPYFILE_H: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 0;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
 pub const HAVE_DECL_RTLD_GLOBAL: u32 = 1;
 pub const HAVE_DECL_RTLD_NOW: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 0;
-pub const HAVE_DECL_STRLCPY: u32 = 0;
+pub const HAVE_DECL_STRLCAT: u32 = 1;
+pub const HAVE_DECL_STRLCPY: u32 = 1;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_EXECINFO_H: u32 = 1;
-pub const HAVE_EXPLICIT_BZERO: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
+pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -210,11 +211,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
-pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
+pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -223,8 +224,10 @@ pub const HAVE_IFADDRS_H: u32 = 1;
 pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
+pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
+pub const HAVE_KQUEUE: u32 = 1;
 pub const HAVE_LANGINFO_H: u32 = 1;
 pub const HAVE_LIBM: u32 = 1;
 pub const HAVE_LIBREADLINE: u32 = 1;
@@ -232,17 +235,17 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LINK: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
+pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
+pub const HAVE_MEMSET_S: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
 pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
-pub const HAVE_POSIX_FADVISE: u32 = 1;
-pub const HAVE_POSIX_FALLOCATE: u32 = 1;
-pub const HAVE_PPOLL: u32 = 1;
 pub const HAVE_PREAD: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
+pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_PWRITE: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
@@ -251,11 +254,7 @@ pub const HAVE_READLINE_READLINE_H: u32 = 1;
 pub const HAVE_READLINK: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
-pub const HAVE_RL_COMPLETION_SUPPRESS_QUOTE: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
-pub const HAVE_RL_FILENAME_QUOTE_CHARACTERS: u32 = 1;
-pub const HAVE_RL_FILENAME_QUOTING_FUNCTION: u32 = 1;
-pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SPINLOCKS: u32 = 1;
@@ -263,10 +262,11 @@ pub const HAVE_SRANDOM: u32 = 1;
 pub const HAVE_STDBOOL_H: u32 = 1;
 pub const HAVE_STDINT_H: u32 = 1;
 pub const HAVE_STDLIB_H: u32 = 1;
-pub const HAVE_STRCHRNUL: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
+pub const HAVE_STRLCAT: u32 = 1;
+pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOF: u32 = 1;
@@ -274,28 +274,32 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
+pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
+pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_UN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
-pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
-pub const HAVE_SYS_EPOLL_H: u32 = 1;
+pub const HAVE_SYS_EVENT_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
-pub const HAVE_SYS_PRCTL_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
+pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
+pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
+pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
 pub const HAVE_USELOCALE: u32 = 1;
+pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE_X86_64_POPCNTQ: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
@@ -312,6 +316,7 @@ pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
 pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const INT64_MODIFIER: &'static [u8; 2usize] = b"l\0";
+pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &'static [u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
@@ -327,8 +332,7 @@ pub const PG_MINORVERSION_NUM: u32 = 2;
 pub const PG_USE_STDBOOL: u32 = 1;
 pub const PG_VERSION: &'static [u8; 5usize] = b"13.2\0";
 pub const PG_VERSION_NUM: u32 = 130002;
-pub const PG_VERSION_STR: &'static [u8; 77usize] =
-    b"PostgreSQL 13.2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.0, 64-bit\0";
+pub const PG_VERSION_STR : & 'static [u8 ; 113usize] = b"PostgreSQL 13.2 on x86_64-apple-darwin20.3.0, compiled by Apple clang version 12.0.5 (clang-1205.0.22.9), 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -336,11 +340,13 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const STRERROR_R_INT: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
+pub const USE_SYSV_SEMAPHORES: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
+pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -355,211 +361,510 @@ pub const PG_SOMAXCONN: u32 = 10000;
 pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &'static [u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &'static [u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const _STDIO_H: u32 = 1;
-pub const _FEATURES_H: u32 = 1;
-pub const _DEFAULT_SOURCE: u32 = 1;
-pub const __GLIBC_USE_ISOC2X: u32 = 0;
-pub const __USE_ISOC11: u32 = 1;
-pub const __USE_ISOC99: u32 = 1;
-pub const __USE_ISOC95: u32 = 1;
-pub const __USE_POSIX_IMPLICITLY: u32 = 1;
-pub const _POSIX_SOURCE: u32 = 1;
-pub const _POSIX_C_SOURCE: u32 = 200809;
-pub const __USE_POSIX: u32 = 1;
-pub const __USE_POSIX2: u32 = 1;
-pub const __USE_POSIX199309: u32 = 1;
-pub const __USE_POSIX199506: u32 = 1;
-pub const __USE_XOPEN2K: u32 = 1;
-pub const __USE_XOPEN2K8: u32 = 1;
-pub const _ATFILE_SOURCE: u32 = 1;
-pub const __USE_MISC: u32 = 1;
-pub const __USE_ATFILE: u32 = 1;
-pub const __USE_FORTIFY_LEVEL: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const _STDC_PREDEF_H: u32 = 1;
-pub const __STDC_IEC_559__: u32 = 1;
-pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
-pub const __STDC_ISO_10646__: u32 = 201706;
-pub const __GNU_LIBRARY__: u32 = 6;
-pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 32;
-pub const _SYS_CDEFS_H: u32 = 1;
-pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
-pub const __HAVE_GENERIC_SELECTION: u32 = 1;
-pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const _BITS_TYPES_H: u32 = 1;
-pub const __TIMESIZE: u32 = 64;
-pub const _BITS_TYPESIZES_H: u32 = 1;
-pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
-pub const __INO_T_MATCHES_INO64_T: u32 = 1;
-pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
-pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
-pub const __FD_SETSIZE: u32 = 1024;
-pub const _BITS_TIME64_H: u32 = 1;
-pub const _____fpos_t_defined: u32 = 1;
-pub const ____mbstate_t_defined: u32 = 1;
-pub const _____fpos64_t_defined: u32 = 1;
-pub const ____FILE_defined: u32 = 1;
-pub const __FILE_defined: u32 = 1;
-pub const __struct_FILE_defined: u32 = 1;
-pub const _IO_EOF_SEEN: u32 = 16;
-pub const _IO_ERR_SEEN: u32 = 32;
-pub const _IO_USER_LOCK: u32 = 32768;
+pub const __darwin__: u32 = 1;
+pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
+pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
+pub const __DARWIN_UNIX03: u32 = 1;
+pub const __DARWIN_64_BIT_INO_T: u32 = 1;
+pub const __DARWIN_VERS_1050: u32 = 1;
+pub const __DARWIN_NON_CANCELABLE: u32 = 0;
+pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
+pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
+pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
+pub const __DARWIN_C_ANSI: u32 = 4096;
+pub const __DARWIN_C_FULL: u32 = 900000;
+pub const __DARWIN_C_LEVEL: u32 = 900000;
+pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
+pub const __DARWIN_NO_LONG_LONG: u32 = 0;
+pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
+pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
+pub const __API_TO_BE_DEPRECATED: u32 = 100000;
+pub const __MAC_10_0: u32 = 1000;
+pub const __MAC_10_1: u32 = 1010;
+pub const __MAC_10_2: u32 = 1020;
+pub const __MAC_10_3: u32 = 1030;
+pub const __MAC_10_4: u32 = 1040;
+pub const __MAC_10_5: u32 = 1050;
+pub const __MAC_10_6: u32 = 1060;
+pub const __MAC_10_7: u32 = 1070;
+pub const __MAC_10_8: u32 = 1080;
+pub const __MAC_10_9: u32 = 1090;
+pub const __MAC_10_10: u32 = 101000;
+pub const __MAC_10_10_2: u32 = 101002;
+pub const __MAC_10_10_3: u32 = 101003;
+pub const __MAC_10_11: u32 = 101100;
+pub const __MAC_10_11_2: u32 = 101102;
+pub const __MAC_10_11_3: u32 = 101103;
+pub const __MAC_10_11_4: u32 = 101104;
+pub const __MAC_10_12: u32 = 101200;
+pub const __MAC_10_12_1: u32 = 101201;
+pub const __MAC_10_12_2: u32 = 101202;
+pub const __MAC_10_12_4: u32 = 101204;
+pub const __MAC_10_13: u32 = 101300;
+pub const __MAC_10_13_1: u32 = 101301;
+pub const __MAC_10_13_2: u32 = 101302;
+pub const __MAC_10_13_4: u32 = 101304;
+pub const __MAC_10_14: u32 = 101400;
+pub const __MAC_10_14_1: u32 = 101401;
+pub const __MAC_10_14_4: u32 = 101404;
+pub const __MAC_10_14_6: u32 = 101406;
+pub const __MAC_10_15: u32 = 101500;
+pub const __MAC_10_15_1: u32 = 101501;
+pub const __MAC_10_15_4: u32 = 101504;
+pub const __MAC_10_16: u32 = 101600;
+pub const __MAC_11_0: u32 = 110000;
+pub const __MAC_11_1: u32 = 110100;
+pub const __IPHONE_2_0: u32 = 20000;
+pub const __IPHONE_2_1: u32 = 20100;
+pub const __IPHONE_2_2: u32 = 20200;
+pub const __IPHONE_3_0: u32 = 30000;
+pub const __IPHONE_3_1: u32 = 30100;
+pub const __IPHONE_3_2: u32 = 30200;
+pub const __IPHONE_4_0: u32 = 40000;
+pub const __IPHONE_4_1: u32 = 40100;
+pub const __IPHONE_4_2: u32 = 40200;
+pub const __IPHONE_4_3: u32 = 40300;
+pub const __IPHONE_5_0: u32 = 50000;
+pub const __IPHONE_5_1: u32 = 50100;
+pub const __IPHONE_6_0: u32 = 60000;
+pub const __IPHONE_6_1: u32 = 60100;
+pub const __IPHONE_7_0: u32 = 70000;
+pub const __IPHONE_7_1: u32 = 70100;
+pub const __IPHONE_8_0: u32 = 80000;
+pub const __IPHONE_8_1: u32 = 80100;
+pub const __IPHONE_8_2: u32 = 80200;
+pub const __IPHONE_8_3: u32 = 80300;
+pub const __IPHONE_8_4: u32 = 80400;
+pub const __IPHONE_9_0: u32 = 90000;
+pub const __IPHONE_9_1: u32 = 90100;
+pub const __IPHONE_9_2: u32 = 90200;
+pub const __IPHONE_9_3: u32 = 90300;
+pub const __IPHONE_10_0: u32 = 100000;
+pub const __IPHONE_10_1: u32 = 100100;
+pub const __IPHONE_10_2: u32 = 100200;
+pub const __IPHONE_10_3: u32 = 100300;
+pub const __IPHONE_11_0: u32 = 110000;
+pub const __IPHONE_11_1: u32 = 110100;
+pub const __IPHONE_11_2: u32 = 110200;
+pub const __IPHONE_11_3: u32 = 110300;
+pub const __IPHONE_11_4: u32 = 110400;
+pub const __IPHONE_12_0: u32 = 120000;
+pub const __IPHONE_12_1: u32 = 120100;
+pub const __IPHONE_12_2: u32 = 120200;
+pub const __IPHONE_12_3: u32 = 120300;
+pub const __IPHONE_12_4: u32 = 120400;
+pub const __IPHONE_13_0: u32 = 130000;
+pub const __IPHONE_13_1: u32 = 130100;
+pub const __IPHONE_13_2: u32 = 130200;
+pub const __IPHONE_13_3: u32 = 130300;
+pub const __IPHONE_13_4: u32 = 130400;
+pub const __IPHONE_13_5: u32 = 130500;
+pub const __IPHONE_13_6: u32 = 130600;
+pub const __IPHONE_13_7: u32 = 130700;
+pub const __IPHONE_14_0: u32 = 140000;
+pub const __IPHONE_14_1: u32 = 140100;
+pub const __IPHONE_14_2: u32 = 140200;
+pub const __IPHONE_14_3: u32 = 140300;
+pub const __TVOS_9_0: u32 = 90000;
+pub const __TVOS_9_1: u32 = 90100;
+pub const __TVOS_9_2: u32 = 90200;
+pub const __TVOS_10_0: u32 = 100000;
+pub const __TVOS_10_0_1: u32 = 100001;
+pub const __TVOS_10_1: u32 = 100100;
+pub const __TVOS_10_2: u32 = 100200;
+pub const __TVOS_11_0: u32 = 110000;
+pub const __TVOS_11_1: u32 = 110100;
+pub const __TVOS_11_2: u32 = 110200;
+pub const __TVOS_11_3: u32 = 110300;
+pub const __TVOS_11_4: u32 = 110400;
+pub const __TVOS_12_0: u32 = 120000;
+pub const __TVOS_12_1: u32 = 120100;
+pub const __TVOS_12_2: u32 = 120200;
+pub const __TVOS_12_3: u32 = 120300;
+pub const __TVOS_12_4: u32 = 120400;
+pub const __TVOS_13_0: u32 = 130000;
+pub const __TVOS_13_2: u32 = 130200;
+pub const __TVOS_13_3: u32 = 130300;
+pub const __TVOS_13_4: u32 = 130400;
+pub const __TVOS_14_0: u32 = 140000;
+pub const __TVOS_14_1: u32 = 140100;
+pub const __TVOS_14_2: u32 = 140200;
+pub const __TVOS_14_3: u32 = 140300;
+pub const __WATCHOS_1_0: u32 = 10000;
+pub const __WATCHOS_2_0: u32 = 20000;
+pub const __WATCHOS_2_1: u32 = 20100;
+pub const __WATCHOS_2_2: u32 = 20200;
+pub const __WATCHOS_3_0: u32 = 30000;
+pub const __WATCHOS_3_1: u32 = 30100;
+pub const __WATCHOS_3_1_1: u32 = 30101;
+pub const __WATCHOS_3_2: u32 = 30200;
+pub const __WATCHOS_4_0: u32 = 40000;
+pub const __WATCHOS_4_1: u32 = 40100;
+pub const __WATCHOS_4_2: u32 = 40200;
+pub const __WATCHOS_4_3: u32 = 40300;
+pub const __WATCHOS_5_0: u32 = 50000;
+pub const __WATCHOS_5_1: u32 = 50100;
+pub const __WATCHOS_5_2: u32 = 50200;
+pub const __WATCHOS_5_3: u32 = 50300;
+pub const __WATCHOS_6_0: u32 = 60000;
+pub const __WATCHOS_6_1: u32 = 60100;
+pub const __WATCHOS_6_2: u32 = 60200;
+pub const __WATCHOS_7_0: u32 = 70000;
+pub const __WATCHOS_7_1: u32 = 70100;
+pub const __WATCHOS_7_2: u32 = 70200;
+pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
+pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
+pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
+pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
+pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
+pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
+pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
+pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
+pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
+pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
+pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
+pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
+pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
+pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
+pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
+pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
+pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
+pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
+pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
+pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
+pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
+pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
+pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
+pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
+pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
+pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
+pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
+pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
+pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
+pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
+pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
+pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
+pub const MAC_OS_VERSION_11_0: u32 = 110000;
+pub const __DRIVERKIT_19_0: u32 = 190000;
+pub const __DRIVERKIT_20_0: u32 = 200000;
+pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
+pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
+pub const __PTHREAD_SIZE__: u32 = 8176;
+pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
+pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
+pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_COND_SIZE__: u32 = 40;
+pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
+pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
+pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
+pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
+pub const _FORTIFY_SOURCE: u32 = 2;
+pub const RENAME_SECLUDE: u32 = 1;
+pub const RENAME_SWAP: u32 = 2;
+pub const RENAME_EXCL: u32 = 4;
+pub const __SLBF: u32 = 1;
+pub const __SNBF: u32 = 2;
+pub const __SRD: u32 = 4;
+pub const __SWR: u32 = 8;
+pub const __SRW: u32 = 16;
+pub const __SEOF: u32 = 32;
+pub const __SERR: u32 = 64;
+pub const __SMBF: u32 = 128;
+pub const __SAPP: u32 = 256;
+pub const __SSTR: u32 = 512;
+pub const __SOPT: u32 = 1024;
+pub const __SNPT: u32 = 2048;
+pub const __SOFF: u32 = 4096;
+pub const __SMOD: u32 = 8192;
+pub const __SALC: u32 = 16384;
+pub const __SIGN: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 8192;
+pub const BUFSIZ: u32 = 1024;
 pub const EOF: i32 = -1;
+pub const FOPEN_MAX: u32 = 20;
+pub const FILENAME_MAX: u32 = 1024;
+pub const P_tmpdir: &'static [u8; 10usize] = b"/var/tmp/\0";
+pub const L_tmpnam: u32 = 1024;
+pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const P_tmpdir: &'static [u8; 5usize] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
-pub const L_tmpnam: u32 = 20;
-pub const TMP_MAX: u32 = 238328;
-pub const FILENAME_MAX: u32 = 4096;
-pub const L_ctermid: u32 = 9;
-pub const FOPEN_MAX: u32 = 16;
-pub const __HAVE_FLOAT128: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
-pub const __HAVE_FLOAT64X: u32 = 1;
-pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
-pub const __HAVE_FLOAT16: u32 = 0;
-pub const __HAVE_FLOAT32: u32 = 1;
-pub const __HAVE_FLOAT64: u32 = 1;
-pub const __HAVE_FLOAT32X: u32 = 1;
-pub const __HAVE_FLOAT128X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
-pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
-pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
+pub const L_ctermid: u32 = 1024;
+pub const _USE_FORTIFY_LEVEL: u32 = 2;
+pub const __DARWIN_NSIG: u32 = 32;
+pub const NSIG: u32 = 32;
+pub const _I386_SIGNAL_H_: u32 = 1;
+pub const SIGHUP: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGQUIT: u32 = 3;
+pub const SIGILL: u32 = 4;
+pub const SIGTRAP: u32 = 5;
+pub const SIGABRT: u32 = 6;
+pub const SIGIOT: u32 = 6;
+pub const SIGEMT: u32 = 7;
+pub const SIGFPE: u32 = 8;
+pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSEGV: u32 = 11;
+pub const SIGSYS: u32 = 12;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGTERM: u32 = 15;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGIO: u32 = 23;
+pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGWINCH: u32 = 28;
+pub const SIGINFO: u32 = 29;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
+pub const FP_PREC_24B: u32 = 0;
+pub const FP_PREC_53B: u32 = 2;
+pub const FP_PREC_64B: u32 = 3;
+pub const FP_RND_NEAR: u32 = 0;
+pub const FP_RND_DOWN: u32 = 1;
+pub const FP_RND_UP: u32 = 2;
+pub const FP_CHOP: u32 = 3;
+pub const FP_STATE_BYTES: u32 = 512;
+pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
+pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
+pub const __LASTBRANCH_MAX: u32 = 32;
+pub const SIGEV_NONE: u32 = 0;
+pub const SIGEV_SIGNAL: u32 = 1;
+pub const SIGEV_THREAD: u32 = 3;
+pub const ILL_NOOP: u32 = 0;
+pub const ILL_ILLOPC: u32 = 1;
+pub const ILL_ILLTRP: u32 = 2;
+pub const ILL_PRVOPC: u32 = 3;
+pub const ILL_ILLOPN: u32 = 4;
+pub const ILL_ILLADR: u32 = 5;
+pub const ILL_PRVREG: u32 = 6;
+pub const ILL_COPROC: u32 = 7;
+pub const ILL_BADSTK: u32 = 8;
+pub const FPE_NOOP: u32 = 0;
+pub const FPE_FLTDIV: u32 = 1;
+pub const FPE_FLTOVF: u32 = 2;
+pub const FPE_FLTUND: u32 = 3;
+pub const FPE_FLTRES: u32 = 4;
+pub const FPE_FLTINV: u32 = 5;
+pub const FPE_FLTSUB: u32 = 6;
+pub const FPE_INTDIV: u32 = 7;
+pub const FPE_INTOVF: u32 = 8;
+pub const SEGV_NOOP: u32 = 0;
+pub const SEGV_MAPERR: u32 = 1;
+pub const SEGV_ACCERR: u32 = 2;
+pub const BUS_NOOP: u32 = 0;
+pub const BUS_ADRALN: u32 = 1;
+pub const BUS_ADRERR: u32 = 2;
+pub const BUS_OBJERR: u32 = 3;
+pub const TRAP_BRKPT: u32 = 1;
+pub const TRAP_TRACE: u32 = 2;
+pub const CLD_NOOP: u32 = 0;
+pub const CLD_EXITED: u32 = 1;
+pub const CLD_KILLED: u32 = 2;
+pub const CLD_DUMPED: u32 = 3;
+pub const CLD_TRAPPED: u32 = 4;
+pub const CLD_STOPPED: u32 = 5;
+pub const CLD_CONTINUED: u32 = 6;
+pub const POLL_IN: u32 = 1;
+pub const POLL_OUT: u32 = 2;
+pub const POLL_MSG: u32 = 3;
+pub const POLL_ERR: u32 = 4;
+pub const POLL_PRI: u32 = 5;
+pub const POLL_HUP: u32 = 6;
+pub const SA_ONSTACK: u32 = 1;
+pub const SA_RESTART: u32 = 2;
+pub const SA_RESETHAND: u32 = 4;
+pub const SA_NOCLDSTOP: u32 = 8;
+pub const SA_NODEFER: u32 = 16;
+pub const SA_NOCLDWAIT: u32 = 32;
+pub const SA_SIGINFO: u32 = 64;
+pub const SA_USERTRAMP: u32 = 256;
+pub const SA_64REGSET: u32 = 512;
+pub const SA_USERSPACE_MASK: u32 = 127;
+pub const SIG_BLOCK: u32 = 1;
+pub const SIG_UNBLOCK: u32 = 2;
+pub const SIG_SETMASK: u32 = 3;
+pub const SI_USER: u32 = 65537;
+pub const SI_QUEUE: u32 = 65538;
+pub const SI_TIMER: u32 = 65539;
+pub const SI_ASYNCIO: u32 = 65540;
+pub const SI_MESGQ: u32 = 65541;
+pub const SS_ONSTACK: u32 = 1;
+pub const SS_DISABLE: u32 = 4;
+pub const MINSIGSTKSZ: u32 = 32768;
+pub const SIGSTKSZ: u32 = 131072;
+pub const SV_ONSTACK: u32 = 1;
+pub const SV_INTERRUPT: u32 = 2;
+pub const SV_RESETHAND: u32 = 4;
+pub const SV_NODEFER: u32 = 16;
+pub const SV_NOCLDSTOP: u32 = 8;
+pub const SV_SIGINFO: u32 = 64;
+pub const __WORDSIZE: u32 = 64;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const INT64_MAX: u64 = 9223372036854775807;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT64_MIN: i64 = -9223372036854775808;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const UINT64_MAX: i32 = -1;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const UINT_LEAST64_MAX: i32 = -1;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i32 = -32768;
+pub const INT_FAST32_MIN: i32 = -2147483648;
+pub const INT_FAST64_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u32 = 32767;
+pub const INT_FAST32_MAX: u32 = 2147483647;
+pub const INT_FAST64_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: u32 = 65535;
+pub const UINT_FAST32_MAX: u32 = 4294967295;
+pub const UINT_FAST64_MAX: i32 = -1;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const UINTPTR_MAX: i32 = -1;
+pub const SIZE_MAX: i32 = -1;
+pub const RSIZE_MAX: i32 = -1;
+pub const WINT_MIN: i32 = -2147483648;
+pub const WINT_MAX: u32 = 2147483647;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const PRIO_PROCESS: u32 = 0;
+pub const PRIO_PGRP: u32 = 1;
+pub const PRIO_USER: u32 = 2;
+pub const PRIO_DARWIN_THREAD: u32 = 3;
+pub const PRIO_DARWIN_PROCESS: u32 = 4;
+pub const PRIO_MIN: i32 = -20;
+pub const PRIO_MAX: u32 = 20;
+pub const PRIO_DARWIN_BG: u32 = 4096;
+pub const PRIO_DARWIN_NONUI: u32 = 4097;
+pub const RUSAGE_SELF: u32 = 0;
+pub const RUSAGE_CHILDREN: i32 = -1;
+pub const RUSAGE_INFO_V0: u32 = 0;
+pub const RUSAGE_INFO_V1: u32 = 1;
+pub const RUSAGE_INFO_V2: u32 = 2;
+pub const RUSAGE_INFO_V3: u32 = 3;
+pub const RUSAGE_INFO_V4: u32 = 4;
+pub const RUSAGE_INFO_V5: u32 = 5;
+pub const RUSAGE_INFO_CURRENT: u32 = 5;
+pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
+pub const RLIMIT_CPU: u32 = 0;
+pub const RLIMIT_FSIZE: u32 = 1;
+pub const RLIMIT_DATA: u32 = 2;
+pub const RLIMIT_STACK: u32 = 3;
+pub const RLIMIT_CORE: u32 = 4;
+pub const RLIMIT_AS: u32 = 5;
+pub const RLIMIT_RSS: u32 = 5;
+pub const RLIMIT_MEMLOCK: u32 = 6;
+pub const RLIMIT_NPROC: u32 = 7;
+pub const RLIMIT_NOFILE: u32 = 8;
+pub const RLIM_NLIMITS: u32 = 9;
+pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
+pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
+pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
+pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
+pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
+pub const WAKEMON_ENABLE: u32 = 1;
+pub const WAKEMON_DISABLE: u32 = 2;
+pub const WAKEMON_GET_PARAMS: u32 = 4;
+pub const WAKEMON_SET_DEFAULTS: u32 = 8;
+pub const WAKEMON_MAKE_FATAL: u32 = 16;
+pub const CPUMON_MAKE_FATAL: u32 = 4096;
+pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
+pub const IOPOL_TYPE_DISK: u32 = 0;
+pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
+pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
+pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
+pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
+pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
+pub const IOPOL_SCOPE_PROCESS: u32 = 0;
+pub const IOPOL_SCOPE_THREAD: u32 = 1;
+pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
+pub const IOPOL_DEFAULT: u32 = 0;
+pub const IOPOL_IMPORTANT: u32 = 1;
+pub const IOPOL_PASSIVE: u32 = 2;
+pub const IOPOL_THROTTLE: u32 = 3;
+pub const IOPOL_UTILITY: u32 = 4;
+pub const IOPOL_STANDARD: u32 = 5;
+pub const IOPOL_APPLICATION: u32 = 5;
+pub const IOPOL_NORMAL: u32 = 1;
+pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
+pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
+pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
+pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
+pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
+pub const WCOREFLAG: u32 = 128;
+pub const _WSTOPPED: u32 = 127;
 pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
-pub const __ldiv_t_defined: u32 = 1;
-pub const __lldiv_t_defined: u32 = 1;
-pub const RAND_MAX: u32 = 2147483647;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const _SYS_TYPES_H: u32 = 1;
-pub const __clock_t_defined: u32 = 1;
-pub const __clockid_t_defined: u32 = 1;
-pub const __time_t_defined: u32 = 1;
-pub const __timer_t_defined: u32 = 1;
-pub const _BITS_STDINT_INTN_H: u32 = 1;
-pub const __BIT_TYPES_DEFINED__: u32 = 1;
-pub const _ENDIAN_H: u32 = 1;
-pub const _BITS_ENDIAN_H: u32 = 1;
-pub const __LITTLE_ENDIAN: u32 = 1234;
-pub const __BIG_ENDIAN: u32 = 4321;
-pub const __PDP_ENDIAN: u32 = 3412;
-pub const _BITS_ENDIANNESS_H: u32 = 1;
-pub const __BYTE_ORDER: u32 = 1234;
-pub const __FLOAT_WORD_ORDER: u32 = 1234;
+pub const WSTOPPED: u32 = 8;
+pub const WCONTINUED: u32 = 16;
+pub const WNOWAIT: u32 = 32;
+pub const WAIT_ANY: i32 = -1;
+pub const WAIT_MYPGRP: u32 = 0;
+pub const _QUAD_HIGHWORD: u32 = 1;
+pub const _QUAD_LOWWORD: u32 = 0;
+pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
+pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
+pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
+pub const __DARWIN_BYTE_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const _BITS_BYTESWAP_H: u32 = 1;
-pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
-pub const _SYS_SELECT_H: u32 = 1;
-pub const __sigset_t_defined: u32 = 1;
-pub const __timeval_defined: u32 = 1;
-pub const _STRUCT_TIMESPEC: u32 = 1;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const RAND_MAX: u32 = 2147483647;
+pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const __DARWIN_FD_SETSIZE: u32 = 1024;
+pub const __DARWIN_NBBY: u32 = 8;
+pub const NBBY: u32 = 8;
 pub const FD_SETSIZE: u32 = 1024;
-pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
-pub const _THREAD_SHARED_TYPES_H: u32 = 1;
-pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
-pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
-pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
-pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
-pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
-pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
-pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
-pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
-pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
-pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
-pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
-pub const __have_pthread_attr_t: u32 = 1;
-pub const _ALLOCA_H: u32 = 1;
-pub const _STRING_H: u32 = 1;
-pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
-pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
-pub const _STRINGS_H: u32 = 1;
-pub const _STDINT_H: u32 = 1;
-pub const _BITS_WCHAR_H: u32 = 1;
-pub const _BITS_STDINT_UINTN_H: u32 = 1;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i64 = -9223372036854775808;
-pub const INT_FAST32_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u64 = 9223372036854775807;
-pub const INT_FAST32_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: i32 = -1;
-pub const UINT_FAST32_MAX: i32 = -1;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const UINTPTR_MAX: i32 = -1;
-pub const PTRDIFF_MIN: i64 = -9223372036854775808;
-pub const PTRDIFF_MAX: u64 = 9223372036854775807;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const SIZE_MAX: i32 = -1;
-pub const WINT_MIN: u32 = 0;
-pub const WINT_MAX: u32 = 4294967295;
-pub const _ERRNO_H: u32 = 1;
-pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -570,7 +875,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EAGAIN: u32 = 11;
+pub const EDEADLK: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -594,147 +899,88 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EDEADLK: u32 = 35;
-pub const ENAMETOOLONG: u32 = 36;
-pub const ENOLCK: u32 = 37;
-pub const ENOSYS: u32 = 38;
-pub const ENOTEMPTY: u32 = 39;
-pub const ELOOP: u32 = 40;
-pub const EWOULDBLOCK: u32 = 11;
-pub const ENOMSG: u32 = 42;
-pub const EIDRM: u32 = 43;
-pub const ECHRNG: u32 = 44;
-pub const EL2NSYNC: u32 = 45;
-pub const EL3HLT: u32 = 46;
-pub const EL3RST: u32 = 47;
-pub const ELNRNG: u32 = 48;
-pub const EUNATCH: u32 = 49;
-pub const ENOCSI: u32 = 50;
-pub const EL2HLT: u32 = 51;
-pub const EBADE: u32 = 52;
-pub const EBADR: u32 = 53;
-pub const EXFULL: u32 = 54;
-pub const ENOANO: u32 = 55;
-pub const EBADRQC: u32 = 56;
-pub const EBADSLT: u32 = 57;
-pub const EDEADLOCK: u32 = 35;
-pub const EBFONT: u32 = 59;
-pub const ENOSTR: u32 = 60;
-pub const ENODATA: u32 = 61;
-pub const ETIME: u32 = 62;
-pub const ENOSR: u32 = 63;
-pub const ENONET: u32 = 64;
-pub const ENOPKG: u32 = 65;
-pub const EREMOTE: u32 = 66;
-pub const ENOLINK: u32 = 67;
-pub const EADV: u32 = 68;
-pub const ESRMNT: u32 = 69;
-pub const ECOMM: u32 = 70;
-pub const EPROTO: u32 = 71;
-pub const EMULTIHOP: u32 = 72;
-pub const EDOTDOT: u32 = 73;
-pub const EBADMSG: u32 = 74;
-pub const EOVERFLOW: u32 = 75;
-pub const ENOTUNIQ: u32 = 76;
-pub const EBADFD: u32 = 77;
-pub const EREMCHG: u32 = 78;
-pub const ELIBACC: u32 = 79;
-pub const ELIBBAD: u32 = 80;
-pub const ELIBSCN: u32 = 81;
-pub const ELIBMAX: u32 = 82;
-pub const ELIBEXEC: u32 = 83;
-pub const EILSEQ: u32 = 84;
-pub const ERESTART: u32 = 85;
-pub const ESTRPIPE: u32 = 86;
-pub const EUSERS: u32 = 87;
-pub const ENOTSOCK: u32 = 88;
-pub const EDESTADDRREQ: u32 = 89;
-pub const EMSGSIZE: u32 = 90;
-pub const EPROTOTYPE: u32 = 91;
-pub const ENOPROTOOPT: u32 = 92;
-pub const EPROTONOSUPPORT: u32 = 93;
-pub const ESOCKTNOSUPPORT: u32 = 94;
-pub const EOPNOTSUPP: u32 = 95;
-pub const EPFNOSUPPORT: u32 = 96;
-pub const EAFNOSUPPORT: u32 = 97;
-pub const EADDRINUSE: u32 = 98;
-pub const EADDRNOTAVAIL: u32 = 99;
-pub const ENETDOWN: u32 = 100;
-pub const ENETUNREACH: u32 = 101;
-pub const ENETRESET: u32 = 102;
-pub const ECONNABORTED: u32 = 103;
-pub const ECONNRESET: u32 = 104;
-pub const ENOBUFS: u32 = 105;
-pub const EISCONN: u32 = 106;
-pub const ENOTCONN: u32 = 107;
-pub const ESHUTDOWN: u32 = 108;
-pub const ETOOMANYREFS: u32 = 109;
-pub const ETIMEDOUT: u32 = 110;
-pub const ECONNREFUSED: u32 = 111;
-pub const EHOSTDOWN: u32 = 112;
-pub const EHOSTUNREACH: u32 = 113;
-pub const EALREADY: u32 = 114;
-pub const EINPROGRESS: u32 = 115;
-pub const ESTALE: u32 = 116;
-pub const EUCLEAN: u32 = 117;
-pub const ENOTNAM: u32 = 118;
-pub const ENAVAIL: u32 = 119;
-pub const EISNAM: u32 = 120;
-pub const EREMOTEIO: u32 = 121;
-pub const EDQUOT: u32 = 122;
-pub const ENOMEDIUM: u32 = 123;
-pub const EMEDIUMTYPE: u32 = 124;
-pub const ECANCELED: u32 = 125;
-pub const ENOKEY: u32 = 126;
-pub const EKEYEXPIRED: u32 = 127;
-pub const EKEYREVOKED: u32 = 128;
-pub const EKEYREJECTED: u32 = 129;
-pub const EOWNERDEAD: u32 = 130;
-pub const ENOTRECOVERABLE: u32 = 131;
-pub const ERFKILL: u32 = 132;
-pub const EHWPOISON: u32 = 133;
-pub const ENOTSUP: u32 = 95;
-pub const _LOCALE_H: u32 = 1;
-pub const _BITS_LOCALE_H: u32 = 1;
-pub const __LC_CTYPE: u32 = 0;
-pub const __LC_NUMERIC: u32 = 1;
-pub const __LC_TIME: u32 = 2;
-pub const __LC_COLLATE: u32 = 3;
-pub const __LC_MONETARY: u32 = 4;
-pub const __LC_MESSAGES: u32 = 5;
-pub const __LC_ALL: u32 = 6;
-pub const __LC_PAPER: u32 = 7;
-pub const __LC_NAME: u32 = 8;
-pub const __LC_ADDRESS: u32 = 9;
-pub const __LC_TELEPHONE: u32 = 10;
-pub const __LC_MEASUREMENT: u32 = 11;
-pub const __LC_IDENTIFICATION: u32 = 12;
-pub const LC_CTYPE: u32 = 0;
-pub const LC_NUMERIC: u32 = 1;
-pub const LC_TIME: u32 = 2;
-pub const LC_COLLATE: u32 = 3;
-pub const LC_MONETARY: u32 = 4;
-pub const LC_MESSAGES: u32 = 5;
-pub const LC_ALL: u32 = 6;
-pub const LC_PAPER: u32 = 7;
-pub const LC_NAME: u32 = 8;
-pub const LC_ADDRESS: u32 = 9;
-pub const LC_TELEPHONE: u32 = 10;
-pub const LC_MEASUREMENT: u32 = 11;
-pub const LC_IDENTIFICATION: u32 = 12;
-pub const LC_CTYPE_MASK: u32 = 1;
-pub const LC_NUMERIC_MASK: u32 = 2;
-pub const LC_TIME_MASK: u32 = 4;
-pub const LC_COLLATE_MASK: u32 = 8;
-pub const LC_MONETARY_MASK: u32 = 16;
-pub const LC_MESSAGES_MASK: u32 = 32;
-pub const LC_PAPER_MASK: u32 = 128;
-pub const LC_NAME_MASK: u32 = 256;
-pub const LC_ADDRESS_MASK: u32 = 512;
-pub const LC_TELEPHONE_MASK: u32 = 1024;
-pub const LC_MEASUREMENT_MASK: u32 = 2048;
-pub const LC_IDENTIFICATION_MASK: u32 = 4096;
-pub const LC_ALL_MASK: u32 = 8127;
+pub const EAGAIN: u32 = 35;
+pub const EWOULDBLOCK: u32 = 35;
+pub const EINPROGRESS: u32 = 36;
+pub const EALREADY: u32 = 37;
+pub const ENOTSOCK: u32 = 38;
+pub const EDESTADDRREQ: u32 = 39;
+pub const EMSGSIZE: u32 = 40;
+pub const EPROTOTYPE: u32 = 41;
+pub const ENOPROTOOPT: u32 = 42;
+pub const EPROTONOSUPPORT: u32 = 43;
+pub const ESOCKTNOSUPPORT: u32 = 44;
+pub const ENOTSUP: u32 = 45;
+pub const EPFNOSUPPORT: u32 = 46;
+pub const EAFNOSUPPORT: u32 = 47;
+pub const EADDRINUSE: u32 = 48;
+pub const EADDRNOTAVAIL: u32 = 49;
+pub const ENETDOWN: u32 = 50;
+pub const ENETUNREACH: u32 = 51;
+pub const ENETRESET: u32 = 52;
+pub const ECONNABORTED: u32 = 53;
+pub const ECONNRESET: u32 = 54;
+pub const ENOBUFS: u32 = 55;
+pub const EISCONN: u32 = 56;
+pub const ENOTCONN: u32 = 57;
+pub const ESHUTDOWN: u32 = 58;
+pub const ETOOMANYREFS: u32 = 59;
+pub const ETIMEDOUT: u32 = 60;
+pub const ECONNREFUSED: u32 = 61;
+pub const ELOOP: u32 = 62;
+pub const ENAMETOOLONG: u32 = 63;
+pub const EHOSTDOWN: u32 = 64;
+pub const EHOSTUNREACH: u32 = 65;
+pub const ENOTEMPTY: u32 = 66;
+pub const EPROCLIM: u32 = 67;
+pub const EUSERS: u32 = 68;
+pub const EDQUOT: u32 = 69;
+pub const ESTALE: u32 = 70;
+pub const EREMOTE: u32 = 71;
+pub const EBADRPC: u32 = 72;
+pub const ERPCMISMATCH: u32 = 73;
+pub const EPROGUNAVAIL: u32 = 74;
+pub const EPROGMISMATCH: u32 = 75;
+pub const EPROCUNAVAIL: u32 = 76;
+pub const ENOLCK: u32 = 77;
+pub const ENOSYS: u32 = 78;
+pub const EFTYPE: u32 = 79;
+pub const EAUTH: u32 = 80;
+pub const ENEEDAUTH: u32 = 81;
+pub const EPWROFF: u32 = 82;
+pub const EDEVERR: u32 = 83;
+pub const EOVERFLOW: u32 = 84;
+pub const EBADEXEC: u32 = 85;
+pub const EBADARCH: u32 = 86;
+pub const ESHLIBVERS: u32 = 87;
+pub const EBADMACHO: u32 = 88;
+pub const ECANCELED: u32 = 89;
+pub const EIDRM: u32 = 90;
+pub const ENOMSG: u32 = 91;
+pub const EILSEQ: u32 = 92;
+pub const ENOATTR: u32 = 93;
+pub const EBADMSG: u32 = 94;
+pub const EMULTIHOP: u32 = 95;
+pub const ENODATA: u32 = 96;
+pub const ENOLINK: u32 = 97;
+pub const ENOSR: u32 = 98;
+pub const ENOSTR: u32 = 99;
+pub const EPROTO: u32 = 100;
+pub const ETIME: u32 = 101;
+pub const EOPNOTSUPP: u32 = 102;
+pub const ENOPOLICY: u32 = 103;
+pub const ENOTRECOVERABLE: u32 = 104;
+pub const EOWNERDEAD: u32 = 105;
+pub const EQFULL: u32 = 106;
+pub const ELAST: u32 = 106;
+pub const LC_ALL: u32 = 0;
+pub const LC_COLLATE: u32 = 1;
+pub const LC_CTYPE: u32 = 2;
+pub const LC_MONETARY: u32 = 3;
+pub const LC_NUMERIC: u32 = 4;
+pub const LC_TIME: u32 = 5;
+pub const LC_MESSAGES: u32 = 6;
+pub const _LC_LAST: u32 = 7;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
@@ -764,355 +1010,375 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &'static [u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &'static [u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &'static [u8; 2usize] = b"w\0";
-pub const _CTYPE_H: u32 = 1;
-pub const _NETDB_H: u32 = 1;
-pub const _NETINET_IN_H: u32 = 1;
-pub const _SYS_SOCKET_H: u32 = 1;
-pub const __iovec_defined: u32 = 1;
+pub const _CACHED_RUNES: u32 = 256;
+pub const _CRMASK: i32 = -256;
+pub const _RUNE_MAGIC_A: &'static [u8; 9usize] = b"RuneMagA\0";
+pub const _CTYPE_A: u32 = 256;
+pub const _CTYPE_C: u32 = 512;
+pub const _CTYPE_D: u32 = 1024;
+pub const _CTYPE_G: u32 = 2048;
+pub const _CTYPE_L: u32 = 4096;
+pub const _CTYPE_P: u32 = 8192;
+pub const _CTYPE_S: u32 = 16384;
+pub const _CTYPE_U: u32 = 32768;
+pub const _CTYPE_X: u32 = 65536;
+pub const _CTYPE_B: u32 = 131072;
+pub const _CTYPE_R: u32 = 262144;
+pub const _CTYPE_I: u32 = 524288;
+pub const _CTYPE_T: u32 = 1048576;
+pub const _CTYPE_Q: u32 = 2097152;
+pub const _CTYPE_SW0: u32 = 536870912;
+pub const _CTYPE_SW1: u32 = 1073741824;
+pub const _CTYPE_SW2: u32 = 2147483648;
+pub const _CTYPE_SW3: u32 = 3221225472;
+pub const _CTYPE_SWM: u32 = 3758096384;
+pub const _CTYPE_SWS: u32 = 30;
+pub const KEV_INET_SUBCLASS: u32 = 1;
+pub const KEV_INET_NEW_ADDR: u32 = 1;
+pub const KEV_INET_CHANGED_ADDR: u32 = 2;
+pub const KEV_INET_ADDR_DELETED: u32 = 3;
+pub const KEV_INET_SIFDSTADDR: u32 = 4;
+pub const KEV_INET_SIFBRDADDR: u32 = 5;
+pub const KEV_INET_SIFNETMASK: u32 = 6;
+pub const KEV_INET_ARPCOLLISION: u32 = 7;
+pub const KEV_INET_PORTINUSE: u32 = 8;
+pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
+pub const KEV_INET_ARPRTRALIVE: u32 = 10;
+pub const KEV_DL_SUBCLASS: u32 = 2;
+pub const KEV_DL_SIFFLAGS: u32 = 1;
+pub const KEV_DL_SIFMETRICS: u32 = 2;
+pub const KEV_DL_SIFMTU: u32 = 3;
+pub const KEV_DL_SIFPHYS: u32 = 4;
+pub const KEV_DL_SIFMEDIA: u32 = 5;
+pub const KEV_DL_SIFGENERIC: u32 = 6;
+pub const KEV_DL_ADDMULTI: u32 = 7;
+pub const KEV_DL_DELMULTI: u32 = 8;
+pub const KEV_DL_IF_ATTACHED: u32 = 9;
+pub const KEV_DL_IF_DETACHING: u32 = 10;
+pub const KEV_DL_IF_DETACHED: u32 = 11;
+pub const KEV_DL_LINK_OFF: u32 = 12;
+pub const KEV_DL_LINK_ON: u32 = 13;
+pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
+pub const KEV_DL_PROTO_DETACHED: u32 = 15;
+pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
+pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
+pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
+pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
+pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
+pub const KEV_DL_NODE_PRESENCE: u32 = 21;
+pub const KEV_DL_NODE_ABSENCE: u32 = 22;
+pub const KEV_DL_MASTER_ELECTED: u32 = 23;
+pub const KEV_DL_ISSUES: u32 = 24;
+pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
+pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
+pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
+pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
+pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
+pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
+pub const KEV_INET6_SUBCLASS: u32 = 6;
+pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
+pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
+pub const KEV_INET6_ADDR_DELETED: u32 = 3;
+pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
+pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
+pub const KEV_INET6_DEFROUTER: u32 = 6;
+pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
+pub const SOCK_STREAM: u32 = 1;
+pub const SOCK_DGRAM: u32 = 2;
+pub const SOCK_RAW: u32 = 3;
+pub const SOCK_RDM: u32 = 4;
+pub const SOCK_SEQPACKET: u32 = 5;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_ACCEPTCONN: u32 = 2;
+pub const SO_REUSEADDR: u32 = 4;
+pub const SO_KEEPALIVE: u32 = 8;
+pub const SO_DONTROUTE: u32 = 16;
+pub const SO_BROADCAST: u32 = 32;
+pub const SO_USELOOPBACK: u32 = 64;
+pub const SO_LINGER: u32 = 128;
+pub const SO_OOBINLINE: u32 = 256;
+pub const SO_REUSEPORT: u32 = 512;
+pub const SO_TIMESTAMP: u32 = 1024;
+pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
+pub const SO_DONTTRUNC: u32 = 8192;
+pub const SO_WANTMORE: u32 = 16384;
+pub const SO_WANTOOBFLAG: u32 = 32768;
+pub const SO_SNDBUF: u32 = 4097;
+pub const SO_RCVBUF: u32 = 4098;
+pub const SO_SNDLOWAT: u32 = 4099;
+pub const SO_RCVLOWAT: u32 = 4100;
+pub const SO_SNDTIMEO: u32 = 4101;
+pub const SO_RCVTIMEO: u32 = 4102;
+pub const SO_ERROR: u32 = 4103;
+pub const SO_TYPE: u32 = 4104;
+pub const SO_LABEL: u32 = 4112;
+pub const SO_PEERLABEL: u32 = 4113;
+pub const SO_NREAD: u32 = 4128;
+pub const SO_NKE: u32 = 4129;
+pub const SO_NOSIGPIPE: u32 = 4130;
+pub const SO_NOADDRERR: u32 = 4131;
+pub const SO_NWRITE: u32 = 4132;
+pub const SO_REUSESHAREUID: u32 = 4133;
+pub const SO_NOTIFYCONFLICT: u32 = 4134;
+pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
+pub const SO_LINGER_SEC: u32 = 4224;
+pub const SO_RANDOMPORT: u32 = 4226;
+pub const SO_NP_EXTENSIONS: u32 = 4227;
+pub const SO_NUMRCVPKT: u32 = 4370;
+pub const SO_NET_SERVICE_TYPE: u32 = 4374;
+pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
+pub const NET_SERVICE_TYPE_BE: u32 = 0;
+pub const NET_SERVICE_TYPE_BK: u32 = 1;
+pub const NET_SERVICE_TYPE_SIG: u32 = 2;
+pub const NET_SERVICE_TYPE_VI: u32 = 3;
+pub const NET_SERVICE_TYPE_VO: u32 = 4;
+pub const NET_SERVICE_TYPE_RV: u32 = 5;
+pub const NET_SERVICE_TYPE_AV: u32 = 6;
+pub const NET_SERVICE_TYPE_OAM: u32 = 7;
+pub const NET_SERVICE_TYPE_RD: u32 = 8;
+pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
+pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
+pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
+pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
+pub const SAE_ASSOCID_ANY: u32 = 0;
+pub const SAE_CONNID_ANY: u32 = 0;
+pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
+pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
+pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
+pub const SONPX_SETOPTSHUT: u32 = 1;
+pub const SOL_SOCKET: u32 = 65535;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_UNIX: u32 = 1;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_IMPLINK: u32 = 3;
+pub const AF_PUP: u32 = 4;
+pub const AF_CHAOS: u32 = 5;
+pub const AF_NS: u32 = 6;
+pub const AF_ISO: u32 = 7;
+pub const AF_OSI: u32 = 7;
+pub const AF_ECMA: u32 = 8;
+pub const AF_DATAKIT: u32 = 9;
+pub const AF_CCITT: u32 = 10;
+pub const AF_SNA: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_DLI: u32 = 13;
+pub const AF_LAT: u32 = 14;
+pub const AF_HYLINK: u32 = 15;
+pub const AF_APPLETALK: u32 = 16;
+pub const AF_ROUTE: u32 = 17;
+pub const AF_LINK: u32 = 18;
+pub const pseudo_AF_XTP: u32 = 19;
+pub const AF_COIP: u32 = 20;
+pub const AF_CNT: u32 = 21;
+pub const pseudo_AF_RTIP: u32 = 22;
+pub const AF_IPX: u32 = 23;
+pub const AF_SIP: u32 = 24;
+pub const pseudo_AF_PIP: u32 = 25;
+pub const AF_NDRV: u32 = 27;
+pub const AF_ISDN: u32 = 28;
+pub const AF_E164: u32 = 28;
+pub const pseudo_AF_KEY: u32 = 29;
+pub const AF_INET6: u32 = 30;
+pub const AF_NATM: u32 = 31;
+pub const AF_SYSTEM: u32 = 32;
+pub const AF_NETBIOS: u32 = 33;
+pub const AF_PPP: u32 = 34;
+pub const pseudo_AF_HDRCMPLT: u32 = 35;
+pub const AF_RESERVED_36: u32 = 36;
+pub const AF_IEEE80211: u32 = 37;
+pub const AF_UTUN: u32 = 38;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_MAX: u32 = 41;
+pub const SOCK_MAXADDRLEN: u32 = 255;
+pub const _SS_MAXSIZE: u32 = 128;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
-pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_AX25: u32 = 3;
-pub const PF_IPX: u32 = 4;
-pub const PF_APPLETALK: u32 = 5;
-pub const PF_NETROM: u32 = 6;
-pub const PF_BRIDGE: u32 = 7;
-pub const PF_ATMPVC: u32 = 8;
-pub const PF_X25: u32 = 9;
-pub const PF_INET6: u32 = 10;
-pub const PF_ROSE: u32 = 11;
+pub const PF_IMPLINK: u32 = 3;
+pub const PF_PUP: u32 = 4;
+pub const PF_CHAOS: u32 = 5;
+pub const PF_NS: u32 = 6;
+pub const PF_ISO: u32 = 7;
+pub const PF_OSI: u32 = 7;
+pub const PF_ECMA: u32 = 8;
+pub const PF_DATAKIT: u32 = 9;
+pub const PF_CCITT: u32 = 10;
+pub const PF_SNA: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_NETBEUI: u32 = 13;
-pub const PF_SECURITY: u32 = 14;
-pub const PF_KEY: u32 = 15;
-pub const PF_NETLINK: u32 = 16;
-pub const PF_ROUTE: u32 = 16;
-pub const PF_PACKET: u32 = 17;
-pub const PF_ASH: u32 = 18;
-pub const PF_ECONET: u32 = 19;
-pub const PF_ATMSVC: u32 = 20;
-pub const PF_RDS: u32 = 21;
-pub const PF_SNA: u32 = 22;
-pub const PF_IRDA: u32 = 23;
-pub const PF_PPPOX: u32 = 24;
-pub const PF_WANPIPE: u32 = 25;
-pub const PF_LLC: u32 = 26;
-pub const PF_IB: u32 = 27;
-pub const PF_MPLS: u32 = 28;
-pub const PF_CAN: u32 = 29;
-pub const PF_TIPC: u32 = 30;
-pub const PF_BLUETOOTH: u32 = 31;
-pub const PF_IUCV: u32 = 32;
-pub const PF_RXRPC: u32 = 33;
-pub const PF_ISDN: u32 = 34;
-pub const PF_PHONET: u32 = 35;
-pub const PF_IEEE802154: u32 = 36;
-pub const PF_CAIF: u32 = 37;
-pub const PF_ALG: u32 = 38;
-pub const PF_NFC: u32 = 39;
+pub const PF_DLI: u32 = 13;
+pub const PF_LAT: u32 = 14;
+pub const PF_HYLINK: u32 = 15;
+pub const PF_APPLETALK: u32 = 16;
+pub const PF_ROUTE: u32 = 17;
+pub const PF_LINK: u32 = 18;
+pub const PF_XTP: u32 = 19;
+pub const PF_COIP: u32 = 20;
+pub const PF_CNT: u32 = 21;
+pub const PF_SIP: u32 = 24;
+pub const PF_IPX: u32 = 23;
+pub const PF_RTIP: u32 = 22;
+pub const PF_PIP: u32 = 25;
+pub const PF_NDRV: u32 = 27;
+pub const PF_ISDN: u32 = 28;
+pub const PF_KEY: u32 = 29;
+pub const PF_INET6: u32 = 30;
+pub const PF_NATM: u32 = 31;
+pub const PF_SYSTEM: u32 = 32;
+pub const PF_NETBIOS: u32 = 33;
+pub const PF_PPP: u32 = 34;
+pub const PF_RESERVED_36: u32 = 36;
+pub const PF_UTUN: u32 = 38;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_KCM: u32 = 41;
-pub const PF_QIPCRTR: u32 = 42;
-pub const PF_SMC: u32 = 43;
-pub const PF_XDP: u32 = 44;
-pub const PF_MAX: u32 = 45;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_UNIX: u32 = 1;
-pub const AF_FILE: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_AX25: u32 = 3;
-pub const AF_IPX: u32 = 4;
-pub const AF_APPLETALK: u32 = 5;
-pub const AF_NETROM: u32 = 6;
-pub const AF_BRIDGE: u32 = 7;
-pub const AF_ATMPVC: u32 = 8;
-pub const AF_X25: u32 = 9;
-pub const AF_INET6: u32 = 10;
-pub const AF_ROSE: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_NETBEUI: u32 = 13;
-pub const AF_SECURITY: u32 = 14;
-pub const AF_KEY: u32 = 15;
-pub const AF_NETLINK: u32 = 16;
-pub const AF_ROUTE: u32 = 16;
-pub const AF_PACKET: u32 = 17;
-pub const AF_ASH: u32 = 18;
-pub const AF_ECONET: u32 = 19;
-pub const AF_ATMSVC: u32 = 20;
-pub const AF_RDS: u32 = 21;
-pub const AF_SNA: u32 = 22;
-pub const AF_IRDA: u32 = 23;
-pub const AF_PPPOX: u32 = 24;
-pub const AF_WANPIPE: u32 = 25;
-pub const AF_LLC: u32 = 26;
-pub const AF_IB: u32 = 27;
-pub const AF_MPLS: u32 = 28;
-pub const AF_CAN: u32 = 29;
-pub const AF_TIPC: u32 = 30;
-pub const AF_BLUETOOTH: u32 = 31;
-pub const AF_IUCV: u32 = 32;
-pub const AF_RXRPC: u32 = 33;
-pub const AF_ISDN: u32 = 34;
-pub const AF_PHONET: u32 = 35;
-pub const AF_IEEE802154: u32 = 36;
-pub const AF_CAIF: u32 = 37;
-pub const AF_ALG: u32 = 38;
-pub const AF_NFC: u32 = 39;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_KCM: u32 = 41;
-pub const AF_QIPCRTR: u32 = 42;
-pub const AF_SMC: u32 = 43;
-pub const AF_XDP: u32 = 44;
-pub const AF_MAX: u32 = 45;
-pub const SOL_RAW: u32 = 255;
-pub const SOL_DECNET: u32 = 261;
-pub const SOL_X25: u32 = 262;
-pub const SOL_PACKET: u32 = 263;
-pub const SOL_ATM: u32 = 264;
-pub const SOL_AAL: u32 = 265;
-pub const SOL_IRDA: u32 = 266;
-pub const SOL_NETBEUI: u32 = 267;
-pub const SOL_LLC: u32 = 268;
-pub const SOL_DCCP: u32 = 269;
-pub const SOL_NETLINK: u32 = 270;
-pub const SOL_TIPC: u32 = 271;
-pub const SOL_RXRPC: u32 = 272;
-pub const SOL_PPPOL2TP: u32 = 273;
-pub const SOL_BLUETOOTH: u32 = 274;
-pub const SOL_PNPIPE: u32 = 275;
-pub const SOL_RDS: u32 = 276;
-pub const SOL_IUCV: u32 = 277;
-pub const SOL_CAIF: u32 = 278;
-pub const SOL_ALG: u32 = 279;
-pub const SOL_NFC: u32 = 280;
-pub const SOL_KCM: u32 = 281;
-pub const SOL_TLS: u32 = 282;
-pub const SOL_XDP: u32 = 283;
-pub const SOMAXCONN: u32 = 4096;
-pub const _BITS_SOCKADDR_H: u32 = 1;
-pub const _SS_SIZE: u32 = 128;
-pub const __BITS_PER_LONG: u32 = 64;
-pub const FIOSETOWN: u32 = 35073;
-pub const SIOCSPGRP: u32 = 35074;
-pub const FIOGETOWN: u32 = 35075;
-pub const SIOCGPGRP: u32 = 35076;
-pub const SIOCATMARK: u32 = 35077;
-pub const SIOCGSTAMP_OLD: u32 = 35078;
-pub const SIOCGSTAMPNS_OLD: u32 = 35079;
-pub const SOL_SOCKET: u32 = 1;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_REUSEADDR: u32 = 2;
-pub const SO_TYPE: u32 = 3;
-pub const SO_ERROR: u32 = 4;
-pub const SO_DONTROUTE: u32 = 5;
-pub const SO_BROADCAST: u32 = 6;
-pub const SO_SNDBUF: u32 = 7;
-pub const SO_RCVBUF: u32 = 8;
-pub const SO_SNDBUFFORCE: u32 = 32;
-pub const SO_RCVBUFFORCE: u32 = 33;
-pub const SO_KEEPALIVE: u32 = 9;
-pub const SO_OOBINLINE: u32 = 10;
-pub const SO_NO_CHECK: u32 = 11;
-pub const SO_PRIORITY: u32 = 12;
-pub const SO_LINGER: u32 = 13;
-pub const SO_BSDCOMPAT: u32 = 14;
-pub const SO_REUSEPORT: u32 = 15;
-pub const SO_PASSCRED: u32 = 16;
-pub const SO_PEERCRED: u32 = 17;
-pub const SO_RCVLOWAT: u32 = 18;
-pub const SO_SNDLOWAT: u32 = 19;
-pub const SO_RCVTIMEO_OLD: u32 = 20;
-pub const SO_SNDTIMEO_OLD: u32 = 21;
-pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
-pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
-pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
-pub const SO_BINDTODEVICE: u32 = 25;
-pub const SO_ATTACH_FILTER: u32 = 26;
-pub const SO_DETACH_FILTER: u32 = 27;
-pub const SO_GET_FILTER: u32 = 26;
-pub const SO_PEERNAME: u32 = 28;
-pub const SO_ACCEPTCONN: u32 = 30;
-pub const SO_PEERSEC: u32 = 31;
-pub const SO_PASSSEC: u32 = 34;
-pub const SO_MARK: u32 = 36;
-pub const SO_PROTOCOL: u32 = 38;
-pub const SO_DOMAIN: u32 = 39;
-pub const SO_RXQ_OVFL: u32 = 40;
-pub const SO_WIFI_STATUS: u32 = 41;
-pub const SCM_WIFI_STATUS: u32 = 41;
-pub const SO_PEEK_OFF: u32 = 42;
-pub const SO_NOFCS: u32 = 43;
-pub const SO_LOCK_FILTER: u32 = 44;
-pub const SO_SELECT_ERR_QUEUE: u32 = 45;
-pub const SO_BUSY_POLL: u32 = 46;
-pub const SO_MAX_PACING_RATE: u32 = 47;
-pub const SO_BPF_EXTENSIONS: u32 = 48;
-pub const SO_INCOMING_CPU: u32 = 49;
-pub const SO_ATTACH_BPF: u32 = 50;
-pub const SO_DETACH_BPF: u32 = 27;
-pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
-pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
-pub const SO_CNX_ADVICE: u32 = 53;
-pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
-pub const SO_MEMINFO: u32 = 55;
-pub const SO_INCOMING_NAPI_ID: u32 = 56;
-pub const SO_COOKIE: u32 = 57;
-pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
-pub const SO_PEERGROUPS: u32 = 59;
-pub const SO_ZEROCOPY: u32 = 60;
-pub const SO_TXTIME: u32 = 61;
-pub const SCM_TXTIME: u32 = 61;
-pub const SO_BINDTOIFINDEX: u32 = 62;
-pub const SO_TIMESTAMP_OLD: u32 = 29;
-pub const SO_TIMESTAMPNS_OLD: u32 = 35;
-pub const SO_TIMESTAMPING_OLD: u32 = 37;
-pub const SO_TIMESTAMP_NEW: u32 = 63;
-pub const SO_TIMESTAMPNS_NEW: u32 = 64;
-pub const SO_TIMESTAMPING_NEW: u32 = 65;
-pub const SO_RCVTIMEO_NEW: u32 = 66;
-pub const SO_SNDTIMEO_NEW: u32 = 67;
-pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_TIMESTAMP: u32 = 29;
-pub const SO_TIMESTAMPNS: u32 = 35;
-pub const SO_TIMESTAMPING: u32 = 37;
-pub const SO_RCVTIMEO: u32 = 20;
-pub const SO_SNDTIMEO: u32 = 21;
-pub const SCM_TIMESTAMP: u32 = 29;
-pub const SCM_TIMESTAMPNS: u32 = 35;
-pub const SCM_TIMESTAMPING: u32 = 37;
-pub const __osockaddr_defined: u32 = 1;
-pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
-pub const IP_OPTIONS: u32 = 4;
-pub const IP_HDRINCL: u32 = 3;
-pub const IP_TOS: u32 = 1;
-pub const IP_TTL: u32 = 2;
-pub const IP_RECVOPTS: u32 = 6;
-pub const IP_RETOPTS: u32 = 7;
-pub const IP_MULTICAST_IF: u32 = 32;
-pub const IP_MULTICAST_TTL: u32 = 33;
-pub const IP_MULTICAST_LOOP: u32 = 34;
-pub const IP_ADD_MEMBERSHIP: u32 = 35;
-pub const IP_DROP_MEMBERSHIP: u32 = 36;
-pub const IP_UNBLOCK_SOURCE: u32 = 37;
-pub const IP_BLOCK_SOURCE: u32 = 38;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
-pub const IP_MSFILTER: u32 = 41;
-pub const MCAST_JOIN_GROUP: u32 = 42;
-pub const MCAST_BLOCK_SOURCE: u32 = 43;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
-pub const MCAST_LEAVE_GROUP: u32 = 45;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
-pub const MCAST_MSFILTER: u32 = 48;
-pub const IP_MULTICAST_ALL: u32 = 49;
-pub const IP_UNICAST_IF: u32 = 50;
-pub const MCAST_EXCLUDE: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const IP_ROUTER_ALERT: u32 = 5;
-pub const IP_PKTINFO: u32 = 8;
-pub const IP_PKTOPTIONS: u32 = 9;
-pub const IP_PMTUDISC: u32 = 10;
-pub const IP_MTU_DISCOVER: u32 = 10;
-pub const IP_RECVERR: u32 = 11;
-pub const IP_RECVTTL: u32 = 12;
-pub const IP_RECVTOS: u32 = 13;
-pub const IP_MTU: u32 = 14;
-pub const IP_FREEBIND: u32 = 15;
-pub const IP_IPSEC_POLICY: u32 = 16;
-pub const IP_XFRM_POLICY: u32 = 17;
-pub const IP_PASSSEC: u32 = 18;
-pub const IP_TRANSPARENT: u32 = 19;
-pub const IP_ORIGDSTADDR: u32 = 20;
-pub const IP_RECVORIGDSTADDR: u32 = 20;
-pub const IP_MINTTL: u32 = 21;
-pub const IP_NODEFRAG: u32 = 22;
-pub const IP_CHECKSUM: u32 = 23;
-pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
-pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_PMTUDISC_DONT: u32 = 0;
-pub const IP_PMTUDISC_WANT: u32 = 1;
-pub const IP_PMTUDISC_DO: u32 = 2;
-pub const IP_PMTUDISC_PROBE: u32 = 3;
-pub const IP_PMTUDISC_INTERFACE: u32 = 4;
-pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const SOL_IP: u32 = 0;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MAX_MEMBERSHIPS: u32 = 20;
-pub const IPV6_ADDRFORM: u32 = 1;
-pub const IPV6_2292PKTINFO: u32 = 2;
-pub const IPV6_2292HOPOPTS: u32 = 3;
-pub const IPV6_2292DSTOPTS: u32 = 4;
-pub const IPV6_2292RTHDR: u32 = 5;
-pub const IPV6_2292PKTOPTIONS: u32 = 6;
-pub const IPV6_CHECKSUM: u32 = 7;
-pub const IPV6_2292HOPLIMIT: u32 = 8;
-pub const IPV6_NEXTHOP: u32 = 9;
-pub const IPV6_AUTHHDR: u32 = 10;
-pub const IPV6_UNICAST_HOPS: u32 = 16;
-pub const IPV6_MULTICAST_IF: u32 = 17;
-pub const IPV6_MULTICAST_HOPS: u32 = 18;
-pub const IPV6_MULTICAST_LOOP: u32 = 19;
-pub const IPV6_JOIN_GROUP: u32 = 20;
-pub const IPV6_LEAVE_GROUP: u32 = 21;
-pub const IPV6_ROUTER_ALERT: u32 = 22;
-pub const IPV6_MTU_DISCOVER: u32 = 23;
-pub const IPV6_MTU: u32 = 24;
-pub const IPV6_RECVERR: u32 = 25;
-pub const IPV6_V6ONLY: u32 = 26;
-pub const IPV6_JOIN_ANYCAST: u32 = 27;
-pub const IPV6_LEAVE_ANYCAST: u32 = 28;
-pub const IPV6_MULTICAST_ALL: u32 = 29;
-pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_IPSEC_POLICY: u32 = 34;
-pub const IPV6_XFRM_POLICY: u32 = 35;
-pub const IPV6_HDRINCL: u32 = 36;
-pub const IPV6_RECVPKTINFO: u32 = 49;
-pub const IPV6_PKTINFO: u32 = 50;
-pub const IPV6_RECVHOPLIMIT: u32 = 51;
-pub const IPV6_HOPLIMIT: u32 = 52;
-pub const IPV6_RECVHOPOPTS: u32 = 53;
-pub const IPV6_HOPOPTS: u32 = 54;
-pub const IPV6_RTHDRDSTOPTS: u32 = 55;
-pub const IPV6_RECVRTHDR: u32 = 56;
-pub const IPV6_RTHDR: u32 = 57;
-pub const IPV6_RECVDSTOPTS: u32 = 58;
-pub const IPV6_DSTOPTS: u32 = 59;
-pub const IPV6_RECVPATHMTU: u32 = 60;
-pub const IPV6_PATHMTU: u32 = 61;
-pub const IPV6_DONTFRAG: u32 = 62;
-pub const IPV6_RECVTCLASS: u32 = 66;
-pub const IPV6_TCLASS: u32 = 67;
-pub const IPV6_AUTOFLOWLABEL: u32 = 70;
-pub const IPV6_ADDR_PREFERENCES: u32 = 72;
-pub const IPV6_MINHOPCOUNT: u32 = 73;
-pub const IPV6_ORIGDSTADDR: u32 = 74;
-pub const IPV6_RECVORIGDSTADDR: u32 = 74;
-pub const IPV6_TRANSPARENT: u32 = 75;
-pub const IPV6_UNICAST_IF: u32 = 76;
-pub const IPV6_RECVFRAGSIZE: u32 = 77;
-pub const IPV6_FREEBIND: u32 = 78;
-pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
-pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
-pub const IPV6_RXHOPOPTS: u32 = 54;
-pub const IPV6_RXDSTOPTS: u32 = 59;
-pub const IPV6_PMTUDISC_DONT: u32 = 0;
-pub const IPV6_PMTUDISC_WANT: u32 = 1;
-pub const IPV6_PMTUDISC_DO: u32 = 2;
-pub const IPV6_PMTUDISC_PROBE: u32 = 3;
-pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
-pub const IPV6_PMTUDISC_OMIT: u32 = 5;
-pub const SOL_IPV6: u32 = 41;
-pub const SOL_ICMPV6: u32 = 58;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
+pub const PF_MAX: u32 = 41;
+pub const NET_MAXID: u32 = 41;
+pub const NET_RT_DUMP: u32 = 1;
+pub const NET_RT_FLAGS: u32 = 2;
+pub const NET_RT_IFLIST: u32 = 3;
+pub const NET_RT_STAT: u32 = 4;
+pub const NET_RT_TRASH: u32 = 5;
+pub const NET_RT_IFLIST2: u32 = 6;
+pub const NET_RT_DUMP2: u32 = 7;
+pub const NET_RT_FLAGS_PRIV: u32 = 10;
+pub const NET_RT_MAXID: u32 = 11;
+pub const SOMAXCONN: u32 = 128;
+pub const MSG_OOB: u32 = 1;
+pub const MSG_PEEK: u32 = 2;
+pub const MSG_DONTROUTE: u32 = 4;
+pub const MSG_EOR: u32 = 8;
+pub const MSG_TRUNC: u32 = 16;
+pub const MSG_CTRUNC: u32 = 32;
+pub const MSG_WAITALL: u32 = 64;
+pub const MSG_DONTWAIT: u32 = 128;
+pub const MSG_EOF: u32 = 256;
+pub const MSG_WAITSTREAM: u32 = 512;
+pub const MSG_FLUSH: u32 = 1024;
+pub const MSG_HOLD: u32 = 2048;
+pub const MSG_SEND: u32 = 4096;
+pub const MSG_HAVEMORE: u32 = 8192;
+pub const MSG_RCVMORE: u32 = 16384;
+pub const MSG_NEEDSA: u32 = 65536;
+pub const MSG_NOSIGNAL: u32 = 524288;
+pub const SCM_RIGHTS: u32 = 1;
+pub const SCM_TIMESTAMP: u32 = 2;
+pub const SCM_CREDS: u32 = 3;
+pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
+pub const SHUT_RD: u32 = 0;
+pub const SHUT_WR: u32 = 1;
+pub const SHUT_RDWR: u32 = 2;
+pub const IPPROTO_IP: u32 = 0;
+pub const IPPROTO_HOPOPTS: u32 = 0;
+pub const IPPROTO_ICMP: u32 = 1;
+pub const IPPROTO_IGMP: u32 = 2;
+pub const IPPROTO_GGP: u32 = 3;
+pub const IPPROTO_IPV4: u32 = 4;
+pub const IPPROTO_IPIP: u32 = 4;
+pub const IPPROTO_TCP: u32 = 6;
+pub const IPPROTO_ST: u32 = 7;
+pub const IPPROTO_EGP: u32 = 8;
+pub const IPPROTO_PIGP: u32 = 9;
+pub const IPPROTO_RCCMON: u32 = 10;
+pub const IPPROTO_NVPII: u32 = 11;
+pub const IPPROTO_PUP: u32 = 12;
+pub const IPPROTO_ARGUS: u32 = 13;
+pub const IPPROTO_EMCON: u32 = 14;
+pub const IPPROTO_XNET: u32 = 15;
+pub const IPPROTO_CHAOS: u32 = 16;
+pub const IPPROTO_UDP: u32 = 17;
+pub const IPPROTO_MUX: u32 = 18;
+pub const IPPROTO_MEAS: u32 = 19;
+pub const IPPROTO_HMP: u32 = 20;
+pub const IPPROTO_PRM: u32 = 21;
+pub const IPPROTO_IDP: u32 = 22;
+pub const IPPROTO_TRUNK1: u32 = 23;
+pub const IPPROTO_TRUNK2: u32 = 24;
+pub const IPPROTO_LEAF1: u32 = 25;
+pub const IPPROTO_LEAF2: u32 = 26;
+pub const IPPROTO_RDP: u32 = 27;
+pub const IPPROTO_IRTP: u32 = 28;
+pub const IPPROTO_TP: u32 = 29;
+pub const IPPROTO_BLT: u32 = 30;
+pub const IPPROTO_NSP: u32 = 31;
+pub const IPPROTO_INP: u32 = 32;
+pub const IPPROTO_SEP: u32 = 33;
+pub const IPPROTO_3PC: u32 = 34;
+pub const IPPROTO_IDPR: u32 = 35;
+pub const IPPROTO_XTP: u32 = 36;
+pub const IPPROTO_DDP: u32 = 37;
+pub const IPPROTO_CMTP: u32 = 38;
+pub const IPPROTO_TPXX: u32 = 39;
+pub const IPPROTO_IL: u32 = 40;
+pub const IPPROTO_IPV6: u32 = 41;
+pub const IPPROTO_SDRP: u32 = 42;
+pub const IPPROTO_ROUTING: u32 = 43;
+pub const IPPROTO_FRAGMENT: u32 = 44;
+pub const IPPROTO_IDRP: u32 = 45;
+pub const IPPROTO_RSVP: u32 = 46;
+pub const IPPROTO_GRE: u32 = 47;
+pub const IPPROTO_MHRP: u32 = 48;
+pub const IPPROTO_BHA: u32 = 49;
+pub const IPPROTO_ESP: u32 = 50;
+pub const IPPROTO_AH: u32 = 51;
+pub const IPPROTO_INLSP: u32 = 52;
+pub const IPPROTO_SWIPE: u32 = 53;
+pub const IPPROTO_NHRP: u32 = 54;
+pub const IPPROTO_ICMPV6: u32 = 58;
+pub const IPPROTO_NONE: u32 = 59;
+pub const IPPROTO_DSTOPTS: u32 = 60;
+pub const IPPROTO_AHIP: u32 = 61;
+pub const IPPROTO_CFTP: u32 = 62;
+pub const IPPROTO_HELLO: u32 = 63;
+pub const IPPROTO_SATEXPAK: u32 = 64;
+pub const IPPROTO_KRYPTOLAN: u32 = 65;
+pub const IPPROTO_RVD: u32 = 66;
+pub const IPPROTO_IPPC: u32 = 67;
+pub const IPPROTO_ADFS: u32 = 68;
+pub const IPPROTO_SATMON: u32 = 69;
+pub const IPPROTO_VISA: u32 = 70;
+pub const IPPROTO_IPCV: u32 = 71;
+pub const IPPROTO_CPNX: u32 = 72;
+pub const IPPROTO_CPHB: u32 = 73;
+pub const IPPROTO_WSN: u32 = 74;
+pub const IPPROTO_PVP: u32 = 75;
+pub const IPPROTO_BRSATMON: u32 = 76;
+pub const IPPROTO_ND: u32 = 77;
+pub const IPPROTO_WBMON: u32 = 78;
+pub const IPPROTO_WBEXPAK: u32 = 79;
+pub const IPPROTO_EON: u32 = 80;
+pub const IPPROTO_VMTP: u32 = 81;
+pub const IPPROTO_SVMTP: u32 = 82;
+pub const IPPROTO_VINES: u32 = 83;
+pub const IPPROTO_TTP: u32 = 84;
+pub const IPPROTO_IGP: u32 = 85;
+pub const IPPROTO_DGP: u32 = 86;
+pub const IPPROTO_TCF: u32 = 87;
+pub const IPPROTO_IGRP: u32 = 88;
+pub const IPPROTO_OSPFIGP: u32 = 89;
+pub const IPPROTO_SRPC: u32 = 90;
+pub const IPPROTO_LARP: u32 = 91;
+pub const IPPROTO_MTP: u32 = 92;
+pub const IPPROTO_AX25: u32 = 93;
+pub const IPPROTO_IPEIP: u32 = 94;
+pub const IPPROTO_MICP: u32 = 95;
+pub const IPPROTO_SCCSP: u32 = 96;
+pub const IPPROTO_ETHERIP: u32 = 97;
+pub const IPPROTO_ENCAP: u32 = 98;
+pub const IPPROTO_APES: u32 = 99;
+pub const IPPROTO_GMTP: u32 = 100;
+pub const IPPROTO_PIM: u32 = 103;
+pub const IPPROTO_IPCOMP: u32 = 108;
+pub const IPPROTO_PGM: u32 = 113;
+pub const IPPROTO_SCTP: u32 = 132;
+pub const IPPROTO_DIVERT: u32 = 254;
+pub const IPPROTO_RAW: u32 = 255;
+pub const IPPROTO_MAX: u32 = 256;
+pub const IPPROTO_DONE: u32 = 257;
+pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
+pub const IPPORT_USERRESERVED: u32 = 5000;
+pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
+pub const IPPORT_HILASTAUTO: u32 = 65535;
+pub const IPPORT_RESERVEDSTART: u32 = 600;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1124,49 +1390,269 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
+pub const IN_CLASSD_NET: u32 = 4026531840;
+pub const IN_CLASSD_NSHIFT: u32 = 28;
+pub const IN_CLASSD_HOST: u32 = 268435455;
+pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
+pub const IP_OPTIONS: u32 = 1;
+pub const IP_HDRINCL: u32 = 2;
+pub const IP_TOS: u32 = 3;
+pub const IP_TTL: u32 = 4;
+pub const IP_RECVOPTS: u32 = 5;
+pub const IP_RECVRETOPTS: u32 = 6;
+pub const IP_RECVDSTADDR: u32 = 7;
+pub const IP_RETOPTS: u32 = 8;
+pub const IP_MULTICAST_IF: u32 = 9;
+pub const IP_MULTICAST_TTL: u32 = 10;
+pub const IP_MULTICAST_LOOP: u32 = 11;
+pub const IP_ADD_MEMBERSHIP: u32 = 12;
+pub const IP_DROP_MEMBERSHIP: u32 = 13;
+pub const IP_MULTICAST_VIF: u32 = 14;
+pub const IP_RSVP_ON: u32 = 15;
+pub const IP_RSVP_OFF: u32 = 16;
+pub const IP_RSVP_VIF_ON: u32 = 17;
+pub const IP_RSVP_VIF_OFF: u32 = 18;
+pub const IP_PORTRANGE: u32 = 19;
+pub const IP_RECVIF: u32 = 20;
+pub const IP_IPSEC_POLICY: u32 = 21;
+pub const IP_FAITH: u32 = 22;
+pub const IP_STRIPHDR: u32 = 23;
+pub const IP_RECVTTL: u32 = 24;
+pub const IP_BOUND_IF: u32 = 25;
+pub const IP_PKTINFO: u32 = 26;
+pub const IP_RECVPKTINFO: u32 = 26;
+pub const IP_RECVTOS: u32 = 27;
+pub const IP_DONTFRAG: u32 = 28;
+pub const IP_FW_ADD: u32 = 40;
+pub const IP_FW_DEL: u32 = 41;
+pub const IP_FW_FLUSH: u32 = 42;
+pub const IP_FW_ZERO: u32 = 43;
+pub const IP_FW_GET: u32 = 44;
+pub const IP_FW_RESETLOG: u32 = 45;
+pub const IP_OLD_FW_ADD: u32 = 50;
+pub const IP_OLD_FW_DEL: u32 = 51;
+pub const IP_OLD_FW_FLUSH: u32 = 52;
+pub const IP_OLD_FW_ZERO: u32 = 53;
+pub const IP_OLD_FW_GET: u32 = 54;
+pub const IP_NAT__XXX: u32 = 55;
+pub const IP_OLD_FW_RESETLOG: u32 = 56;
+pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
+pub const IP_DUMMYNET_DEL: u32 = 61;
+pub const IP_DUMMYNET_FLUSH: u32 = 62;
+pub const IP_DUMMYNET_GET: u32 = 64;
+pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
+pub const IP_MULTICAST_IFINDEX: u32 = 66;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
+pub const IP_BLOCK_SOURCE: u32 = 72;
+pub const IP_UNBLOCK_SOURCE: u32 = 73;
+pub const IP_MSFILTER: u32 = 74;
+pub const MCAST_JOIN_GROUP: u32 = 80;
+pub const MCAST_LEAVE_GROUP: u32 = 81;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
+pub const MCAST_BLOCK_SOURCE: u32 = 84;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MIN_MEMBERSHIPS: u32 = 31;
+pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
+pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
+pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
+pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
+pub const MCAST_UNDEFINED: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const MCAST_EXCLUDE: u32 = 2;
+pub const IP_PORTRANGE_DEFAULT: u32 = 0;
+pub const IP_PORTRANGE_HIGH: u32 = 1;
+pub const IP_PORTRANGE_LOW: u32 = 2;
+pub const IPPROTO_MAXID: u32 = 52;
+pub const IPCTL_FORWARDING: u32 = 1;
+pub const IPCTL_SENDREDIRECTS: u32 = 2;
+pub const IPCTL_DEFTTL: u32 = 3;
+pub const IPCTL_RTEXPIRE: u32 = 5;
+pub const IPCTL_RTMINEXPIRE: u32 = 6;
+pub const IPCTL_RTMAXCACHE: u32 = 7;
+pub const IPCTL_SOURCEROUTE: u32 = 8;
+pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
+pub const IPCTL_INTRQMAXLEN: u32 = 10;
+pub const IPCTL_INTRQDROPS: u32 = 11;
+pub const IPCTL_STATS: u32 = 12;
+pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
+pub const IPCTL_FASTFORWARDING: u32 = 14;
+pub const IPCTL_KEEPFAITH: u32 = 15;
+pub const IPCTL_GIF_TTL: u32 = 16;
+pub const IPCTL_MAXID: u32 = 17;
+pub const __KAME_VERSION: &'static [u8; 18usize] = b"2009/apple-darwin\0";
+pub const IPV6PORT_RESERVED: u32 = 1024;
+pub const IPV6PORT_ANONMIN: u32 = 49152;
+pub const IPV6PORT_ANONMAX: u32 = 65535;
+pub const IPV6PORT_RESERVEDMIN: u32 = 600;
+pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const _RPC_NETDB_H: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
+pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
+pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
+pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
+pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
+pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
+pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
+pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
+pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
+pub const IPV6_UNICAST_HOPS: u32 = 4;
+pub const IPV6_MULTICAST_IF: u32 = 9;
+pub const IPV6_MULTICAST_HOPS: u32 = 10;
+pub const IPV6_MULTICAST_LOOP: u32 = 11;
+pub const IPV6_JOIN_GROUP: u32 = 12;
+pub const IPV6_LEAVE_GROUP: u32 = 13;
+pub const IPV6_PORTRANGE: u32 = 14;
+pub const ICMP6_FILTER: u32 = 18;
+pub const IPV6_2292PKTINFO: u32 = 19;
+pub const IPV6_2292HOPLIMIT: u32 = 20;
+pub const IPV6_2292NEXTHOP: u32 = 21;
+pub const IPV6_2292HOPOPTS: u32 = 22;
+pub const IPV6_2292DSTOPTS: u32 = 23;
+pub const IPV6_2292RTHDR: u32 = 24;
+pub const IPV6_2292PKTOPTIONS: u32 = 25;
+pub const IPV6_CHECKSUM: u32 = 26;
+pub const IPV6_V6ONLY: u32 = 27;
+pub const IPV6_BINDV6ONLY: u32 = 27;
+pub const IPV6_IPSEC_POLICY: u32 = 28;
+pub const IPV6_FAITH: u32 = 29;
+pub const IPV6_FW_ADD: u32 = 30;
+pub const IPV6_FW_DEL: u32 = 31;
+pub const IPV6_FW_FLUSH: u32 = 32;
+pub const IPV6_FW_ZERO: u32 = 33;
+pub const IPV6_FW_GET: u32 = 34;
+pub const IPV6_RECVTCLASS: u32 = 35;
+pub const IPV6_TCLASS: u32 = 36;
+pub const IPV6_BOUND_IF: u32 = 125;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
+pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
+pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
+pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
+pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
+pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
+pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
+pub const IPV6_PORTRANGE_HIGH: u32 = 1;
+pub const IPV6_PORTRANGE_LOW: u32 = 2;
+pub const IPV6PROTO_MAXID: u32 = 104;
+pub const IPV6CTL_FORWARDING: u32 = 1;
+pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
+pub const IPV6CTL_DEFHLIM: u32 = 3;
+pub const IPV6CTL_FORWSRCRT: u32 = 5;
+pub const IPV6CTL_STATS: u32 = 6;
+pub const IPV6CTL_MRTSTATS: u32 = 7;
+pub const IPV6CTL_MRTPROTO: u32 = 8;
+pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
+pub const IPV6CTL_SOURCECHECK: u32 = 10;
+pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
+pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
+pub const IPV6CTL_KEEPFAITH: u32 = 13;
+pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
+pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
+pub const IPV6CTL_DAD_COUNT: u32 = 16;
+pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
+pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
+pub const IPV6CTL_GIF_HLIM: u32 = 19;
+pub const IPV6CTL_KAME_VERSION: u32 = 20;
+pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
+pub const IPV6CTL_RR_PRUNE: u32 = 22;
+pub const IPV6CTL_V6ONLY: u32 = 24;
+pub const IPV6CTL_RTEXPIRE: u32 = 25;
+pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
+pub const IPV6CTL_RTMAXCACHE: u32 = 27;
+pub const IPV6CTL_USETEMPADDR: u32 = 32;
+pub const IPV6CTL_TEMPPLTIME: u32 = 33;
+pub const IPV6CTL_TEMPVLTIME: u32 = 34;
+pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
+pub const IPV6CTL_RIP6STATS: u32 = 36;
+pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
+pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
+pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
+pub const IPV6CTL_MAXFRAGS: u32 = 41;
+pub const IPV6CTL_MCAST_PMTU: u32 = 44;
+pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
+pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
+pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
+pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
+pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
+pub const IPV6CTL_MAXID: u32 = 51;
 pub const _PATH_HEQUIV: &'static [u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &'static [u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &'static [u8; 14usize] = b"/etc/networks\0";
-pub const _PATH_NSSWITCH_CONF: &'static [u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &'static [u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &'static [u8; 14usize] = b"/etc/services\0";
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
+pub const EAI_ADDRFAMILY: u32 = 1;
+pub const EAI_AGAIN: u32 = 2;
+pub const EAI_BADFLAGS: u32 = 3;
+pub const EAI_FAIL: u32 = 4;
+pub const EAI_FAMILY: u32 = 5;
+pub const EAI_MEMORY: u32 = 6;
+pub const EAI_NODATA: u32 = 7;
+pub const EAI_NONAME: u32 = 8;
+pub const EAI_SERVICE: u32 = 9;
+pub const EAI_SOCKTYPE: u32 = 10;
+pub const EAI_SYSTEM: u32 = 11;
+pub const EAI_BADHINTS: u32 = 12;
+pub const EAI_PROTOCOL: u32 = 13;
+pub const EAI_OVERFLOW: u32 = 14;
+pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_V4MAPPED: u32 = 8;
-pub const AI_ALL: u32 = 16;
-pub const AI_ADDRCONFIG: u32 = 32;
-pub const AI_NUMERICSERV: u32 = 1024;
-pub const EAI_BADFLAGS: i32 = -1;
-pub const EAI_NONAME: i32 = -2;
-pub const EAI_AGAIN: i32 = -3;
-pub const EAI_FAIL: i32 = -4;
-pub const EAI_FAMILY: i32 = -6;
-pub const EAI_SOCKTYPE: i32 = -7;
-pub const EAI_SERVICE: i32 = -8;
-pub const EAI_MEMORY: i32 = -10;
-pub const EAI_SYSTEM: i32 = -11;
-pub const EAI_OVERFLOW: i32 = -12;
+pub const AI_NUMERICSERV: u32 = 4096;
+pub const AI_ALL: u32 = 256;
+pub const AI_V4MAPPED_CFG: u32 = 512;
+pub const AI_ADDRCONFIG: u32 = 1024;
+pub const AI_V4MAPPED: u32 = 2048;
+pub const AI_DEFAULT: u32 = 1536;
+pub const AI_UNUSABLE: u32 = 268435456;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NUMERICHOST: u32 = 1;
-pub const NI_NUMERICSERV: u32 = 2;
-pub const NI_NOFQDN: u32 = 4;
-pub const NI_NAMEREQD: u32 = 8;
+pub const NI_NOFQDN: u32 = 1;
+pub const NI_NUMERICHOST: u32 = 2;
+pub const NI_NAMEREQD: u32 = 4;
+pub const NI_NUMERICSERV: u32 = 8;
+pub const NI_NUMERICSCOPE: u32 = 256;
 pub const NI_DGRAM: u32 = 16;
-pub const _PWD_H: u32 = 1;
-pub const NSS_BUFLEN_PASSWD: u32 = 1024;
+pub const NI_WITHSCOPEID: u32 = 32;
+pub const SCOPE_DELIMITER: u8 = 37u8;
+pub const _PATH_PWD: &'static [u8; 5usize] = b"/etc\0";
+pub const _PATH_PASSWD: &'static [u8; 12usize] = b"/etc/passwd\0";
+pub const _PASSWD: &'static [u8; 7usize] = b"passwd\0";
+pub const _PATH_MASTERPASSWD: &'static [u8; 19usize] = b"/etc/master.passwd\0";
+pub const _PATH_MASTERPASSWD_LOCK: &'static [u8; 10usize] = b"/etc/ptmp\0";
+pub const _MASTERPASSWD: &'static [u8; 14usize] = b"master.passwd\0";
+pub const _PATH_MP_DB: &'static [u8; 12usize] = b"/etc/pwd.db\0";
+pub const _MP_DB: &'static [u8; 7usize] = b"pwd.db\0";
+pub const _PATH_SMP_DB: &'static [u8; 13usize] = b"/etc/spwd.db\0";
+pub const _SMP_DB: &'static [u8; 8usize] = b"spwd.db\0";
+pub const _PATH_PWD_MKDB: &'static [u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
+pub const _PW_KEYBYNAME: u8 = 49u8;
+pub const _PW_KEYBYNUM: u8 = 50u8;
+pub const _PW_KEYBYUID: u8 = 51u8;
+pub const _PASSWORD_EFMT1: u8 = 95u8;
+pub const _PASSWORD_LEN: u32 = 128;
+pub const _PASSWORD_NOUID: u32 = 1;
+pub const _PASSWORD_NOGID: u32 = 2;
+pub const _PASSWORD_NOCHG: u32 = 4;
+pub const _PASSWORD_NOEXP: u32 = 8;
+pub const _PASSWORD_WARNDAYS: u32 = 14;
+pub const _PASSWORD_CHGNOW: i32 = -1;
 pub const PGINVALID_SOCKET: i32 = -1;
 pub const PG_BACKEND_VERSIONSTR: &'static [u8; 28usize] = b"postgres (PostgreSQL) 13.2\n\0";
 pub const EXE: &'static [u8; 1usize] = b"\0";
@@ -1174,18 +1660,11 @@ pub const DEVNULL: &'static [u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
 pub const PG_STRERROR_R_BUFLEN: u32 = 256;
 pub const PG_IOLBF: u32 = 1;
-pub const _MATH_H: u32 = 1;
-pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
-pub const __FP_LOGB0_IS_MIN: u32 = 1;
-pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
+pub const FP_SUPERNORMAL: u32 = 6;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
-pub const __MATH_DECLARING_DOUBLE: u32 = 1;
-pub const __MATH_DECLARING_FLOATN: u32 = 0;
-pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
-pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1199,8 +1678,13 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const _SETJMP_H: u32 = 1;
-pub const _BITS_SETJMP_H: u32 = 1;
+pub const DOMAIN: u32 = 1;
+pub const SING: u32 = 2;
+pub const OVERFLOW: u32 = 3;
+pub const UNDERFLOW: u32 = 4;
+pub const TLOSS: u32 = 5;
+pub const PLOSS: u32 = 6;
+pub const _JBLEN: u32 = 37;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1270,139 +1754,153 @@ pub const LP_DEAD: u32 = 3;
 pub const SpecTokenOffsetNumber: u32 = 65534;
 pub const MovedPartitionsOffsetNumber: u32 = 65533;
 pub const FIELDNO_HEAPTUPLEDATA_DATA: u32 = 3;
-pub const _FCNTL_H: u32 = 1;
-pub const __O_LARGEFILE: u32 = 0;
-pub const F_GETLK64: u32 = 5;
-pub const F_SETLK64: u32 = 6;
-pub const F_SETLKW64: u32 = 7;
-pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_CREAT: u32 = 64;
-pub const O_EXCL: u32 = 128;
-pub const O_NOCTTY: u32 = 256;
-pub const O_TRUNC: u32 = 512;
-pub const O_APPEND: u32 = 1024;
-pub const O_NONBLOCK: u32 = 2048;
-pub const O_NDELAY: u32 = 2048;
-pub const O_SYNC: u32 = 1052672;
-pub const O_FSYNC: u32 = 1052672;
-pub const O_ASYNC: u32 = 8192;
-pub const __O_DIRECTORY: u32 = 65536;
-pub const __O_NOFOLLOW: u32 = 131072;
-pub const __O_CLOEXEC: u32 = 524288;
-pub const __O_DIRECT: u32 = 16384;
-pub const __O_NOATIME: u32 = 262144;
-pub const __O_PATH: u32 = 2097152;
-pub const __O_DSYNC: u32 = 4096;
-pub const __O_TMPFILE: u32 = 4259840;
-pub const F_GETLK: u32 = 5;
-pub const F_SETLK: u32 = 6;
-pub const F_SETLKW: u32 = 7;
-pub const O_DIRECTORY: u32 = 65536;
-pub const O_NOFOLLOW: u32 = 131072;
-pub const O_CLOEXEC: u32 = 524288;
-pub const O_DSYNC: u32 = 4096;
-pub const O_RSYNC: u32 = 1052672;
+pub const O_ACCMODE: u32 = 3;
+pub const FREAD: u32 = 1;
+pub const FWRITE: u32 = 2;
+pub const O_NONBLOCK: u32 = 4;
+pub const O_APPEND: u32 = 8;
+pub const O_SYNC: u32 = 128;
+pub const O_SHLOCK: u32 = 16;
+pub const O_EXLOCK: u32 = 32;
+pub const O_ASYNC: u32 = 64;
+pub const O_FSYNC: u32 = 128;
+pub const O_NOFOLLOW: u32 = 256;
+pub const O_CREAT: u32 = 512;
+pub const O_TRUNC: u32 = 1024;
+pub const O_EXCL: u32 = 2048;
+pub const O_EVTONLY: u32 = 32768;
+pub const O_NOCTTY: u32 = 131072;
+pub const O_DIRECTORY: u32 = 1048576;
+pub const O_SYMLINK: u32 = 2097152;
+pub const O_DSYNC: u32 = 4194304;
+pub const O_CLOEXEC: u32 = 16777216;
+pub const O_NOFOLLOW_ANY: u32 = 536870912;
+pub const AT_FDCWD: i32 = -2;
+pub const AT_EACCESS: u32 = 16;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
+pub const AT_SYMLINK_FOLLOW: u32 = 64;
+pub const AT_REMOVEDIR: u32 = 128;
+pub const AT_REALDEV: u32 = 512;
+pub const AT_FDONLY: u32 = 1024;
+pub const O_DP_GETRAWENCRYPTED: u32 = 1;
+pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
+pub const FAPPEND: u32 = 8;
+pub const FASYNC: u32 = 64;
+pub const FFSYNC: u32 = 128;
+pub const FFDSYNC: u32 = 4194304;
+pub const FNONBLOCK: u32 = 4;
+pub const FNDELAY: u32 = 4;
+pub const O_NDELAY: u32 = 4;
+pub const CPF_OVERWRITE: u32 = 1;
+pub const CPF_IGNORE_MODE: u32 = 2;
+pub const CPF_MASK: u32 = 3;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const __F_SETOWN: u32 = 8;
-pub const __F_GETOWN: u32 = 9;
-pub const F_SETOWN: u32 = 8;
-pub const F_GETOWN: u32 = 9;
-pub const __F_SETSIG: u32 = 10;
-pub const __F_GETSIG: u32 = 11;
-pub const __F_SETOWN_EX: u32 = 15;
-pub const __F_GETOWN_EX: u32 = 16;
-pub const F_DUPFD_CLOEXEC: u32 = 1030;
+pub const F_GETOWN: u32 = 5;
+pub const F_SETOWN: u32 = 6;
+pub const F_GETLK: u32 = 7;
+pub const F_SETLK: u32 = 8;
+pub const F_SETLKW: u32 = 9;
+pub const F_SETLKWTIMEOUT: u32 = 10;
+pub const F_FLUSH_DATA: u32 = 40;
+pub const F_CHKCLEAN: u32 = 41;
+pub const F_PREALLOCATE: u32 = 42;
+pub const F_SETSIZE: u32 = 43;
+pub const F_RDADVISE: u32 = 44;
+pub const F_RDAHEAD: u32 = 45;
+pub const F_NOCACHE: u32 = 48;
+pub const F_LOG2PHYS: u32 = 49;
+pub const F_GETPATH: u32 = 50;
+pub const F_FULLFSYNC: u32 = 51;
+pub const F_PATHPKG_CHECK: u32 = 52;
+pub const F_FREEZE_FS: u32 = 53;
+pub const F_THAW_FS: u32 = 54;
+pub const F_GLOBAL_NOCACHE: u32 = 55;
+pub const F_ADDSIGS: u32 = 59;
+pub const F_ADDFILESIGS: u32 = 61;
+pub const F_NODIRECT: u32 = 62;
+pub const F_GETPROTECTIONCLASS: u32 = 63;
+pub const F_SETPROTECTIONCLASS: u32 = 64;
+pub const F_LOG2PHYS_EXT: u32 = 65;
+pub const F_GETLKPID: u32 = 66;
+pub const F_SETBACKINGSTORE: u32 = 70;
+pub const F_GETPATH_MTMINFO: u32 = 71;
+pub const F_GETCODEDIR: u32 = 72;
+pub const F_SETNOSIGPIPE: u32 = 73;
+pub const F_GETNOSIGPIPE: u32 = 74;
+pub const F_TRANSCODEKEY: u32 = 75;
+pub const F_SINGLE_WRITER: u32 = 76;
+pub const F_GETPROTECTIONLEVEL: u32 = 77;
+pub const F_FINDSIGS: u32 = 78;
+pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
+pub const F_BARRIERFSYNC: u32 = 85;
+pub const F_ADDFILESIGS_RETURN: u32 = 97;
+pub const F_CHECK_LV: u32 = 98;
+pub const F_PUNCHHOLE: u32 = 99;
+pub const F_TRIM_ACTIVE_FILE: u32 = 100;
+pub const F_SPECULATIVE_READ: u32 = 101;
+pub const F_GETPATH_NOFIRMLINK: u32 = 102;
+pub const F_ADDFILESIGS_INFO: u32 = 103;
+pub const F_ADDFILESUPPL: u32 = 104;
+pub const F_GETSIGSINFO: u32 = 105;
+pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
+pub const F_DUPFD_CLOEXEC: u32 = 67;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 0;
-pub const F_WRLCK: u32 = 1;
+pub const F_RDLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_EXLCK: u32 = 4;
-pub const F_SHLCK: u32 = 8;
+pub const F_WRLCK: u32 = 3;
+pub const SEEK_HOLE: u32 = 3;
+pub const SEEK_DATA: u32 = 4;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_IFWHT: u32 = 57344;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXG: u32 = 56;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXO: u32 = 7;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_ISTXT: u32 = 512;
+pub const S_IREAD: u32 = 256;
+pub const S_IWRITE: u32 = 128;
+pub const S_IEXEC: u32 = 64;
+pub const F_ALLOCATECONTIG: u32 = 2;
+pub const F_ALLOCATEALL: u32 = 4;
+pub const F_PEOFPOSMODE: u32 = 3;
+pub const F_VOLPOSMODE: u32 = 4;
+pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
+pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const FAPPEND: u32 = 1024;
-pub const FFSYNC: u32 = 1052672;
-pub const FASYNC: u32 = 8192;
-pub const FNONBLOCK: u32 = 2048;
-pub const FNDELAY: u32 = 2048;
-pub const __POSIX_FADV_DONTNEED: u32 = 4;
-pub const __POSIX_FADV_NOREUSE: u32 = 5;
-pub const POSIX_FADV_NORMAL: u32 = 0;
-pub const POSIX_FADV_RANDOM: u32 = 1;
-pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
-pub const POSIX_FADV_WILLNEED: u32 = 3;
-pub const POSIX_FADV_DONTNEED: u32 = 4;
-pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const _BITS_STAT_H: u32 = 1;
-pub const _STAT_VER_KERNEL: u32 = 0;
-pub const _STAT_VER_LINUX: u32 = 1;
-pub const _MKNOD_VER_LINUX: u32 = 0;
-pub const _STAT_VER: u32 = 1;
-pub const __S_IFMT: u32 = 61440;
-pub const __S_IFDIR: u32 = 16384;
-pub const __S_IFCHR: u32 = 8192;
-pub const __S_IFBLK: u32 = 24576;
-pub const __S_IFREG: u32 = 32768;
-pub const __S_IFIFO: u32 = 4096;
-pub const __S_IFLNK: u32 = 40960;
-pub const __S_IFSOCK: u32 = 49152;
-pub const __S_ISUID: u32 = 2048;
-pub const __S_ISGID: u32 = 1024;
-pub const __S_ISVTX: u32 = 512;
-pub const __S_IREAD: u32 = 256;
-pub const __S_IWRITE: u32 = 128;
-pub const __S_IEXEC: u32 = 64;
-pub const UTIME_NOW: u32 = 1073741823;
-pub const UTIME_OMIT: u32 = 1073741822;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXG: u32 = 56;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_IRWXO: u32 = 7;
-pub const R_OK: u32 = 4;
-pub const W_OK: u32 = 2;
-pub const X_OK: u32 = 1;
-pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
-pub const F_ULOCK: u32 = 0;
-pub const F_LOCK: u32 = 1;
-pub const F_TLOCK: u32 = 2;
-pub const F_TEST: u32 = 3;
+pub const O_POPUP: u32 = 2147483648;
+pub const O_ALERT: u32 = 536870912;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 1052672;
-pub const OPEN_DATASYNC_FLAG: u32 = 4096;
+pub const OPEN_SYNC_FLAG: u32 = 128;
+pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
 pub const FirstGenbkiObjectId: u32 = 10000;
 pub const FirstBootstrapObjectId: u32 = 12000;
 pub const FirstNormalObjectId: u32 = 16384;
@@ -1706,24 +2204,8 @@ pub const FIELDNO_HEAPTUPLETABLESLOT_OFF: u32 = 2;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_TUPLE: u32 = 1;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_OFF: u32 = 4;
 pub const BITS_PER_BITMAPWORD: u32 = 64;
-pub const _TIME_H: u32 = 1;
-pub const _BITS_TIME_H: u32 = 1;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_TAI: u32 = 11;
-pub const TIMER_ABSTIME: u32 = 1;
-pub const __struct_tm_defined: u32 = 1;
-pub const __itimerspec_defined: u32 = 1;
+pub const CLOCKS_PER_SEC: u32 = 1000000;
 pub const TIME_UTC: u32 = 1;
-pub const PG_INSTR_CLOCK: u32 = 1;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ISNULL: u32 = 4;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ARGS: u32 = 6;
 pub const PG_MAGIC_FUNCTION_NAME_STRING: &'static [u8; 14usize] = b"Pg_magic_func\0";
@@ -1772,84 +2254,121 @@ pub const OUTER_VAR: u32 = 65001;
 pub const INDEX_VAR: u32 = 65002;
 pub const PRS2_OLD_VARNO: u32 = 1;
 pub const PRS2_NEW_VARNO: u32 = 2;
-pub const _LIBC_LIMITS_H_: u32 = 1;
-pub const MB_LEN_MAX: u32 = 16;
-pub const _BITS_POSIX1_LIM_H: u32 = 1;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
+pub const __DARWIN_CLK_TCK: u32 = 100;
+pub const CHAR_BIT: u32 = 8;
+pub const MB_LEN_MAX: u32 = 6;
+pub const CLK_TCK: u32 = 100;
+pub const SCHAR_MAX: u32 = 127;
+pub const SCHAR_MIN: i32 = -128;
+pub const UCHAR_MAX: u32 = 255;
+pub const CHAR_MAX: u32 = 127;
+pub const CHAR_MIN: i32 = -128;
+pub const USHRT_MAX: u32 = 65535;
+pub const SHRT_MAX: u32 = 32767;
+pub const SHRT_MIN: i32 = -32768;
+pub const UINT_MAX: u32 = 4294967295;
+pub const INT_MAX: u32 = 2147483647;
+pub const INT_MIN: i32 = -2147483648;
+pub const ULONG_MAX: i32 = -1;
+pub const LONG_MAX: u64 = 9223372036854775807;
+pub const LONG_MIN: i64 = -9223372036854775808;
+pub const ULLONG_MAX: i32 = -1;
+pub const LLONG_MAX: u64 = 9223372036854775807;
+pub const LLONG_MIN: i64 = -9223372036854775808;
+pub const LONG_BIT: u32 = 64;
+pub const SSIZE_MAX: u64 = 9223372036854775807;
+pub const WORD_BIT: u32 = 32;
+pub const SIZE_T_MAX: i32 = -1;
+pub const UQUAD_MAX: i32 = -1;
+pub const QUAD_MAX: u64 = 9223372036854775807;
+pub const QUAD_MIN: i64 = -9223372036854775808;
+pub const ARG_MAX: u32 = 1048576;
+pub const CHILD_MAX: u32 = 266;
+pub const GID_MAX: u32 = 2147483647;
+pub const LINK_MAX: u32 = 32767;
+pub const MAX_CANON: u32 = 1024;
+pub const MAX_INPUT: u32 = 1024;
+pub const NAME_MAX: u32 = 255;
+pub const NGROUPS_MAX: u32 = 16;
+pub const UID_MAX: u32 = 2147483647;
+pub const OPEN_MAX: u32 = 10240;
+pub const PATH_MAX: u32 = 1024;
+pub const PIPE_BUF: u32 = 512;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const CHARCLASS_NAME_MAX: u32 = 14;
+pub const COLL_WEIGHTS_MAX: u32 = 2;
+pub const EQUIV_CLASS_MAX: u32 = 2;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 255;
+pub const NZERO: u32 = 20;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_RTSIG_MAX: u32 = 8;
-pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
-pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
-pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
 pub const _POSIX_SSIZE_MAX: u32 = 32767;
 pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_SYMLINK_MAX: u32 = 255;
-pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_TTY_NAME_MAX: u32 = 9;
 pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const NR_OPEN: u32 = 1024;
-pub const NGROUPS_MAX: u32 = 65536;
-pub const ARG_MAX: u32 = 131072;
-pub const LINK_MAX: u32 = 127;
-pub const MAX_CANON: u32 = 255;
-pub const MAX_INPUT: u32 = 255;
-pub const NAME_MAX: u32 = 255;
-pub const PATH_MAX: u32 = 4096;
-pub const PIPE_BUF: u32 = 4096;
-pub const XATTR_NAME_MAX: u32 = 255;
-pub const XATTR_SIZE_MAX: u32 = 65536;
-pub const XATTR_LIST_MAX: u32 = 65536;
-pub const RTSIG_MAX: u32 = 32;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const PTHREAD_KEYS_MAX: u32 = 1024;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const AIO_PRIO_DELTA_MAX: u32 = 20;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const DELAYTIMER_MAX: u32 = 2147483647;
-pub const TTY_NAME_MAX: u32 = 32;
-pub const LOGIN_NAME_MAX: u32 = 256;
-pub const HOST_NAME_MAX: u32 = 64;
-pub const MQ_PRIO_MAX: u32 = 32768;
-pub const SEM_VALUE_MAX: u32 = 2147483647;
-pub const _BITS_POSIX2_LIM_H: u32 = 1;
 pub const _POSIX2_BC_BASE_MAX: u32 = 99;
 pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
 pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
 pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
+pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
 pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
 pub const _POSIX2_LINE_MAX: u32 = 2048;
 pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RTSIG_MAX: u32 = 8;
+pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
+pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
+pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_KEYS_MAX: u32 = 512;
+pub const PTHREAD_STACK_MIN: u32 = 8192;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
+pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SYMLINK_MAX: u32 = 255;
+pub const _POSIX_SYMLOOP_MAX: u32 = 8;
+pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
+pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
+pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
+pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TTY_NAME_MAX: u32 = 9;
 pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const COLL_WEIGHTS_MAX: u32 = 255;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const CHARCLASS_NAME_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 32767;
+pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
+pub const OFF_MIN: i64 = -9223372036854775808;
+pub const OFF_MAX: u64 = 9223372036854775807;
+pub const PASS_MAX: u32 = 128;
+pub const NL_ARGMAX: u32 = 9;
+pub const NL_LANGMAX: u32 = 14;
+pub const NL_MSGMAX: u32 = 32767;
+pub const NL_NMAX: u32 = 1;
+pub const NL_SETMAX: u32 = 255;
+pub const NL_TEXTMAX: u32 = 2048;
+pub const _XOPEN_IOV_MAX: u32 = 16;
+pub const IOV_MAX: u32 = 1024;
+pub const _XOPEN_NAME_MAX: u32 = 255;
+pub const _XOPEN_PATH_MAX: u32 = 1024;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
 pub const DSM_IMPL_WINDOWS: u32 = 3;
@@ -1880,9 +2399,25 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const _DIRENT_H: u32 = 1;
-pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
+pub const __DARWIN_MAXNAMLEN: u32 = 255;
+pub const __DARWIN_MAXPATHLEN: u32 = 1024;
 pub const MAXNAMLEN: u32 = 255;
+pub const DT_UNKNOWN: u32 = 0;
+pub const DT_FIFO: u32 = 1;
+pub const DT_CHR: u32 = 2;
+pub const DT_DIR: u32 = 4;
+pub const DT_BLK: u32 = 6;
+pub const DT_REG: u32 = 8;
+pub const DT_LNK: u32 = 10;
+pub const DT_SOCK: u32 = 12;
+pub const DT_WHT: u32 = 14;
+pub const DIRBLKSIZ: u32 = 1024;
+pub const DTF_HIDEW: u32 = 1;
+pub const DTF_NODUP: u32 = 2;
+pub const DTF_REWIND: u32 = 4;
+pub const __DTF_READALL: u32 = 8;
+pub const __DTF_SKIPREAD: u32 = 16;
+pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const SHARED_TUPLESTORE_SINGLE_PASS: u32 = 1;
@@ -1996,6 +2531,7 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
+pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const REINDEXOPT_REPORT_PROGRESS: u32 = 2;
 pub const MaxAllocHugeSize: u32 = 0;
@@ -2014,85 +2550,6 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
-pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGILL: u32 = 4;
-pub const SIGABRT: u32 = 6;
-pub const SIGFPE: u32 = 8;
-pub const SIGSEGV: u32 = 11;
-pub const SIGTERM: u32 = 15;
-pub const SIGHUP: u32 = 1;
-pub const SIGQUIT: u32 = 3;
-pub const SIGTRAP: u32 = 5;
-pub const SIGKILL: u32 = 9;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGXCPU: u32 = 24;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
-pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
-pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
-pub const __sig_atomic_t_defined: u32 = 1;
-pub const __siginfo_t_defined: u32 = 1;
-pub const __SI_MAX_SIZE: u32 = 128;
-pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
-pub const __SI_ERRNO_THEN_CODE: u32 = 1;
-pub const __SI_HAVE_SIGSYS: u32 = 1;
-pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
-pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
-pub const __sigevent_t_defined: u32 = 1;
-pub const __SIGEV_MAX_SIZE: u32 = 64;
-pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
-pub const _BITS_SIGACTION_H: u32 = 1;
-pub const SA_NOCLDSTOP: u32 = 1;
-pub const SA_NOCLDWAIT: u32 = 2;
-pub const SA_SIGINFO: u32 = 4;
-pub const SA_ONSTACK: u32 = 134217728;
-pub const SA_RESTART: u32 = 268435456;
-pub const SA_NODEFER: u32 = 1073741824;
-pub const SA_RESETHAND: u32 = 2147483648;
-pub const SA_INTERRUPT: u32 = 536870912;
-pub const SA_NOMASK: u32 = 1073741824;
-pub const SA_ONESHOT: u32 = 2147483648;
-pub const SA_STACK: u32 = 134217728;
-pub const SIG_BLOCK: u32 = 0;
-pub const SIG_UNBLOCK: u32 = 1;
-pub const SIG_SETMASK: u32 = 2;
-pub const _BITS_SIGCONTEXT_H: u32 = 1;
-pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
-pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
-pub const __stack_t_defined: u32 = 1;
-pub const _SYS_UCONTEXT_H: u32 = 1;
-pub const __NGREG: u32 = 23;
-pub const NGREG: u32 = 23;
-pub const _BITS_SIGSTACK_H: u32 = 1;
-pub const MINSIGSTKSZ: u32 = 2048;
-pub const SIGSTKSZ: u32 = 8192;
-pub const _BITS_SS_FLAGS_H: u32 = 1;
-pub const __sigstack_defined: u32 = 1;
-pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2111,7 +2568,13 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const _SYS_UN_H: u32 = 1;
+pub const SOL_LOCAL: u32 = 0;
+pub const LOCAL_PEERCRED: u32 = 1;
+pub const LOCAL_PEERPID: u32 = 2;
+pub const LOCAL_PEEREPID: u32 = 3;
+pub const LOCAL_PEERUUID: u32 = 4;
+pub const LOCAL_PEEREUUID: u32 = 5;
+pub const LOCAL_PEERTOKEN: u32 = 6;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -2298,6 +2761,7 @@ pub const F_HAS_GARBAGE: u32 = 16;
 pub const GIST_PAGE_ID: u32 = 65409;
 pub const EOH_HEADER_MAGIC: i32 = -1;
 pub const EA_MAGIC: u32 = 689375833;
+pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &'static [u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -2925,195 +3389,428 @@ pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
 pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
-pub type va_list = __builtin_va_list;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type __u_char = ::std::os::raw::c_uchar;
-pub type __u_short = ::std::os::raw::c_ushort;
-pub type __u_int = ::std::os::raw::c_uint;
-pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_long;
-pub type __uint64_t = ::std::os::raw::c_ulong;
-pub type __int_least8_t = __int8_t;
-pub type __uint_least8_t = __uint8_t;
-pub type __int_least16_t = __int16_t;
-pub type __uint_least16_t = __uint16_t;
-pub type __int_least32_t = __int32_t;
-pub type __uint_least32_t = __uint32_t;
-pub type __int_least64_t = __int64_t;
-pub type __uint_least64_t = __uint64_t;
-pub type __quad_t = ::std::os::raw::c_long;
-pub type __u_quad_t = ::std::os::raw::c_ulong;
-pub type __intmax_t = ::std::os::raw::c_long;
-pub type __uintmax_t = ::std::os::raw::c_ulong;
-pub type __dev_t = ::std::os::raw::c_ulong;
-pub type __uid_t = ::std::os::raw::c_uint;
-pub type __gid_t = ::std::os::raw::c_uint;
-pub type __ino_t = ::std::os::raw::c_ulong;
-pub type __ino64_t = ::std::os::raw::c_ulong;
-pub type __mode_t = ::std::os::raw::c_uint;
-pub type __nlink_t = ::std::os::raw::c_ulong;
-pub type __off_t = ::std::os::raw::c_long;
-pub type __off64_t = ::std::os::raw::c_long;
-pub type __pid_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __fsid_t {
-    pub __val: [::std::os::raw::c_int; 2usize],
-}
-pub type __clock_t = ::std::os::raw::c_long;
-pub type __rlim_t = ::std::os::raw::c_ulong;
-pub type __rlim64_t = ::std::os::raw::c_ulong;
-pub type __id_t = ::std::os::raw::c_uint;
-pub type __time_t = ::std::os::raw::c_long;
-pub type __useconds_t = ::std::os::raw::c_uint;
-pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
-pub type __daddr_t = ::std::os::raw::c_int;
-pub type __key_t = ::std::os::raw::c_int;
-pub type __clockid_t = ::std::os::raw::c_int;
-pub type __timer_t = *mut ::std::os::raw::c_void;
-pub type __blksize_t = ::std::os::raw::c_long;
-pub type __blkcnt_t = ::std::os::raw::c_long;
-pub type __blkcnt64_t = ::std::os::raw::c_long;
-pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
-pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsword_t = ::std::os::raw::c_long;
-pub type __ssize_t = ::std::os::raw::c_long;
-pub type __syscall_slong_t = ::std::os::raw::c_long;
-pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
-pub type __loff_t = __off64_t;
-pub type __caddr_t = *mut ::std::os::raw::c_char;
-pub type __intptr_t = ::std::os::raw::c_long;
-pub type __socklen_t = ::std::os::raw::c_uint;
-pub type __sig_atomic_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_longlong;
+pub type __uint64_t = ::std::os::raw::c_ulonglong;
+pub type __darwin_intptr_t = ::std::os::raw::c_long;
+pub type __darwin_natural_t = ::std::os::raw::c_uint;
+pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct __mbstate_t {
-    pub __count: ::std::os::raw::c_int,
-    pub __value: __mbstate_t__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __mbstate_t__bindgen_ty_1 {
-    pub __wch: ::std::os::raw::c_uint,
-    pub __wchb: [::std::os::raw::c_char; 4usize],
-    _bindgen_union_align: u32,
-}
-impl Default for __mbstate_t__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+pub union __mbstate_t {
+    pub __mbstate8: [::std::os::raw::c_char; 128usize],
+    pub _mbstateL: ::std::os::raw::c_longlong,
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub type __darwin_mbstate_t = __mbstate_t;
+pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
+pub type __darwin_size_t = ::std::os::raw::c_ulong;
+pub type __darwin_va_list = __builtin_va_list;
+pub type __darwin_wchar_t = ::std::os::raw::c_int;
+pub type __darwin_rune_t = __darwin_wchar_t;
+pub type __darwin_wint_t = ::std::os::raw::c_int;
+pub type __darwin_clock_t = ::std::os::raw::c_ulong;
+pub type __darwin_socklen_t = __uint32_t;
+pub type __darwin_ssize_t = ::std::os::raw::c_long;
+pub type __darwin_time_t = ::std::os::raw::c_long;
+pub type __darwin_blkcnt_t = __int64_t;
+pub type __darwin_blksize_t = __int32_t;
+pub type __darwin_dev_t = __int32_t;
+pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_gid_t = __uint32_t;
+pub type __darwin_id_t = __uint32_t;
+pub type __darwin_ino64_t = __uint64_t;
+pub type __darwin_ino_t = __darwin_ino64_t;
+pub type __darwin_mach_port_name_t = __darwin_natural_t;
+pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
+pub type __darwin_mode_t = __uint16_t;
+pub type __darwin_off_t = __int64_t;
+pub type __darwin_pid_t = __int32_t;
+pub type __darwin_sigset_t = __uint32_t;
+pub type __darwin_suseconds_t = __int32_t;
+pub type __darwin_uid_t = __uint32_t;
+pub type __darwin_useconds_t = __uint32_t;
+pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
+pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_pthread_handler_rec {
+    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+    pub __arg: *mut ::std::os::raw::c_void,
+    pub __next: *mut __darwin_pthread_handler_rec,
+}
+impl Default for __darwin_pthread_handler_rec {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _G_fpos_t {
-    pub __pos: __off_t,
-    pub __state: __mbstate_t,
+pub struct _opaque_pthread_attr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
 }
-impl Default for _G_fpos_t {
+impl Default for _opaque_pthread_attr_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _G_fpos64_t {
-    pub __pos: __off64_t,
-    pub __state: __mbstate_t,
+pub struct _opaque_pthread_cond_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 40usize],
 }
-impl Default for _G_fpos64_t {
+impl Default for _opaque_pthread_cond_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __fpos64_t = _G_fpos64_t;
-pub type __FILE = _IO_FILE;
-pub type FILE = _IO_FILE;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_condattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_mutex_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
-    _unused: [u8; 0],
-}
-pub type _IO_lock_t = ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_FILE {
-    pub _flags: ::std::os::raw::c_int,
-    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    pub _IO_read_end: *mut ::std::os::raw::c_char,
-    pub _IO_read_base: *mut ::std::os::raw::c_char,
-    pub _IO_write_base: *mut ::std::os::raw::c_char,
-    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    pub _IO_write_end: *mut ::std::os::raw::c_char,
-    pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    pub _IO_save_base: *mut ::std::os::raw::c_char,
-    pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    pub _IO_save_end: *mut ::std::os::raw::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::std::os::raw::c_int,
-    pub _flags2: ::std::os::raw::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::std::os::raw::c_ushort,
-    pub _vtable_offset: ::std::os::raw::c_schar,
-    pub _shortbuf: [::std::os::raw::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::std::os::raw::c_void,
-    pub __pad5: usize,
-    pub _mode: ::std::os::raw::c_int,
-    pub _unused2: [::std::os::raw::c_char; 20usize],
-}
-impl Default for _IO_FILE {
+impl Default for _opaque_pthread_mutex_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type off_t = __off_t;
-pub type fpos_t = __fpos_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_mutexattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_once_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_rwlock_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 192usize],
+}
+impl Default for _opaque_pthread_rwlock_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _opaque_pthread_rwlockattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 16usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _opaque_pthread_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
+    pub __opaque: [::std::os::raw::c_char; 8176usize],
+}
+impl Default for _opaque_pthread_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
+pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
+pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
+pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
+pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
+pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
+pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
+pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
+pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
+pub type __darwin_pthread_t = *mut _opaque_pthread_t;
+pub type __darwin_nl_item = ::std::os::raw::c_int;
+pub type __darwin_wctrans_t = ::std::os::raw::c_int;
+pub type __darwin_wctype_t = __uint32_t;
+pub type u_int8_t = ::std::os::raw::c_uchar;
+pub type u_int16_t = ::std::os::raw::c_ushort;
+pub type u_int32_t = ::std::os::raw::c_uint;
+pub type u_int64_t = ::std::os::raw::c_ulonglong;
+pub type register_t = i64;
+pub type user_addr_t = u_int64_t;
+pub type user_size_t = u_int64_t;
+pub type user_ssize_t = i64;
+pub type user_long_t = i64;
+pub type user_ulong_t = u_int64_t;
+pub type user_time_t = i64;
+pub type user_off_t = i64;
+pub type syscall_arg_t = u_int64_t;
+pub type va_list = __darwin_va_list;
 #[pg_guard]
 extern "C" {
-    pub static mut stdin: *mut FILE;
+    pub fn renameat(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut stdout: *mut FILE;
+    pub fn renamex_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut stderr: *mut FILE;
+    pub fn renameatx_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fpos_t = __darwin_off_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sbuf {
+    pub _base: *mut ::std::os::raw::c_uchar,
+    pub _size: ::std::os::raw::c_int,
+}
+impl Default for __sbuf {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sFILEX {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sFILE {
+    pub _p: *mut ::std::os::raw::c_uchar,
+    pub _r: ::std::os::raw::c_int,
+    pub _w: ::std::os::raw::c_int,
+    pub _flags: ::std::os::raw::c_short,
+    pub _file: ::std::os::raw::c_short,
+    pub _bf: __sbuf,
+    pub _lbfsize: ::std::os::raw::c_int,
+    pub _cookie: *mut ::std::os::raw::c_void,
+    pub _close: ::std::option::Option<
+        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+    >,
+    pub _read: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: *mut ::std::os::raw::c_char,
+            arg3: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub _seek: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: fpos_t,
+            arg3: ::std::os::raw::c_int,
+        ) -> fpos_t,
+    >,
+    pub _write: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: *const ::std::os::raw::c_char,
+            arg3: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub _ub: __sbuf,
+    pub _extra: *mut __sFILEX,
+    pub _ur: ::std::os::raw::c_int,
+    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
+    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
+    pub _lb: __sbuf,
+    pub _blksize: ::std::os::raw::c_int,
+    pub _offset: fpos_t,
+}
+impl Default for __sFILE {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type FILE = __sFILE;
+#[pg_guard]
+extern "C" {
+    pub static mut __stdinp: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub static mut __stdoutp: *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __stderrp: *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr(arg1: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgets(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __mode: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fprintf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __nitems: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freopen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut FILE,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fscanf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseek(
+        arg1: *mut FILE,
+        arg2: ::std::os::raw::c_long,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __nitems: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn perror(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3124,11 +3821,39 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn renameat(
-        __oldfd: ::std::os::raw::c_int,
-        __old: *const ::std::os::raw::c_char,
-        __newfd: ::std::os::raw::c_int,
-        __new: *const ::std::os::raw::c_char,
+    pub fn rewind(arg1: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setvbuf(
+        arg1: *mut FILE,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sprintf(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sscanf(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3137,275 +3862,89 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tempnam(
-        __dir: *const ::std::os::raw::c_char,
-        __pfx: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freopen(
-        __filename: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
-        __stream: *mut FILE,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
-        -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmemopen(
-        __s: *mut ::std::os::raw::c_void,
-        __len: usize,
-        __modes: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn open_memstream(
-        __bufloc: *mut *mut ::std::os::raw::c_char,
-        __sizeloc: *mut usize,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setvbuf(
-        __stream: *mut FILE,
-        __buf: *mut ::std::os::raw::c_char,
-        __modes: ::std::os::raw::c_int,
-        __n: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setlinebuf(__stream: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn fprintf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vfprintf(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vprintf(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vsprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn snprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __maxlen: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        ...
+    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn popen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __svfscanf(
+        arg1: *mut FILE,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vsnprintf(
-        __s: *mut ::std::os::raw::c_char,
-        __maxlen: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
+    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vdprintf(
-        __fd: ::std::os::raw::c_int,
-        __fmt: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
+    pub fn flockfile(arg1: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn dprintf(
-        __fd: ::std::os::raw::c_int,
-        __fmt: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fscanf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn funlockfile(arg1: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sscanf(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_fscanf"]
-    pub fn fscanf1(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_scanf"]
-    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_sscanf"]
-    pub fn sscanf1(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vfscanf(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vscanf(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsscanf(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vfscanf"]
-    pub fn vfscanf1(
-        __s: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vscanf"]
-    pub fn vscanf1(
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}__isoc99_vsscanf"]
-    pub fn vsscanf1(
-        __s: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        __arg: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3413,231 +3952,2080 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgets(
-        __s: *mut ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_int,
-        __stream: *mut FILE,
+    pub fn tempnam(
+        __dir: *const ::std::os::raw::c_char,
+        __prefix: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-#[pg_guard]
-extern "C" {
-    pub fn __getdelim(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getdelim(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getline(
-        __lineptr: *mut *mut ::std::os::raw::c_char,
-        __n: *mut usize,
-        __stream: *mut FILE,
-    ) -> __ssize_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __n: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __n: ::std::os::raw::c_ulong,
-        __s: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread_unlocked(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
-        __n: usize,
-        __stream: *mut FILE,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite_unlocked(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: usize,
-        __n: usize,
-        __stream: *mut FILE,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fseek(
-        __stream: *mut FILE,
-        __off: ::std::os::raw::c_long,
-        __whence: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rewind(__stream: *mut FILE);
-}
+pub type off_t = __darwin_off_t;
 #[pg_guard]
 extern "C" {
     pub fn fseeko(
         __stream: *mut FILE,
-        __off: __off_t,
+        __offset: off_t,
         __whence: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> __off_t;
+    pub fn ftello(__stream: *mut FILE) -> off_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+    pub fn snprintf(
+        __str: *mut ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+    pub fn vfscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr(__stream: *mut FILE);
+    pub fn vscanf(
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vsnprintf(
+        __str: *mut ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vsscanf(
+        __str: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        arg1: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr_unlocked(__stream: *mut FILE);
+    pub fn dprintf(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn vdprintf(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getdelim(
+        __linep: *mut *mut ::std::os::raw::c_char,
+        __linecapp: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn perror(__s: *const ::std::os::raw::c_char);
+    pub fn getline(
+        __linep: *mut *mut ::std::os::raw::c_char,
+        __linecapp: *mut usize,
+        __stream: *mut FILE,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn popen(
-        __command: *const ::std::os::raw::c_char,
-        __modes: *const ::std::os::raw::c_char,
+    pub fn fmemopen(
+        __buf: *mut ::std::os::raw::c_void,
+        __size: usize,
+        __mode: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn open_memstream(
+        __bufp: *mut *mut ::std::os::raw::c_char,
+        __sizep: *mut usize,
+    ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub static sys_nerr: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn flockfile(__stream: *mut FILE);
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn asprintf(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn funlockfile(__stream: *mut FILE);
+    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn fmtcheck(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *const ::std::os::raw::c_char;
 }
-pub type wchar_t = ::std::os::raw::c_int;
+#[pg_guard]
+extern "C" {
+    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuffer(
+        arg1: *mut FILE,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vasprintf(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn zopen(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn funopen(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *mut ::std::os::raw::c_char,
+                arg3: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int,
+        >,
+        arg3: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_char,
+                arg3: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int,
+        >,
+        arg4: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: fpos_t,
+                arg3: ::std::os::raw::c_int,
+            ) -> fpos_t,
+        >,
+        arg5: ::std::option::Option<
+            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+        >,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __snprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+        arg5: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __vsprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __vsnprintf_chk(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: usize,
+        arg5: *const ::std::os::raw::c_char,
+        arg6: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type pid_t = __darwin_pid_t;
+pub type id_t = __darwin_id_t;
+pub type sig_atomic_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_i386_thread_state {
+    pub __eax: ::std::os::raw::c_uint,
+    pub __ebx: ::std::os::raw::c_uint,
+    pub __ecx: ::std::os::raw::c_uint,
+    pub __edx: ::std::os::raw::c_uint,
+    pub __edi: ::std::os::raw::c_uint,
+    pub __esi: ::std::os::raw::c_uint,
+    pub __ebp: ::std::os::raw::c_uint,
+    pub __esp: ::std::os::raw::c_uint,
+    pub __ss: ::std::os::raw::c_uint,
+    pub __eflags: ::std::os::raw::c_uint,
+    pub __eip: ::std::os::raw::c_uint,
+    pub __cs: ::std::os::raw::c_uint,
+    pub __ds: ::std::os::raw::c_uint,
+    pub __es: ::std::os::raw::c_uint,
+    pub __fs: ::std::os::raw::c_uint,
+    pub __gs: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_fp_control {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+}
+impl __darwin_fp_control {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __pc: ::std::os::raw::c_ushort,
+        __rc: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 2u8, {
+            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
+            __pc as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 2u8, {
+            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
+            __rc as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_control_t = __darwin_fp_control;
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_fp_status {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+}
+impl __darwin_fp_status {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(6usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(9usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
+    }
+    #[inline]
+    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(11usize, 3u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(14usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(15usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __stkflt: ::std::os::raw::c_ushort,
+        __errsumm: ::std::os::raw::c_ushort,
+        __c0: ::std::os::raw::c_ushort,
+        __c1: ::std::os::raw::c_ushort,
+        __c2: ::std::os::raw::c_ushort,
+        __tos: ::std::os::raw::c_ushort,
+        __c3: ::std::os::raw::c_ushort,
+        __busy: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(6usize, 1u8, {
+            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
+            __stkflt as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
+            __errsumm as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 1u8, {
+            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
+            __c0 as u64
+        });
+        __bindgen_bitfield_unit.set(9usize, 1u8, {
+            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
+            __c1 as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 1u8, {
+            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
+            __c2 as u64
+        });
+        __bindgen_bitfield_unit.set(11usize, 3u8, {
+            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
+            __tos as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 1u8, {
+            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
+            __c3 as u64
+        });
+        __bindgen_bitfield_unit.set(15usize, 1u8, {
+            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
+            __busy as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_status_t = __darwin_fp_status;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_mmst_reg {
+    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
+    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_xmm_reg {
+    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_ymm_reg {
+    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_zmm_reg {
+    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
+}
+impl Default for __darwin_zmm_reg {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_opmask_reg {
+    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_float_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+impl Default for __darwin_i386_float_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_avx_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+}
+impl Default for __darwin_i386_avx_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_i386_avx512_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+}
+impl Default for __darwin_i386_avx512_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_i386_exception_state {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_debug_state32 {
+    pub __dr0: ::std::os::raw::c_uint,
+    pub __dr1: ::std::os::raw::c_uint,
+    pub __dr2: ::std::os::raw::c_uint,
+    pub __dr3: ::std::os::raw::c_uint,
+    pub __dr4: ::std::os::raw::c_uint,
+    pub __dr5: ::std::os::raw::c_uint,
+    pub __dr6: ::std::os::raw::c_uint,
+    pub __dr7: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __x86_instruction_state {
+    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
+    pub __insn_offset: ::std::os::raw::c_int,
+    pub __out_of_synch: ::std::os::raw::c_int,
+    pub __insn_bytes: [__uint8_t; 2380usize],
+    pub __insn_cacheline: [__uint8_t; 64usize],
+}
+impl Default for __x86_instruction_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __last_branch_record {
+    pub __from_ip: __uint64_t,
+    pub __to_ip: __uint64_t,
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __bindgen_padding_0: u32,
+}
+impl __last_branch_record {
+    #[inline]
+    pub fn __mispredict(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___mispredict(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tsx_abort(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __in_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___in_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set___cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(19usize, 13u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __mispredict: __uint32_t,
+        __tsx_abort: __uint32_t,
+        __in_tsx: __uint32_t,
+        __cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
+            __mispredict as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
+            __tsx_abort as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
+            __in_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 16u8, {
+            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
+            __cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(19usize, 13u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __last_branch_state {
+    pub __lbr_count: ::std::os::raw::c_int,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __lbrs: [__last_branch_record; 32usize],
+}
+impl __last_branch_state {
+    #[inline]
+    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 30u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __lbr_supported_tsx: __uint32_t,
+        __lbr_supported_cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
+            __lbr_supported_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __lbr_supported_cycle_count: u32 =
+                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
+            __lbr_supported_cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 30u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __x86_pagein_state {
+    pub __pagein_error: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_thread_state64 {
+    pub __rax: __uint64_t,
+    pub __rbx: __uint64_t,
+    pub __rcx: __uint64_t,
+    pub __rdx: __uint64_t,
+    pub __rdi: __uint64_t,
+    pub __rsi: __uint64_t,
+    pub __rbp: __uint64_t,
+    pub __rsp: __uint64_t,
+    pub __r8: __uint64_t,
+    pub __r9: __uint64_t,
+    pub __r10: __uint64_t,
+    pub __r11: __uint64_t,
+    pub __r12: __uint64_t,
+    pub __r13: __uint64_t,
+    pub __r14: __uint64_t,
+    pub __r15: __uint64_t,
+    pub __rip: __uint64_t,
+    pub __rflags: __uint64_t,
+    pub __cs: __uint64_t,
+    pub __fs: __uint64_t,
+    pub __gs: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_thread_full_state64 {
+    pub __ss64: __darwin_x86_thread_state64,
+    pub __ds: __uint64_t,
+    pub __es: __uint64_t,
+    pub __ss: __uint64_t,
+    pub __gsbase: __uint64_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_float_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+impl Default for __darwin_x86_float_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_avx_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+}
+impl Default for __darwin_x86_avx_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_x86_avx512_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+    pub __fpu_zmmh8: __darwin_ymm_reg,
+    pub __fpu_zmmh9: __darwin_ymm_reg,
+    pub __fpu_zmmh10: __darwin_ymm_reg,
+    pub __fpu_zmmh11: __darwin_ymm_reg,
+    pub __fpu_zmmh12: __darwin_ymm_reg,
+    pub __fpu_zmmh13: __darwin_ymm_reg,
+    pub __fpu_zmmh14: __darwin_ymm_reg,
+    pub __fpu_zmmh15: __darwin_ymm_reg,
+    pub __fpu_zmm16: __darwin_zmm_reg,
+    pub __fpu_zmm17: __darwin_zmm_reg,
+    pub __fpu_zmm18: __darwin_zmm_reg,
+    pub __fpu_zmm19: __darwin_zmm_reg,
+    pub __fpu_zmm20: __darwin_zmm_reg,
+    pub __fpu_zmm21: __darwin_zmm_reg,
+    pub __fpu_zmm22: __darwin_zmm_reg,
+    pub __fpu_zmm23: __darwin_zmm_reg,
+    pub __fpu_zmm24: __darwin_zmm_reg,
+    pub __fpu_zmm25: __darwin_zmm_reg,
+    pub __fpu_zmm26: __darwin_zmm_reg,
+    pub __fpu_zmm27: __darwin_zmm_reg,
+    pub __fpu_zmm28: __darwin_zmm_reg,
+    pub __fpu_zmm29: __darwin_zmm_reg,
+    pub __fpu_zmm30: __darwin_zmm_reg,
+    pub __fpu_zmm31: __darwin_zmm_reg,
+}
+impl Default for __darwin_x86_avx512_state64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_exception_state64 {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_debug_state64 {
+    pub __dr0: __uint64_t,
+    pub __dr1: __uint64_t,
+    pub __dr2: __uint64_t,
+    pub __dr3: __uint64_t,
+    pub __dr4: __uint64_t,
+    pub __dr5: __uint64_t,
+    pub __dr6: __uint64_t,
+    pub __dr7: __uint64_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __darwin_x86_cpmu_state64 {
+    pub __ctrs: [__uint64_t; 16usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_float_state,
+}
+impl Default for __darwin_mcontext32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx_state,
+}
+impl Default for __darwin_mcontext_avx32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx512_state,
+}
+impl Default for __darwin_mcontext_avx512_32 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+impl Default for __darwin_mcontext64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+impl Default for __darwin_mcontext64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+impl Default for __darwin_mcontext_avx64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+impl Default for __darwin_mcontext_avx64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+impl Default for __darwin_mcontext_avx512_64 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+impl Default for __darwin_mcontext_avx512_64_full {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type mcontext_t = *mut __darwin_mcontext64;
+pub type pthread_attr_t = __darwin_pthread_attr_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_sigaltstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_size: __darwin_size_t,
+    pub ss_flags: ::std::os::raw::c_int,
+}
+impl Default for __darwin_sigaltstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type stack_t = __darwin_sigaltstack;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_ucontext {
+    pub uc_onstack: ::std::os::raw::c_int,
+    pub uc_sigmask: __darwin_sigset_t,
+    pub uc_stack: __darwin_sigaltstack,
+    pub uc_link: *mut __darwin_ucontext,
+    pub uc_mcsize: __darwin_size_t,
+    pub uc_mcontext: *mut __darwin_mcontext64,
+}
+impl Default for __darwin_ucontext {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type ucontext_t = __darwin_ucontext;
+pub type sigset_t = __darwin_sigset_t;
+pub type uid_t = __darwin_uid_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
+}
+impl Default for sigval {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_value: sigval,
+    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
+    pub sigev_notify_attributes: *mut pthread_attr_t,
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __siginfo {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub si_pid: pid_t,
+    pub si_uid: uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_value: sigval,
+    pub si_band: ::std::os::raw::c_long,
+    pub __pad: [::std::os::raw::c_ulong; 7usize],
+}
+impl Default for __siginfo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type siginfo_t = __siginfo;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __sigaction_u {
+    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub __sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut __siginfo,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for __sigaction_u {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __sigaction {
+    pub __sigaction_u: __sigaction_u,
+    pub sa_tramp: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut ::std::os::raw::c_void,
+            arg2: ::std::os::raw::c_int,
+            arg3: ::std::os::raw::c_int,
+            arg4: *mut siginfo_t,
+            arg5: *mut ::std::os::raw::c_void,
+        ),
+    >,
+    pub sa_mask: sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+}
+impl Default for __sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_u: __sigaction_u,
+    pub sa_mask: sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sigvec {
+    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub sv_mask: ::std::os::raw::c_int,
+    pub sv_flags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_char,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn signal(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+        ),
+    >;
+}
+pub type int_least8_t = i8;
+pub type int_least16_t = i16;
+pub type int_least32_t = i32;
+pub type int_least64_t = i64;
+pub type uint_least8_t = u8;
+pub type uint_least16_t = u16;
+pub type uint_least32_t = u32;
+pub type uint_least64_t = u64;
+pub type int_fast8_t = i8;
+pub type int_fast16_t = i16;
+pub type int_fast32_t = i32;
+pub type int_fast64_t = i64;
+pub type uint_fast8_t = u8;
+pub type uint_fast16_t = u16;
+pub type uint_fast32_t = u32;
+pub type uint_fast64_t = u64;
+pub type intmax_t = ::std::os::raw::c_long;
+pub type uintmax_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __darwin_time_t,
+    pub tv_usec: __darwin_suseconds_t,
+}
+pub type rlim_t = __uint64_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage {
+    pub ru_utime: timeval,
+    pub ru_stime: timeval,
+    pub ru_maxrss: ::std::os::raw::c_long,
+    pub ru_ixrss: ::std::os::raw::c_long,
+    pub ru_idrss: ::std::os::raw::c_long,
+    pub ru_isrss: ::std::os::raw::c_long,
+    pub ru_minflt: ::std::os::raw::c_long,
+    pub ru_majflt: ::std::os::raw::c_long,
+    pub ru_nswap: ::std::os::raw::c_long,
+    pub ru_inblock: ::std::os::raw::c_long,
+    pub ru_oublock: ::std::os::raw::c_long,
+    pub ru_msgsnd: ::std::os::raw::c_long,
+    pub ru_msgrcv: ::std::os::raw::c_long,
+    pub ru_nsignals: ::std::os::raw::c_long,
+    pub ru_nvcsw: ::std::os::raw::c_long,
+    pub ru_nivcsw: ::std::os::raw::c_long,
+}
+pub type rusage_info_t = *mut ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v0 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v1 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v2 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v3 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v4 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rusage_info_v5 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+    pub ri_flags: u64,
+}
+pub type rusage_info_current = rusage_info_v5;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct rlimit {
+    pub rlim_cur: rlim_t,
+    pub rlim_max: rlim_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct proc_rlimit_control_wakeupmon {
+    pub wm_flags: u32,
+    pub wm_rate: i32,
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getiopolicy_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setpriority(
+        arg1: ::std::os::raw::c_int,
+        arg2: id_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setiopolicy_np(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union wait {
+    pub w_status: ::std::os::raw::c_int,
+    pub w_T: wait__bindgen_ty_1,
+    pub w_S: wait__bindgen_ty_2,
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct wait__bindgen_ty_1 {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+impl wait__bindgen_ty_1 {
+    #[inline]
+    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 7u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        w_Termsig: ::std::os::raw::c_uint,
+        w_Coredump: ::std::os::raw::c_uint,
+        w_Retcode: ::std::os::raw::c_uint,
+        w_Filler: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 7u8, {
+            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
+            w_Termsig as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
+            w_Coredump as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 8u8, {
+            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
+            w_Retcode as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
+            w_Filler as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct wait__bindgen_ty_2 {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+impl wait__bindgen_ty_2 {
+    #[inline]
+    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        w_Stopval: ::std::os::raw::c_uint,
+        w_Stopsig: ::std::os::raw::c_uint,
+        w_Filler: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 8u8, {
+            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
+            w_Stopval as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 8u8, {
+            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
+            w_Stopsig as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
+            w_Filler as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+impl Default for wait {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn waitpid(
+        arg1: pid_t,
+        arg2: *mut ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn waitid(
+        arg1: idtype_t,
+        arg2: id_t,
+        arg3: *mut siginfo_t,
+        arg4: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait3(
+        arg1: *mut ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut rusage,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wait4(
+        arg1: pid_t,
+        arg2: *mut ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut rusage,
+    ) -> pid_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+}
+pub type ct_rune_t = __darwin_ct_rune_t;
+pub type rune_t = __darwin_rune_t;
+pub type wchar_t = __darwin_wchar_t;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -3658,595 +6046,7 @@ pub struct lldiv_t {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_get_mb_cur_max() -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtod(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtof(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtold(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-    ) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtol(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoul(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoq(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtouq(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoll(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoull(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-pub type u_char = __u_char;
-pub type u_short = __u_short;
-pub type u_int = __u_int;
-pub type u_long = __u_long;
-pub type quad_t = __quad_t;
-pub type u_quad_t = __u_quad_t;
-pub type fsid_t = __fsid_t;
-pub type loff_t = __loff_t;
-pub type ino_t = __ino_t;
-pub type dev_t = __dev_t;
-pub type gid_t = __gid_t;
-pub type mode_t = __mode_t;
-pub type nlink_t = __nlink_t;
-pub type uid_t = __uid_t;
-pub type pid_t = __pid_t;
-pub type id_t = __id_t;
-pub type daddr_t = __daddr_t;
-pub type caddr_t = __caddr_t;
-pub type key_t = __key_t;
-pub type clock_t = __clock_t;
-pub type clockid_t = __clockid_t;
-pub type time_t = __time_t;
-pub type timer_t = __timer_t;
-pub type ulong = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_int8_t = __uint8_t;
-pub type u_int16_t = __uint16_t;
-pub type u_int32_t = __uint32_t;
-pub type u_int64_t = __uint64_t;
-pub type register_t = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sigset_t {
-    pub __val: [::std::os::raw::c_ulong; 16usize],
-}
-pub type sigset_t = __sigset_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __time_t,
-    pub tv_usec: __suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __time_t,
-    pub tv_nsec: __syscall_slong_t,
-}
-pub type suseconds_t = __suseconds_t;
-pub type __fd_mask = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub __fds_bits: [__fd_mask; 16usize],
-}
-pub type fd_mask = __fd_mask;
-#[pg_guard]
-extern "C" {
-    pub fn select(
-        __nfds: ::std::os::raw::c_int,
-        __readfds: *mut fd_set,
-        __writefds: *mut fd_set,
-        __exceptfds: *mut fd_set,
-        __timeout: *mut timeval,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pselect(
-        __nfds: ::std::os::raw::c_int,
-        __readfds: *mut fd_set,
-        __writefds: *mut fd_set,
-        __exceptfds: *mut fd_set,
-        __timeout: *const timespec,
-        __sigmask: *const __sigset_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type blksize_t = __blksize_t;
-pub type blkcnt_t = __blkcnt_t;
-pub type fsblkcnt_t = __fsblkcnt_t;
-pub type fsfilcnt_t = __fsfilcnt_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_internal_list {
-    pub __prev: *mut __pthread_internal_list,
-    pub __next: *mut __pthread_internal_list,
-}
-impl Default for __pthread_internal_list {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __pthread_list_t = __pthread_internal_list;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_internal_slist {
-    pub __next: *mut __pthread_internal_slist,
-}
-impl Default for __pthread_internal_slist {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __pthread_slist_t = __pthread_internal_slist;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __pthread_mutex_s {
-    pub __lock: ::std::os::raw::c_int,
-    pub __count: ::std::os::raw::c_uint,
-    pub __owner: ::std::os::raw::c_int,
-    pub __nusers: ::std::os::raw::c_uint,
-    pub __kind: ::std::os::raw::c_int,
-    pub __spins: ::std::os::raw::c_short,
-    pub __elision: ::std::os::raw::c_short,
-    pub __list: __pthread_list_t,
-}
-impl Default for __pthread_mutex_s {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_rwlock_arch_t {
-    pub __readers: ::std::os::raw::c_uint,
-    pub __writers: ::std::os::raw::c_uint,
-    pub __wrphase_futex: ::std::os::raw::c_uint,
-    pub __writers_futex: ::std::os::raw::c_uint,
-    pub __pad3: ::std::os::raw::c_uint,
-    pub __pad4: ::std::os::raw::c_uint,
-    pub __cur_writer: ::std::os::raw::c_int,
-    pub __shared: ::std::os::raw::c_int,
-    pub __rwelision: ::std::os::raw::c_schar,
-    pub __pad1: [::std::os::raw::c_uchar; 7usize],
-    pub __pad2: ::std::os::raw::c_ulong,
-    pub __flags: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __pthread_cond_s {
-    pub __bindgen_anon_1: __pthread_cond_s__bindgen_ty_1,
-    pub __bindgen_anon_2: __pthread_cond_s__bindgen_ty_2,
-    pub __g_refs: [::std::os::raw::c_uint; 2usize],
-    pub __g_size: [::std::os::raw::c_uint; 2usize],
-    pub __g1_orig_size: ::std::os::raw::c_uint,
-    pub __wrefs: ::std::os::raw::c_uint,
-    pub __g_signals: [::std::os::raw::c_uint; 2usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __pthread_cond_s__bindgen_ty_1 {
-    pub __wseq: ::std::os::raw::c_ulonglong,
-    pub __wseq32: __pthread_cond_s__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_cond_s__bindgen_ty_1__bindgen_ty_1 {
-    pub __low: ::std::os::raw::c_uint,
-    pub __high: ::std::os::raw::c_uint,
-}
-impl Default for __pthread_cond_s__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __pthread_cond_s__bindgen_ty_2 {
-    pub __g1_start: ::std::os::raw::c_ulonglong,
-    pub __g1_start32: __pthread_cond_s__bindgen_ty_2__bindgen_ty_1,
-    _bindgen_union_align: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __pthread_cond_s__bindgen_ty_2__bindgen_ty_1 {
-    pub __low: ::std::os::raw::c_uint,
-    pub __high: ::std::os::raw::c_uint,
-}
-impl Default for __pthread_cond_s__bindgen_ty_2 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for __pthread_cond_s {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
-}
-pub type pthread_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_mutexattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_mutexattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_condattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_condattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type pthread_key_t = ::std::os::raw::c_uint;
-pub type pthread_once_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_attr_t {
-    pub __size: [::std::os::raw::c_char; 56usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 7usize],
-}
-impl Default for pthread_attr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_mutex_t {
-    pub __data: __pthread_mutex_s,
-    pub __size: [::std::os::raw::c_char; 40usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 5usize],
-}
-impl Default for pthread_mutex_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_cond_t {
-    pub __data: __pthread_cond_s,
-    pub __size: [::std::os::raw::c_char; 48usize],
-    pub __align: ::std::os::raw::c_longlong,
-    _bindgen_union_align: [u64; 6usize],
-}
-impl Default for pthread_cond_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_rwlock_t {
-    pub __data: __pthread_rwlock_arch_t,
-    pub __size: [::std::os::raw::c_char; 56usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 7usize],
-}
-impl Default for pthread_rwlock_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_rwlockattr_t {
-    pub __size: [::std::os::raw::c_char; 8usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: u64,
-}
-impl Default for pthread_rwlockattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type pthread_spinlock_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_barrier_t {
-    pub __size: [::std::os::raw::c_char; 32usize],
-    pub __align: ::std::os::raw::c_long,
-    _bindgen_union_align: [u64; 4usize],
-}
-impl Default for pthread_barrier_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union pthread_barrierattr_t {
-    pub __size: [::std::os::raw::c_char; 4usize],
-    pub __align: ::std::os::raw::c_int,
-    _bindgen_union_align: u32,
-}
-impl Default for pthread_barrierattr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom(__seed: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn initstate(
-        __seed: ::std::os::raw::c_uint,
-        __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct random_data {
-    pub fptr: *mut i32,
-    pub rptr: *mut i32,
-    pub state: *mut i32,
-    pub rand_type: ::std::os::raw::c_int,
-    pub rand_deg: ::std::os::raw::c_int,
-    pub rand_sep: ::std::os::raw::c_int,
-    pub end_ptr: *mut i32,
-}
-impl Default for random_data {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom_r(
-        __seed: ::std::os::raw::c_uint,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn initstate_r(
-        __seed: ::std::os::raw::c_uint,
-        __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: usize,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate_r(
-        __statebuf: *mut ::std::os::raw::c_char,
-        __buf: *mut random_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand(__seed: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48(__seedval: ::std::os::raw::c_long);
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct drand48_data {
-    pub __x: [::std::os::raw::c_ushort; 3usize],
-    pub __old_x: [::std::os::raw::c_ushort; 3usize],
-    pub __c: ::std::os::raw::c_ushort,
-    pub __init: ::std::os::raw::c_ushort,
-    pub __a: ::std::os::raw::c_ulonglong,
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut f64,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48_r(
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48_r(
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48_r(
-        __xsubi: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-        __result: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48_r(
-        __seedval: ::std::os::raw::c_long,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48_r(
-        __seed16v: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48_r(
-        __param: *mut ::std::os::raw::c_ushort,
-        __buffer: *mut drand48_data,
-    ) -> ::std::os::raw::c_int;
+    pub static mut __mb_cur_max: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -4255,9 +6055,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn calloc(
-        __nmemb: ::std::os::raw::c_ulong,
+        __count: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4268,23 +6072,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn reallocarray(
-        __ptr: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
-    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -4296,247 +6088,74 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
     pub fn abort();
 }
 #[pg_guard]
 extern "C" {
-    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn at_quick_exit(
-        __func: ::std::option::Option<unsafe extern "C" fn()>,
-    ) -> ::std::os::raw::c_int;
+    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn on_exit(
-        __func: ::std::option::Option<
-            unsafe extern "C" fn(
-                __status: ::std::os::raw::c_int,
-                __arg: *mut ::std::os::raw::c_void,
-            ),
-        >,
-        __arg: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
+    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exit(__status: ::std::os::raw::c_int);
+    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn quick_exit(__status: ::std::os::raw::c_int);
+    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _Exit(__status: ::std::os::raw::c_int);
+    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
 }
-#[pg_guard]
-extern "C" {
-    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __replace: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn clearenv() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemps(
-        __template: *mut ::std::os::raw::c_char,
-        __suffixlen: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn realpath(
-        __name: *const ::std::os::raw::c_char,
-        __resolved: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-pub type __compar_fn_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int,
->;
 #[pg_guard]
 extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-        __compar: __compar_fn_t,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
-        __size: usize,
-        __compar: __compar_fn_t,
-    );
+    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn exit(arg1: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
+    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
+    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lldiv(
-        __numer: ::std::os::raw::c_longlong,
-        __denom: ::std::os::raw::c_longlong,
-    ) -> lldiv_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gcvt(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qecvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qfcvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qgcvt(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt_r(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt_r(
-        __value: f64,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qecvt_r(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn qfcvt_r(
-        __value: u128,
-        __ndigit: ::std::os::raw::c_int,
-        __decpt: *mut ::std::os::raw::c_int,
-        __sign: *mut ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
 }
 #[pg_guard]
 extern "C" {
@@ -4544,70 +6163,594 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
     pub fn mbtowc(
-        __pwc: *mut wchar_t,
-        __s: *const ::std::os::raw::c_char,
-        __n: usize,
+        arg1: *mut wchar_t,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn rand() -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
+    pub fn srand(arg1: ::std::os::raw::c_uint);
 }
 #[pg_guard]
 extern "C" {
-    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn strtod(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtof(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtol(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtold(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoll(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoul(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoull(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _Exit(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gcvt(
+        arg1: f64,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn getsubopt(
-        __optionp: *mut *mut ::std::os::raw::c_char,
-        __tokens: *const *mut ::std::os::raw::c_char,
-        __valuep: *mut *mut ::std::os::raw::c_char,
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *const *mut ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
+    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memcpy(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+    pub fn initstate(
+        arg1: ::std::os::raw::c_uint,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ptsname_r(
+        fildes: ::std::os::raw::c_int,
+        buffer: *mut ::std::os::raw::c_char,
+        buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn random() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
+    pub fn realpath(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setenv(
+        __name: *const ::std::os::raw::c_char,
+        __value: *const ::std::os::raw::c_char,
+        __overwrite: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setkey(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48(arg1: ::std::os::raw::c_long);
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom(arg1: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+pub type dev_t = __darwin_dev_t;
+pub type mode_t = __darwin_mode_t;
+#[pg_guard]
+extern "C" {
+    pub fn arc4random() -> u32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_stir();
+}
+#[pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bsearch_b(
+        __key: *const ::std::os::raw::c_void,
+        __base: *const ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmove(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+    pub fn cgetcap(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetclose() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetent(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+        arg3: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetfirst(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetmatch(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetnext(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetnum(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetstr(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cgetustr(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_daemon$1050"]
+    pub fn daemon(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn devname_r(
+        arg1: dev_t,
+        arg2: mode_t,
+        buf: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getbsize(
+        arg1: *mut ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_long,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprogname() -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn heapsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn heapsort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mergesort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mergesort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *const ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn psort_r(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        arg1: *mut ::std::os::raw::c_void,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+                arg3: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn qsort_b(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        __compar: *mut ::std::os::raw::c_void,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn qsort_r(
+        __base: *mut ::std::os::raw::c_void,
+        __nel: usize,
+        __width: usize,
+        arg1: *mut ::std::os::raw::c_void,
+        __compar: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: *mut ::std::os::raw::c_void,
+                arg2: *const ::std::os::raw::c_void,
+                arg3: *const ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn radixsort(
+        __base: *mut *const ::std::os::raw::c_uchar,
+        __nel: ::std::os::raw::c_int,
+        __table: *const ::std::os::raw::c_uchar,
+        __endbyte: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sradixsort(
+        __base: *mut *const ::std::os::raw::c_uchar,
+        __nel: ::std::os::raw::c_int,
+        __table: *const ::std::os::raw::c_uchar,
+        __endbyte: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sranddev();
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandomdev();
+}
+#[pg_guard]
+extern "C" {
+    pub fn reallocf(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memccpy(
-        __dest: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __n: usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn strtonum(
+        __numstr: *const ::std::os::raw::c_char,
+        __minval: ::std::os::raw::c_longlong,
+        __maxval: ::std::os::raw::c_longlong,
+        __errstrp: *mut *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memset(
-        __s: *mut ::std::os::raw::c_void,
+    pub fn strtoq(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtouq(
+        __str: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut suboptarg: *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -4622,114 +6765,33 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
+    pub fn memcpy(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn memmove(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __len: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn memset(
+        __b: *mut ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __len: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
     pub fn strcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcmp(
-        __s1: *const ::std::os::raw::c_char,
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncmp(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strxfrm(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __locale_struct {
-    pub __locales: [*mut __locale_data; 13usize],
-    pub __ctype_b: *const ::std::os::raw::c_ushort,
-    pub __ctype_tolower: *const ::std::os::raw::c_int,
-    pub __ctype_toupper: *const ::std::os::raw::c_int,
-    pub __names: [*const ::std::os::raw::c_char; 13usize],
-}
-impl Default for __locale_struct {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __locale_t = *mut __locale_struct;
-pub type locale_t = __locale_t;
-#[pg_guard]
-extern "C" {
-    pub fn strcoll_l(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __l: locale_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strxfrm_l(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: usize,
-        __l: locale_t,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strndup(
-        __string: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -4741,69 +6803,31 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strrchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strcmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strcspn(
         __s: *const ::std::os::raw::c_char,
-        __reject: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strspn(
-        __s: *const ::std::os::raw::c_char,
-        __accept: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strpbrk(
-        __s: *const ::std::os::raw::c_char,
-        __accept: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strstr(
-        __haystack: *const ::std::os::raw::c_char,
-        __needle: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtok(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __strtok_r(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-        __save_ptr: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtok_r(
-        __s: *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-        __save_ptr: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
@@ -4811,76 +6835,19 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}__xpg_strerror_r"]
-    pub fn strerror_r(
-        __errnum: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strerror_l(
-        __errnum: ::std::os::raw::c_int,
-        __l: locale_t,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcmp(
-        __s1: *const ::std::os::raw::c_void,
-        __s2: *const ::std::os::raw::c_void,
-        __n: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcopy(
-        __src: *const ::std::os::raw::c_void,
-        __dest: *mut ::std::os::raw::c_void,
-        __n: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
-}
-#[pg_guard]
-extern "C" {
-    pub fn index(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rindex(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcasecmp(
-        __s1: *const ::std::os::raw::c_char,
+    pub fn strncat(
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncasecmp(
+    pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
@@ -4888,24 +6855,192 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcasecmp_l(
-        __s1: *const ::std::os::raw::c_char,
+    pub fn strncpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strrchr(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __charset: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strstr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtok(
+        __str: *mut ::std::os::raw::c_char,
+        __sep: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm(
+        __s1: *mut ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-        __loc: locale_t,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtok_r(
+        __str: *mut ::std::os::raw::c_char,
+        __sep: *const ::std::os::raw::c_char,
+        __lasts: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strerror_r(
+        __errnum: ::std::os::raw::c_int,
+        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncasecmp_l(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: usize,
-        __loc: locale_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+    pub fn memccpy(
+        __dst: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn stpcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn stpncpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strndup(
+        __s1: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+pub type rsize_t = __darwin_size_t;
+pub type errno_t = ::std::os::raw::c_int;
+#[pg_guard]
+extern "C" {
+    pub fn memset_s(
+        __s: *mut ::std::os::raw::c_void,
+        __smax: rsize_t,
+        __c: ::std::os::raw::c_int,
+        __n: rsize_t,
+    ) -> errno_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memmem(
+        __big: *const ::std::os::raw::c_void,
+        __big_len: usize,
+        __little: *const ::std::os::raw::c_void,
+        __little_len: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern4(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern4: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern8(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern8: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn memset_pattern16(
+        __b: *mut ::std::os::raw::c_void,
+        __pattern16: *const ::std::os::raw::c_void,
+        __len: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcasestr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnstr(
+        __big: *const ::std::os::raw::c_char,
+        __little: *const ::std::os::raw::c_char,
+        __len: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dst: *mut ::std::os::raw::c_char,
+        __source: *const ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dst: *mut ::std::os::raw::c_char,
+        __source: *const ::std::os::raw::c_char,
+        __size: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
@@ -4916,67 +7051,158 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+    pub fn swab(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: isize,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn __stpcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
+    pub fn timingsafe_bcmp(
+        __b1: *const ::std::os::raw::c_void,
+        __b2: *const ::std::os::raw::c_void,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strsignal_r(
+        __sig: ::std::os::raw::c_int,
+        __strsignalbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcmp(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcopy(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
+}
+#[pg_guard]
+extern "C" {
+    pub fn index(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
+    pub fn rindex(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __stpncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: usize,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpncpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn strcasecmp(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
 }
+#[pg_guard]
+extern "C" {
+    pub fn strncasecmp(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+pub type max_align_t = u128;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type u_char = ::std::os::raw::c_uchar;
+pub type u_short = ::std::os::raw::c_ushort;
+pub type u_int = ::std::os::raw::c_uint;
+pub type u_long = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_quad_t = u_int64_t;
+pub type quad_t = i64;
+pub type qaddr_t = *mut quad_t;
+pub type caddr_t = *mut ::std::os::raw::c_char;
+pub type daddr_t = i32;
+pub type fixpt_t = u_int32_t;
+pub type blkcnt_t = __darwin_blkcnt_t;
+pub type blksize_t = __darwin_blksize_t;
+pub type gid_t = __darwin_gid_t;
+pub type in_addr_t = __uint32_t;
+pub type in_port_t = __uint16_t;
+pub type ino_t = __darwin_ino_t;
+pub type ino64_t = __darwin_ino64_t;
+pub type key_t = __int32_t;
+pub type nlink_t = __uint16_t;
+pub type segsz_t = i32;
+pub type swblk_t = i32;
+pub type clock_t = __darwin_clock_t;
+pub type time_t = __darwin_time_t;
+pub type useconds_t = __darwin_useconds_t;
+pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
-#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct max_align_t {
-    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
-    pub __bindgen_padding_0: u64,
-    pub __clang_max_align_nonce2: u128,
+pub struct fd_set {
+    pub fds_bits: [__int32_t; 32usize],
 }
-pub type int_least8_t = __int_least8_t;
-pub type int_least16_t = __int_least16_t;
-pub type int_least32_t = __int_least32_t;
-pub type int_least64_t = __int_least64_t;
-pub type uint_least8_t = __uint_least8_t;
-pub type uint_least16_t = __uint_least16_t;
-pub type uint_least32_t = __uint_least32_t;
-pub type uint_least64_t = __uint_least64_t;
-pub type int_fast8_t = ::std::os::raw::c_schar;
-pub type int_fast16_t = ::std::os::raw::c_long;
-pub type int_fast32_t = ::std::os::raw::c_long;
-pub type int_fast64_t = ::std::os::raw::c_long;
-pub type uint_fast8_t = ::std::os::raw::c_uchar;
-pub type uint_fast16_t = ::std::os::raw::c_ulong;
-pub type uint_fast32_t = ::std::os::raw::c_ulong;
-pub type uint_fast64_t = ::std::os::raw::c_ulong;
-pub type intmax_t = __intmax_t;
-pub type uintmax_t = __uintmax_t;
 #[pg_guard]
 extern "C" {
-    pub fn __errno_location() -> *mut ::std::os::raw::c_int;
+    pub fn __darwin_check_fd_set_overflow(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fd_mask = __int32_t;
+pub type pthread_cond_t = __darwin_pthread_cond_t;
+pub type pthread_condattr_t = __darwin_pthread_condattr_t;
+pub type pthread_mutex_t = __darwin_pthread_mutex_t;
+pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
+pub type pthread_once_t = __darwin_pthread_once_t;
+pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
+pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
+pub type pthread_t = __darwin_pthread_t;
+pub type pthread_key_t = __darwin_pthread_key_t;
+pub type fsblkcnt_t = __darwin_fsblkcnt_t;
+pub type fsfilcnt_t = __darwin_fsfilcnt_t;
+#[pg_guard]
+extern "C" {
+    pub fn __error() -> *mut ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5000,8 +7226,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_p_sep_by_space: ::std::os::raw::c_char,
     pub int_n_cs_precedes: ::std::os::raw::c_char,
+    pub int_p_sep_by_space: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -5013,34 +7239,14 @@ impl Default for lconv {
 }
 #[pg_guard]
 extern "C" {
-    pub fn setlocale(
-        __category: ::std::os::raw::c_int,
-        __locale: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
     pub fn localeconv() -> *mut lconv;
 }
 #[pg_guard]
 extern "C" {
-    pub fn newlocale(
-        __category_mask: ::std::os::raw::c_int,
-        __locale: *const ::std::os::raw::c_char,
-        __base: locale_t,
-    ) -> locale_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn duplocale(__dataset: locale_t) -> locale_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freelocale(__dataset: locale_t);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uselocale(__dataset: locale_t) -> locale_t;
+    pub fn setlocale(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
 pub type int8 = ::std::os::raw::c_schar;
@@ -5133,7 +7339,6 @@ pub union PGAlignedBlock {
     pub data: [::std::os::raw::c_char; 8192usize],
     pub force_align_d: f64,
     pub force_align_i64: int64,
-    _bindgen_union_align: [u64; 1024usize],
 }
 impl Default for PGAlignedBlock {
     fn default() -> Self {
@@ -5146,174 +7351,121 @@ pub union PGAlignedXLogBlock {
     pub data: [::std::os::raw::c_char; 8192usize],
     pub force_align_d: f64,
     pub force_align_i64: int64,
-    _bindgen_union_align: [u64; 1024usize],
 }
 impl Default for PGAlignedXLogBlock {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub const _ISupper: ::std::os::raw::c_uint = 256;
-pub const _ISlower: ::std::os::raw::c_uint = 512;
-pub const _ISalpha: ::std::os::raw::c_uint = 1024;
-pub const _ISdigit: ::std::os::raw::c_uint = 2048;
-pub const _ISxdigit: ::std::os::raw::c_uint = 4096;
-pub const _ISspace: ::std::os::raw::c_uint = 8192;
-pub const _ISprint: ::std::os::raw::c_uint = 16384;
-pub const _ISgraph: ::std::os::raw::c_uint = 32768;
-pub const _ISblank: ::std::os::raw::c_uint = 1;
-pub const _IScntrl: ::std::os::raw::c_uint = 2;
-pub const _ISpunct: ::std::os::raw::c_uint = 4;
-pub const _ISalnum: ::std::os::raw::c_uint = 8;
-pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
+    pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+pub type wint_t = __darwin_wint_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _RuneEntry {
+    pub __min: __darwin_rune_t,
+    pub __max: __darwin_rune_t,
+    pub __map: __darwin_rune_t,
+    pub __types: *mut __uint32_t,
+}
+impl Default for _RuneEntry {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _RuneRange {
+    pub __nranges: ::std::os::raw::c_int,
+    pub __ranges: *mut _RuneEntry,
+}
+impl Default for _RuneRange {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _RuneCharClass {
+    pub __name: [::std::os::raw::c_char; 14usize],
+    pub __mask: __uint32_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _RuneLocale {
+    pub __magic: [::std::os::raw::c_char; 8usize],
+    pub __encoding: [::std::os::raw::c_char; 32usize],
+    pub __sgetrune: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *const ::std::os::raw::c_char,
+            arg2: __darwin_size_t,
+            arg3: *mut *const ::std::os::raw::c_char,
+        ) -> __darwin_rune_t,
+    >,
+    pub __sputrune: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: __darwin_rune_t,
+            arg2: *mut ::std::os::raw::c_char,
+            arg3: __darwin_size_t,
+            arg4: *mut *mut ::std::os::raw::c_char,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub __invalid_rune: __darwin_rune_t,
+    pub __runetype: [__uint32_t; 256usize],
+    pub __maplower: [__darwin_rune_t; 256usize],
+    pub __mapupper: [__darwin_rune_t; 256usize],
+    pub __runetype_ext: _RuneRange,
+    pub __maplower_ext: _RuneRange,
+    pub __mapupper_ext: _RuneRange,
+    pub __variable: *mut ::std::os::raw::c_void,
+    pub __variable_len: ::std::os::raw::c_int,
+    pub __ncharclasses: ::std::os::raw::c_int,
+    pub __charclasses: *mut _RuneCharClass,
+}
+impl Default for _RuneLocale {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
+    pub static mut _DefaultRuneLocale: _RuneLocale;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
+    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __maskrune(
+        arg1: __darwin_ct_rune_t,
+        arg2: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
 }
-#[pg_guard]
-extern "C" {
-    pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
-}
+pub type socklen_t = __darwin_socklen_t;
+pub type sa_family_t = __uint8_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -5325,131 +7477,23 @@ impl Default for iovec {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type socklen_t = __socklen_t;
-pub const __socket_type_SOCK_STREAM: __socket_type = 1;
-pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
-pub const __socket_type_SOCK_RAW: __socket_type = 3;
-pub const __socket_type_SOCK_RDM: __socket_type = 4;
-pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
-pub const __socket_type_SOCK_DCCP: __socket_type = 6;
-pub const __socket_type_SOCK_PACKET: __socket_type = 10;
-pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
-pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
-pub type __socket_type = ::std::os::raw::c_uint;
-pub type sa_family_t = ::std::os::raw::c_ushort;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr {
-    pub sa_family: sa_family_t,
-    pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_storage {
-    pub ss_family: sa_family_t,
-    pub __ss_padding: [::std::os::raw::c_char; 118usize],
-    pub __ss_align: ::std::os::raw::c_ulong,
-}
-impl Default for sockaddr_storage {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub const MSG_OOB: ::std::os::raw::c_uint = 1;
-pub const MSG_PEEK: ::std::os::raw::c_uint = 2;
-pub const MSG_DONTROUTE: ::std::os::raw::c_uint = 4;
-pub const MSG_CTRUNC: ::std::os::raw::c_uint = 8;
-pub const MSG_PROXY: ::std::os::raw::c_uint = 16;
-pub const MSG_TRUNC: ::std::os::raw::c_uint = 32;
-pub const MSG_DONTWAIT: ::std::os::raw::c_uint = 64;
-pub const MSG_EOR: ::std::os::raw::c_uint = 128;
-pub const MSG_WAITALL: ::std::os::raw::c_uint = 256;
-pub const MSG_FIN: ::std::os::raw::c_uint = 512;
-pub const MSG_SYN: ::std::os::raw::c_uint = 1024;
-pub const MSG_CONFIRM: ::std::os::raw::c_uint = 2048;
-pub const MSG_RST: ::std::os::raw::c_uint = 4096;
-pub const MSG_ERRQUEUE: ::std::os::raw::c_uint = 8192;
-pub const MSG_NOSIGNAL: ::std::os::raw::c_uint = 16384;
-pub const MSG_MORE: ::std::os::raw::c_uint = 32768;
-pub const MSG_WAITFORONE: ::std::os::raw::c_uint = 65536;
-pub const MSG_BATCH: ::std::os::raw::c_uint = 262144;
-pub const MSG_ZEROCOPY: ::std::os::raw::c_uint = 67108864;
-pub const MSG_FASTOPEN: ::std::os::raw::c_uint = 536870912;
-pub const MSG_CMSG_CLOEXEC: ::std::os::raw::c_uint = 1073741824;
-pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
+pub type sae_associd_t = __uint32_t;
+pub type sae_connid_t = __uint32_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct msghdr {
-    pub msg_name: *mut ::std::os::raw::c_void,
-    pub msg_namelen: socklen_t,
-    pub msg_iov: *mut iovec,
-    pub msg_iovlen: usize,
-    pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: usize,
-    pub msg_flags: ::std::os::raw::c_int,
+pub struct sa_endpoints {
+    pub sae_srcif: ::std::os::raw::c_uint,
+    pub sae_srcaddr: *const sockaddr,
+    pub sae_srcaddrlen: socklen_t,
+    pub sae_dstaddr: *const sockaddr,
+    pub sae_dstaddrlen: socklen_t,
 }
-impl Default for msghdr {
+impl Default for sa_endpoints {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct cmsghdr {
-    pub cmsg_len: usize,
-    pub cmsg_level: ::std::os::raw::c_int,
-    pub cmsg_type: ::std::os::raw::c_int,
-    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
-}
-pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
-pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __kernel_fd_set {
-    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
-}
-pub type __kernel_sighandler_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
-pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = __kernel_ulong_t;
-pub type __kernel_ssize_t = __kernel_long_t;
-pub type __kernel_ptrdiff_t = __kernel_long_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __kernel_fsid_t {
-    pub val: [::std::os::raw::c_int; 2usize],
-}
-pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
-pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
-pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type sa_endpoints_t = sa_endpoints;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct linger {
@@ -5458,175 +7502,273 @@ pub struct linger {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct osockaddr {
-    pub sa_family: ::std::os::raw::c_ushort,
-    pub sa_data: [::std::os::raw::c_uchar; 14usize],
+pub struct so_np_extensions {
+    pub npx_flags: u_int32_t,
+    pub npx_mask: u_int32_t,
 }
-pub const SHUT_RD: ::std::os::raw::c_uint = 0;
-pub const SHUT_WR: ::std::os::raw::c_uint = 1;
-pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
-pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr {
+    pub sa_len: __uint8_t,
+    pub sa_family: sa_family_t,
+    pub sa_data: [::std::os::raw::c_char; 14usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockproto {
+    pub sp_family: __uint16_t,
+    pub sp_protocol: __uint16_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_storage {
+    pub ss_len: __uint8_t,
+    pub ss_family: sa_family_t,
+    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
+    pub __ss_align: __int64_t,
+    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+}
+impl Default for sockaddr_storage {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct msghdr {
+    pub msg_name: *mut ::std::os::raw::c_void,
+    pub msg_namelen: socklen_t,
+    pub msg_iov: *mut iovec,
+    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_control: *mut ::std::os::raw::c_void,
+    pub msg_controllen: socklen_t,
+    pub msg_flags: ::std::os::raw::c_int,
+}
+impl Default for msghdr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct cmsghdr {
+    pub cmsg_len: socklen_t,
+    pub cmsg_level: ::std::os::raw::c_int,
+    pub cmsg_type: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sf_hdtr {
+    pub headers: *mut iovec,
+    pub hdr_cnt: ::std::os::raw::c_int,
+    pub trailers: *mut iovec,
+    pub trl_cnt: ::std::os::raw::c_int,
+}
+impl Default for sf_hdtr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[pg_guard]
 extern "C" {
-    pub fn socket(
-        __domain: ::std::os::raw::c_int,
-        __type: ::std::os::raw::c_int,
-        __protocol: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn socketpair(
-        __domain: ::std::os::raw::c_int,
-        __type: ::std::os::raw::c_int,
-        __protocol: ::std::os::raw::c_int,
-        __fds: *mut ::std::os::raw::c_int,
+    pub fn accept(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn bind(
-        __fd: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __len: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockname(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sockaddr,
+        arg3: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn connect(
-        __fd: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __len: socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sockaddr,
+        arg3: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn getpeername(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn send(
-        __fd: ::std::os::raw::c_int,
-        __buf: *const ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-    ) -> isize;
+    pub fn getsockname(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
+        arg3: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsockopt(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_void,
+        arg5: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn listen(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn recv(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendto(
-        __fd: ::std::os::raw::c_int,
-        __buf: *const ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-        __addr: *const sockaddr,
-        __addr_len: socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn recvfrom(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_void,
-        __n: usize,
-        __flags: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __addr_len: *mut socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendmsg(
-        __fd: ::std::os::raw::c_int,
-        __message: *const msghdr,
-        __flags: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+        arg5: *mut sockaddr,
+        arg6: *mut socklen_t,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn recvmsg(
-        __fd: ::std::os::raw::c_int,
-        __message: *mut msghdr,
-        __flags: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut msghdr,
+        arg3: ::std::os::raw::c_int,
     ) -> isize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getsockopt(
-        __fd: ::std::os::raw::c_int,
-        __level: ::std::os::raw::c_int,
-        __optname: ::std::os::raw::c_int,
-        __optval: *mut ::std::os::raw::c_void,
-        __optlen: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn send(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendmsg(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const msghdr,
+        arg3: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendto(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: usize,
+        arg4: ::std::os::raw::c_int,
+        arg5: *const sockaddr,
+        arg6: socklen_t,
+    ) -> isize;
 }
 #[pg_guard]
 extern "C" {
     pub fn setsockopt(
-        __fd: ::std::os::raw::c_int,
-        __level: ::std::os::raw::c_int,
-        __optname: ::std::os::raw::c_int,
-        __optval: *const ::std::os::raw::c_void,
-        __optlen: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn accept(
-        __fd: ::std::os::raw::c_int,
-        __addr: *mut sockaddr,
-        __addr_len: *mut socklen_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *const ::std::os::raw::c_void,
+        arg5: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn shutdown(
-        __fd: ::std::os::raw::c_int,
-        __how: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isfdtype(
-        __fd: ::std::os::raw::c_int,
-        __fdtype: ::std::os::raw::c_int,
+    pub fn socket(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
-pub type in_addr_t = u32;
+#[pg_guard]
+extern "C" {
+    pub fn socketpair(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendfile(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: off_t,
+        arg4: *mut off_t,
+        arg5: *mut sf_hdtr,
+        arg6: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
+}
+#[pg_guard]
+extern "C" {
+    pub fn connectx(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sa_endpoints_t,
+        arg3: sae_associd_t,
+        arg4: ::std::os::raw::c_uint,
+        arg5: *const iovec,
+        arg6: ::std::os::raw::c_uint,
+        arg7: *mut usize,
+        arg8: *mut sae_connid_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn disconnectx(
+        arg1: ::std::os::raw::c_int,
+        arg2: sae_associd_t,
+        arg3: sae_connid_t,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_len: __uint8_t,
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5641,6 +7783,12 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -5648,88 +7796,113 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_sourceaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
+}
+impl Default for group_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
+}
+impl Default for group_source_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct __msfilterreq {
+    pub msfr_ifindex: u32,
+    pub msfr_fmode: u32,
+    pub msfr_nsrcs: u32,
+    pub __msfr_align: u32,
+    pub msfr_group: sockaddr_storage,
+    pub msfr_srcs: *mut sockaddr_storage,
+}
+impl Default for __msfilterreq {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setipv4sourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: in_addr,
+        arg3: in_addr,
+        arg4: u32,
+        arg5: u32,
+        arg6: *mut in_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipv4sourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: in_addr,
+        arg3: in_addr,
+        arg4: *mut u32,
+        arg5: *mut u32,
+        arg6: *mut in_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setsourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: u32,
+        arg3: *mut sockaddr,
+        arg4: socklen_t,
+        arg5: u32,
+        arg6: u32,
+        arg7: *mut sockaddr_storage,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsourcefilter(
+        arg1: ::std::os::raw::c_int,
+        arg2: u32,
+        arg3: *mut sockaddr,
+        arg4: socklen_t,
+        arg5: *mut u32,
+        arg6: *mut u32,
+        arg7: *mut sockaddr_storage,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_int,
+    pub ipi_ifindex: ::std::os::raw::c_uint,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
-pub const IPPROTO_IP: ::std::os::raw::c_uint = 0;
-pub const IPPROTO_ICMP: ::std::os::raw::c_uint = 1;
-pub const IPPROTO_IGMP: ::std::os::raw::c_uint = 2;
-pub const IPPROTO_IPIP: ::std::os::raw::c_uint = 4;
-pub const IPPROTO_TCP: ::std::os::raw::c_uint = 6;
-pub const IPPROTO_EGP: ::std::os::raw::c_uint = 8;
-pub const IPPROTO_PUP: ::std::os::raw::c_uint = 12;
-pub const IPPROTO_UDP: ::std::os::raw::c_uint = 17;
-pub const IPPROTO_IDP: ::std::os::raw::c_uint = 22;
-pub const IPPROTO_TP: ::std::os::raw::c_uint = 29;
-pub const IPPROTO_DCCP: ::std::os::raw::c_uint = 33;
-pub const IPPROTO_IPV6: ::std::os::raw::c_uint = 41;
-pub const IPPROTO_RSVP: ::std::os::raw::c_uint = 46;
-pub const IPPROTO_GRE: ::std::os::raw::c_uint = 47;
-pub const IPPROTO_ESP: ::std::os::raw::c_uint = 50;
-pub const IPPROTO_AH: ::std::os::raw::c_uint = 51;
-pub const IPPROTO_MTP: ::std::os::raw::c_uint = 92;
-pub const IPPROTO_BEETPH: ::std::os::raw::c_uint = 94;
-pub const IPPROTO_ENCAP: ::std::os::raw::c_uint = 98;
-pub const IPPROTO_PIM: ::std::os::raw::c_uint = 103;
-pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
-pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
-pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
-pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
-pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
-pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
-pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
-pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
-pub const IPPROTO_FRAGMENT: ::std::os::raw::c_uint = 44;
-pub const IPPROTO_ICMPV6: ::std::os::raw::c_uint = 58;
-pub const IPPROTO_NONE: ::std::os::raw::c_uint = 59;
-pub const IPPROTO_DSTOPTS: ::std::os::raw::c_uint = 60;
-pub const IPPROTO_MH: ::std::os::raw::c_uint = 135;
-pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
-pub type in_port_t = u16;
-pub const IPPORT_ECHO: ::std::os::raw::c_uint = 7;
-pub const IPPORT_DISCARD: ::std::os::raw::c_uint = 9;
-pub const IPPORT_SYSTAT: ::std::os::raw::c_uint = 11;
-pub const IPPORT_DAYTIME: ::std::os::raw::c_uint = 13;
-pub const IPPORT_NETSTAT: ::std::os::raw::c_uint = 15;
-pub const IPPORT_FTP: ::std::os::raw::c_uint = 21;
-pub const IPPORT_TELNET: ::std::os::raw::c_uint = 23;
-pub const IPPORT_SMTP: ::std::os::raw::c_uint = 25;
-pub const IPPORT_TIMESERVER: ::std::os::raw::c_uint = 37;
-pub const IPPORT_NAMESERVER: ::std::os::raw::c_uint = 42;
-pub const IPPORT_WHOIS: ::std::os::raw::c_uint = 43;
-pub const IPPORT_MTP: ::std::os::raw::c_uint = 57;
-pub const IPPORT_TFTP: ::std::os::raw::c_uint = 69;
-pub const IPPORT_RJE: ::std::os::raw::c_uint = 77;
-pub const IPPORT_FINGER: ::std::os::raw::c_uint = 79;
-pub const IPPORT_TTYLINK: ::std::os::raw::c_uint = 87;
-pub const IPPORT_SUPDUP: ::std::os::raw::c_uint = 95;
-pub const IPPORT_EXECSERVER: ::std::os::raw::c_uint = 512;
-pub const IPPORT_LOGINSERVER: ::std::os::raw::c_uint = 513;
-pub const IPPORT_CMDSERVER: ::std::os::raw::c_uint = 514;
-pub const IPPORT_EFSSERVER: ::std::os::raw::c_uint = 520;
-pub const IPPORT_BIFFUDP: ::std::os::raw::c_uint = 512;
-pub const IPPORT_WHOSERVER: ::std::os::raw::c_uint = 513;
-pub const IPPORT_ROUTESERVER: ::std::os::raw::c_uint = 520;
-pub const IPPORT_RESERVED: ::std::os::raw::c_uint = 1024;
-pub const IPPORT_USERRESERVED: ::std::os::raw::c_uint = 5000;
-pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __in6_u: in6_addr__bindgen_ty_1,
+    pub __u6_addr: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [u8; 16usize],
-    pub __u6_addr16: [u16; 8usize],
-    pub __u6_addr32: [u32; 4usize],
-    _bindgen_union_align: [u32; 4usize],
+    pub __u6_addr8: [__uint8_t; 16usize],
+    pub __u6_addr16: [__uint16_t; 8usize],
+    pub __u6_addr32: [__uint32_t; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -5737,6 +7910,22 @@ impl Default for in6_addr__bindgen_ty_1 {
     }
 }
 impl Default for in6_addr {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type in6_addr_t = in6_addr;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_len: __uint8_t,
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: __uint32_t,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: __uint32_t,
+}
+impl Default for sockaddr_in6 {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
@@ -5749,40 +7938,21 @@ extern "C" {
 extern "C" {
     pub static in6addr_loopback: in6_addr;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+#[pg_guard]
+extern "C" {
+    pub static in6addr_nodelocal_allnodes: in6_addr;
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_in6 {
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: u32,
-    pub sin6_addr: in6_addr,
-    pub sin6_scope_id: u32,
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allnodes: in6_addr;
 }
-impl Default for sockaddr_in6 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allrouters: in6_addr;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-    pub imr_sourceaddr: in_addr,
+#[pg_guard]
+extern "C" {
+    pub static in6addr_linklocal_allv2routers: in6_addr;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5797,165 +7967,234 @@ impl Default for ipv6_mreq {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
+pub struct in6_pktinfo {
+    pub ipi6_addr: in6_addr,
+    pub ipi6_ifindex: ::std::os::raw::c_uint,
 }
-impl Default for group_req {
+impl Default for in6_pktinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
+pub struct ip6_mtuinfo {
+    pub ip6m_addr: sockaddr_in6,
+    pub ip6m_mtu: u32,
 }
-impl Default for group_source_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_msfilter {
-    pub imsf_multiaddr: in_addr,
-    pub imsf_interface: in_addr,
-    pub imsf_fmode: u32,
-    pub imsf_numsrc: u32,
-    pub imsf_slist: [in_addr; 1usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct group_filter {
-    pub gf_interface: u32,
-    pub gf_group: sockaddr_storage,
-    pub gf_fmode: u32,
-    pub gf_numsrc: u32,
-    pub gf_slist: [sockaddr_storage; 1usize],
-}
-impl Default for group_filter {
+impl Default for ip6_mtuinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn ntohl(__netlong: u32) -> u32;
+    pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ntohs(__netshort: u16) -> u16;
+    pub fn inet6_option_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *mut *mut cmsghdr,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn htonl(__hostlong: u32) -> u32;
+    pub fn inet6_option_append(
+        arg1: *mut cmsghdr,
+        arg2: *const __uint8_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn htons(__hostshort: u16) -> u16;
+    pub fn inet6_option_alloc(
+        arg1: *mut cmsghdr,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> *mut __uint8_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_option_next(
+        arg1: *const cmsghdr,
+        arg2: *mut *mut __uint8_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_option_find(
+        arg1: *const cmsghdr,
+        arg2: *mut *mut __uint8_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut cmsghdr;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_add(
+        arg1: *mut cmsghdr,
+        arg2: *const in6_addr,
+        arg3: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_lasthop(
+        arg1: *mut cmsghdr,
+        arg2: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_getaddr(arg1: *mut cmsghdr, arg2: ::std::os::raw::c_int) -> *mut in6_addr;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rthdr_getflags(
+        arg1: *const cmsghdr,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_append(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: __uint8_t,
+        arg5: socklen_t,
+        arg6: __uint8_t,
+        arg7: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_finish(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_set_val(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_next(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut __uint8_t,
+        arg5: *mut socklen_t,
+        arg6: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_find(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: __uint8_t,
+        arg5: *mut socklen_t,
+        arg6: *mut *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_opt_get_val(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> socklen_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_init(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_add(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *const in6_addr,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_reverse(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn inet6_rth_getaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut in6_addr;
 }
 #[pg_guard]
 extern "C" {
     pub fn bindresvport(
-        __sockfd: ::std::os::raw::c_int,
-        __sock_in: *mut sockaddr_in,
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr_in,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bindresvport6(
-        __sockfd: ::std::os::raw::c_int,
-        __sock_in: *mut sockaddr_in6,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endrpcent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent() -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
+    pub fn bindresvport_sa(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sockaddr,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getrpcbynumber_r(
-        __number: ::std::os::raw::c_int,
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent_r(
-        __result_buf: *mut rpcent,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut rpcent,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn herror(__str: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub static mut h_errno: ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5971,135 +8210,18 @@ impl Default for hostent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn sethostent(__stay_open: ::std::os::raw::c_int);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
 }
-#[pg_guard]
-extern "C" {
-    pub fn endhostent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent() -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr(
-        __addr: *const ::std::os::raw::c_void,
-        __len: __socklen_t,
-        __type: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2(
-        __name: *const ::std::os::raw::c_char,
-        __af: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent_r(
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr_r(
-        __addr: *const ::std::os::raw::c_void,
-        __len: __socklen_t,
-        __type: ::std::os::raw::c_int,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2_r(
-        __name: *const ::std::os::raw::c_char,
-        __af: ::std::os::raw::c_int,
-        __result_buf: *mut hostent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut hostent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent() -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent_r(
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr_r(
-        __net: u32,
-        __type: ::std::os::raw::c_int,
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut netent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut netent,
-        __h_errnop: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+impl Default for netent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6114,63 +8236,6 @@ impl Default for servent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn setservent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endservent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent() -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname(
-        __name: *const ::std::os::raw::c_char,
-        __proto: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport(
-        __port: ::std::os::raw::c_int,
-        __proto: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent_r(
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __proto: *const ::std::os::raw::c_char,
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport_r(
-        __port: ::std::os::raw::c_int,
-        __proto: *const ::std::os::raw::c_char,
-        __result_buf: *mut servent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut servent,
-    ) -> ::std::os::raw::c_int;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -6183,185 +8248,6 @@ impl Default for protoent {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn endprotoent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent() -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent_r(
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname_r(
-        __name: *const ::std::os::raw::c_char,
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber_r(
-        __proto: ::std::os::raw::c_int,
-        __result_buf: *mut protoent,
-        __buf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut protoent,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetgrent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetgrent(
-        __hostp: *mut *mut ::std::os::raw::c_char,
-        __userp: *mut *mut ::std::os::raw::c_char,
-        __domainp: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn innetgr(
-        __netgroup: *const ::std::os::raw::c_char,
-        __host: *const ::std::os::raw::c_char,
-        __user: *const ::std::os::raw::c_char,
-        __domain: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetgrent_r(
-        __hostp: *mut *mut ::std::os::raw::c_char,
-        __userp: *mut *mut ::std::os::raw::c_char,
-        __domainp: *mut *mut ::std::os::raw::c_char,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rcmd(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_ushort,
-        __locuser: *const ::std::os::raw::c_char,
-        __remuser: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rcmd_af(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_ushort,
-        __locuser: *const ::std::os::raw::c_char,
-        __remuser: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rexec(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_int,
-        __name: *const ::std::os::raw::c_char,
-        __pass: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rexec_af(
-        __ahost: *mut *mut ::std::os::raw::c_char,
-        __rport: ::std::os::raw::c_int,
-        __name: *const ::std::os::raw::c_char,
-        __pass: *const ::std::os::raw::c_char,
-        __cmd: *const ::std::os::raw::c_char,
-        __fd2p: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ruserok(
-        __rhost: *const ::std::os::raw::c_char,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ruserok_af(
-        __rhost: *const ::std::os::raw::c_char,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iruserok(
-        __raddr: u32,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn iruserok_af(
-        __raddr: *const ::std::os::raw::c_void,
-        __suser: ::std::os::raw::c_int,
-        __remuser: *const ::std::os::raw::c_char,
-        __locuser: *const ::std::os::raw::c_char,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rresvport_af(
-        __alport: *mut ::std::os::raw::c_int,
-        __af: sa_family_t,
-    ) -> ::std::os::raw::c_int;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct addrinfo {
@@ -6370,8 +8256,8 @@ pub struct addrinfo {
     pub ai_socktype: ::std::os::raw::c_int,
     pub ai_protocol: ::std::os::raw::c_int,
     pub ai_addrlen: socklen_t,
-    pub ai_addr: *mut sockaddr,
     pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_addr: *mut sockaddr,
     pub ai_next: *mut addrinfo,
 }
 impl Default for addrinfo {
@@ -6379,50 +8265,269 @@ impl Default for addrinfo {
         unsafe { ::std::mem::zeroed() }
     }
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn endhostent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endprotoent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn endservent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn freeaddrinfo(arg1: *mut addrinfo);
+}
+#[pg_guard]
+extern "C" {
+    pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
 #[pg_guard]
 extern "C" {
     pub fn getaddrinfo(
-        __name: *const ::std::os::raw::c_char,
-        __service: *const ::std::os::raw::c_char,
-        __req: *const addrinfo,
-        __pai: *mut *mut addrinfo,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *const addrinfo,
+        arg4: *mut *mut addrinfo,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn freeaddrinfo(__ai: *mut addrinfo);
+    pub fn gethostbyaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: socklen_t,
+        arg3: ::std::os::raw::c_int,
+    ) -> *mut hostent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent() -> *mut hostent;
 }
 #[pg_guard]
 extern "C" {
     pub fn getnameinfo(
-        __sa: *const sockaddr,
-        __salen: socklen_t,
-        __host: *mut ::std::os::raw::c_char,
-        __hostlen: socklen_t,
-        __serv: *mut ::std::os::raw::c_char,
-        __servlen: socklen_t,
-        __flags: ::std::os::raw::c_int,
+        arg1: *const sockaddr,
+        arg2: socklen_t,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: socklen_t,
+        arg5: *mut ::std::os::raw::c_char,
+        arg6: socklen_t,
+        arg7: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent() -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent() -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent() -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sethostent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprotoent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setservent(arg1: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn freehostent(arg1: *mut hostent);
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipnodebyaddr(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: usize,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getipnodebyname(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcent() -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setrpcent(stayopen: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endrpcent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn herror(arg1: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn innetgr(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *const ::std::os::raw::c_char,
+        arg4: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetgrent(
+        arg1: *mut *mut ::std::os::raw::c_char,
+        arg2: *mut *mut ::std::os::raw::c_char,
+        arg3: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetgrent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct passwd {
     pub pw_name: *mut ::std::os::raw::c_char,
     pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: __uid_t,
-    pub pw_gid: __gid_t,
+    pub pw_uid: uid_t,
+    pub pw_gid: gid_t,
+    pub pw_change: __darwin_time_t,
+    pub pw_class: *mut ::std::os::raw::c_char,
     pub pw_gecos: *mut ::std::os::raw::c_char,
     pub pw_dir: *mut ::std::os::raw::c_char,
     pub pw_shell: *mut ::std::os::raw::c_char,
+    pub pw_expire: __darwin_time_t,
 }
 impl Default for passwd {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid(arg1: uid_t) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid_r(
+        arg1: uid_t,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam_r(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwent() -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
@@ -6432,63 +8537,86 @@ extern "C" {
 extern "C" {
     pub fn endpwent();
 }
+pub type uuid_t = __darwin_uuid_t;
+pub type uuid_string_t = __darwin_uuid_string_t;
 #[pg_guard]
 extern "C" {
-    pub fn getpwent() -> *mut passwd;
+    pub static UUID_NULL: uuid_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
+    pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
 }
 #[pg_guard]
 extern "C" {
-    pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwent_r(
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_compare(
+        uu1: *mut ::std::os::raw::c_uchar,
+        uu2: *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwuid_r(
-        __uid: __uid_t,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_generate_early_random(out: *mut ::std::os::raw::c_uchar);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_parse(
+        in_: *mut ::std::os::raw::c_char,
+        uu: *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwnam_r(
-        __name: *const ::std::os::raw::c_char,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
-    ) -> ::std::os::raw::c_int;
+    pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetpwent_r(
-        __stream: *mut FILE,
-        __resultbuf: *mut passwd,
-        __buffer: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-        __result: *mut *mut passwd,
+    pub fn uuid_unparse_lower(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uuid_unparse_upper(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn user_from_uid(arg1: uid_t, arg2: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuuid_r(
+        arg1: *mut ::std::os::raw::c_uchar,
+        arg2: *mut passwd,
+        arg3: *mut ::std::os::raw::c_char,
+        arg4: usize,
+        arg5: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -6843,979 +8971,407 @@ extern "C" {
 extern "C" {
     pub fn pg_srand48(seed: ::std::os::raw::c_long);
 }
-#[pg_guard]
-extern "C" {
-    pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpeereid(
-        sock: ::std::os::raw::c_int,
-        uid: *mut uid_t,
-        gid: *mut gid_t,
-    ) -> ::std::os::raw::c_int;
-}
 pub type float_t = f32;
 pub type double_t = f64;
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __math_errhandling() -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
+    pub fn acosf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
+    pub fn acos(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
+    pub fn acosl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acos(__x: f64) -> f64;
+    pub fn asinf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __acos(__x: f64) -> f64;
+    pub fn asin(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asin(__x: f64) -> f64;
+    pub fn asinl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __asin(__x: f64) -> f64;
+    pub fn atanf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan(__x: f64) -> f64;
+    pub fn atan(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atan(__x: f64) -> f64;
+    pub fn atanl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2(__y: f64, __x: f64) -> f64;
+    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atan2(__y: f64, __x: f64) -> f64;
+    pub fn atan2(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cos(__x: f64) -> f64;
+    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cos(__x: f64) -> f64;
+    pub fn cosf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sin(__x: f64) -> f64;
+    pub fn cos(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sin(__x: f64) -> f64;
+    pub fn cosl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tan(__x: f64) -> f64;
+    pub fn sinf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tan(__x: f64) -> f64;
+    pub fn sin(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosh(__x: f64) -> f64;
+    pub fn sinl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cosh(__x: f64) -> f64;
+    pub fn tanf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinh(__x: f64) -> f64;
+    pub fn tan(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sinh(__x: f64) -> f64;
+    pub fn tanl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanh(__x: f64) -> f64;
+    pub fn acoshf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tanh(__x: f64) -> f64;
+    pub fn acosh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosh(__x: f64) -> f64;
+    pub fn acoshl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __acosh(__x: f64) -> f64;
+    pub fn asinhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinh(__x: f64) -> f64;
+    pub fn asinh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __asinh(__x: f64) -> f64;
+    pub fn asinhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanh(__x: f64) -> f64;
+    pub fn atanhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __atanh(__x: f64) -> f64;
+    pub fn atanh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp(__x: f64) -> f64;
+    pub fn atanhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __exp(__x: f64) -> f64;
+    pub fn coshf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
+    pub fn cosh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
+    pub fn coshl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
+    pub fn sinhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
+    pub fn sinh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log(__x: f64) -> f64;
+    pub fn sinhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log(__x: f64) -> f64;
+    pub fn tanhf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10(__x: f64) -> f64;
+    pub fn tanh(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log10(__x: f64) -> f64;
+    pub fn tanhl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
+    pub fn expf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
+    pub fn exp(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1(__x: f64) -> f64;
+    pub fn expl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __expm1(__x: f64) -> f64;
+    pub fn exp2f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1p(__x: f64) -> f64;
+    pub fn exp2(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log1p(__x: f64) -> f64;
+    pub fn exp2l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logb(__x: f64) -> f64;
+    pub fn expm1f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __logb(__x: f64) -> f64;
+    pub fn expm1(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2(__x: f64) -> f64;
+    pub fn expm1l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __exp2(__x: f64) -> f64;
+    pub fn logf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2(__x: f64) -> f64;
+    pub fn log(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __log2(__x: f64) -> f64;
+    pub fn logl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pow(__x: f64, __y: f64) -> f64;
+    pub fn log10f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __pow(__x: f64, __y: f64) -> f64;
+    pub fn log10(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sqrt(__x: f64) -> f64;
+    pub fn log10l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sqrt(__x: f64) -> f64;
+    pub fn log2f(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn hypot(__x: f64, __y: f64) -> f64;
+    pub fn log2(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __hypot(__x: f64, __y: f64) -> f64;
+    pub fn log2l(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cbrt(__x: f64) -> f64;
+    pub fn log1pf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __cbrt(__x: f64) -> f64;
+    pub fn log1p(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ceil(__x: f64) -> f64;
+    pub fn log1pl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ceil(__x: f64) -> f64;
+    pub fn logbf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fabs(__x: f64) -> f64;
+    pub fn logb(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fabs(__x: f64) -> f64;
+    pub fn logbl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn floor(__x: f64) -> f64;
+    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __floor(__x: f64) -> f64;
+    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmod(__x: f64, __y: f64) -> f64;
+    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmod(__x: f64, __y: f64) -> f64;
+    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
+    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
+    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn drem(__x: f64, __y: f64) -> f64;
+    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __drem(__x: f64, __y: f64) -> f64;
+    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn significand(__x: f64) -> f64;
+    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __significand(__x: f64) -> f64;
+    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn copysign(__x: f64, __y: f64) -> f64;
+    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __copysign(__x: f64, __y: f64) -> f64;
+    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
+    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
+    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
+    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn j0(arg1: f64) -> f64;
+    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __j0(arg1: f64) -> f64;
+    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn j1(arg1: f64) -> f64;
+    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __j1(arg1: f64) -> f64;
+    pub fn fabsf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn fabs(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn fabsl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn y0(arg1: f64) -> f64;
+    pub fn cbrtf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __y0(arg1: f64) -> f64;
+    pub fn cbrt(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn y1(arg1: f64) -> f64;
+    pub fn cbrtl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __y1(arg1: f64) -> f64;
+    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn hypot(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn erf(arg1: f64) -> f64;
+    pub fn powf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erf(arg1: f64) -> f64;
+    pub fn pow(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
+    pub fn powl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfc(arg1: f64) -> f64;
+    pub fn sqrtf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
+    pub fn sqrt(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __gamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __rint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafter(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nextafter(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttoward(__x: f64, __y: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainder(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remainder(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nearbyint(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn round(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __round(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn trunc(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __trunc(__x: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdim(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fdim(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmax(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmax(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmin(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmin(__x: f64, __y: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalb(__x: f64, __n: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalb(__x: f64, __n: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atan2f(__y: f32, __x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atan2f(__y: f32, __x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cosf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn coshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __coshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acoshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acoshf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanhf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log10f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log10f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expm1f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expm1f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log1pf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log1pf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logbf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logbf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn exp2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log2f(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __powf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sqrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __hypotf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cbrtf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceilf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ceilf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fabsf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __floorf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmodf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dremf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __dremf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn significandf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __significandf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __copysignf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y0f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y1f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+    pub fn sqrtl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
@@ -7823,583 +9379,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erff(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __gammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __rintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remainderf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nearbyintf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __roundf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __truncf(__x: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdimf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fdimf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fminf(__x: f32, __y: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbf(__x: f32, __n: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __scalbf(__x: f32, __n: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atan2l(__y: u128, __x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atan2l(__y: u128, __x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cosl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn coshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __coshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn acoshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __acoshl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __asinhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __atanhl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log10l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log10l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn expm1l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __expm1l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log1pl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log1pl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn logbl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __logbl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn exp2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn log2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __log2l(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __powl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sqrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __hypotl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cbrtl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceill(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ceill(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fabsl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __floorl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __fmodl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dreml(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __dreml(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn significandl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __significandl(__x: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __copysignl(__x: u128, __y: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn j1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __j1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y0l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn y1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __y1l(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+    pub fn erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8407,7 +9387,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfl(arg1: u128) -> u128;
+    pub fn erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8415,7 +9399,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __erfcl(arg1: u128) -> u128;
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8423,7 +9411,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgammal(arg1: u128) -> u128;
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -8431,209 +9423,405 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tgammal(arg1: u128) -> u128;
+    pub fn ceilf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gammal(arg1: u128) -> u128;
+    pub fn ceil(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __gammal(arg1: u128) -> u128;
+    pub fn ceill(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+    pub fn floorf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+    pub fn floor(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rintl(__x: u128) -> u128;
+    pub fn floorl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __rintl(__x: u128) -> u128;
+    pub fn nearbyintf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+    pub fn nearbyint(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+    pub fn nearbyintl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+    pub fn rintf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+    pub fn rint(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remainderl(__x: u128, __y: u128) -> u128;
+    pub fn rintl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+    pub fn roundf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+    pub fn round(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+    pub fn roundl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nearbyintl(__x: u128) -> u128;
+    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __nearbyintl(__x: u128) -> u128;
+    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn roundl(__x: u128) -> u128;
+    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __roundl(__x: u128) -> u128;
+    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn truncl(__x: u128) -> u128;
+    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __truncl(__x: u128) -> u128;
+    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn truncf(arg1: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn trunc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn truncl(arg1: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn fmod(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+    pub fn remainder(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fdiml(__x: u128, __y: u128) -> u128;
+    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fminl(__x: u128, __y: u128) -> u128;
+    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fminl(__x: u128, __y: u128) -> u128;
+    pub fn copysign(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbl(__x: u128, __n: u128) -> u128;
+    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdim(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmax(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminf(arg1: f32, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmin(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminl(arg1: u128, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __inff() -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __inf() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __infl() -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nan() -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp10f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp10(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cospif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cospi(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinpif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinpi(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanpif(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanpi(arg1: f64) -> f64;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __float2 {
+    pub __sinval: f32,
+    pub __cosval: f32,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __double2 {
+    pub __sinval: f64,
+    pub __cosval: f64,
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincosf_stret(arg1: f32) -> __float2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincos_stret(arg1: f64) -> __double2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincospif_stret(arg1: f32) -> __float2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sincospi_stret(arg1: f64) -> __double2;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalb(arg1: f64, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-pub const FP_NAN: ::std::os::raw::c_uint = 0;
-pub const FP_INFINITE: ::std::os::raw::c_uint = 1;
-pub const FP_ZERO: ::std::os::raw::c_uint = 2;
-pub const FP_SUBNORMAL: ::std::os::raw::c_uint = 3;
-pub const FP_NORMAL: ::std::os::raw::c_uint = 4;
-pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drem(arg1: f64, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significand(arg1: f64) -> f64;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct exception {
+    pub type_: ::std::os::raw::c_int,
+    pub name: *mut ::std::os::raw::c_char,
+    pub arg1: f64,
+    pub arg2: f64,
+    pub retval: f64,
+}
+impl Default for exception {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn explicit_bzero(buf: *mut ::std::os::raw::c_void, len: usize);
 }
 #[pg_guard]
 extern "C" {
@@ -8755,39 +9943,28 @@ extern "C" {
         include_command_not_found: bool,
     ) -> bool;
 }
-pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __jmp_buf_tag {
-    pub __jmpbuf: __jmp_buf,
-    pub __mask_was_saved: ::std::os::raw::c_int,
-    pub __saved_mask: __sigset_t,
-}
-pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type jmp_buf = [::std::os::raw::c_int; 37usize];
+pub type sigjmp_buf = [::std::os::raw::c_int; 38usize];
 #[pg_guard]
 extern "C" {
-    pub fn setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
+    pub fn setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __sigsetjmp(
-        __env: *mut __jmp_buf_tag,
-        __savemask: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn _setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
+    pub fn _setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
+    pub fn _longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn _longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
+    pub fn longjmperror();
 }
-pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
     pub fn errstart(elevel: ::std::os::raw::c_int, domain: *const ::std::os::raw::c_char) -> bool;
@@ -9853,7 +11030,6 @@ pub union ListCell {
     pub ptr_value: *mut ::std::os::raw::c_void,
     pub int_value: ::std::os::raw::c_int,
     pub oid_value: Oid,
-    _bindgen_union_align: u64,
 }
 impl Default for ListCell {
     fn default() -> Self {
@@ -10508,83 +11684,239 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
+    pub l_start: off_t,
+    pub l_len: off_t,
+    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
-    pub l_start: __off_t,
-    pub l_len: __off_t,
-    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct stat {
-    pub st_dev: __dev_t,
-    pub st_ino: __ino_t,
-    pub st_nlink: __nlink_t,
-    pub st_mode: __mode_t,
-    pub st_uid: __uid_t,
-    pub st_gid: __gid_t,
-    pub __pad0: ::std::os::raw::c_int,
-    pub st_rdev: __dev_t,
-    pub st_size: __off_t,
-    pub st_blksize: __blksize_t,
-    pub st_blocks: __blkcnt_t,
-    pub st_atim: timespec,
-    pub st_mtim: timespec,
-    pub st_ctim: timespec,
-    pub __glibc_reserved: [__syscall_slong_t; 3usize],
+pub struct timespec {
+    pub tv_sec: __darwin_time_t,
+    pub tv_nsec: ::std::os::raw::c_long,
 }
-#[pg_guard]
-extern "C" {
-    pub fn fcntl(
-        __fd: ::std::os::raw::c_int,
-        __cmd: ::std::os::raw::c_int,
-        ...
-    ) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct flocktimeout {
+    pub fl: flock,
+    pub timeout: timespec,
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct radvisory {
+    pub ra_offset: off_t,
+    pub ra_count: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsignatures {
+    pub fs_file_start: off_t,
+    pub fs_blob_start: *mut ::std::os::raw::c_void,
+    pub fs_blob_size: usize,
+    pub fs_fsignatures_size: usize,
+    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
+    pub fs_hash_type: ::std::os::raw::c_int,
+}
+impl Default for fsignatures {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fsignatures_t = fsignatures;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fsupplement {
+    pub fs_file_start: off_t,
+    pub fs_blob_start: off_t,
+    pub fs_blob_size: usize,
+    pub fs_orig_fd: ::std::os::raw::c_int,
+}
+pub type fsupplement_t = fsupplement;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fchecklv {
+    pub lv_file_start: off_t,
+    pub lv_error_message_size: usize,
+    pub lv_error_message: *mut ::std::os::raw::c_void,
+}
+impl Default for fchecklv {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fchecklv_t = fchecklv;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fgetsigsinfo {
+    pub fg_file_start: off_t,
+    pub fg_info_request: ::std::os::raw::c_int,
+    pub fg_sig_is_platform: ::std::os::raw::c_int,
+}
+pub type fgetsigsinfo_t = fgetsigsinfo;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fstore {
+    pub fst_flags: ::std::os::raw::c_uint,
+    pub fst_posmode: ::std::os::raw::c_int,
+    pub fst_offset: off_t,
+    pub fst_length: off_t,
+    pub fst_bytesalloc: off_t,
+}
+pub type fstore_t = fstore;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fpunchhole {
+    pub fp_flags: ::std::os::raw::c_uint,
+    pub reserved: ::std::os::raw::c_uint,
+    pub fp_offset: off_t,
+    pub fp_length: off_t,
+}
+pub type fpunchhole_t = fpunchhole;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ftrimactivefile {
+    pub fta_offset: off_t,
+    pub fta_length: off_t,
+}
+pub type ftrimactivefile_t = ftrimactivefile;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fspecread {
+    pub fsr_flags: ::std::os::raw::c_uint,
+    pub reserved: ::std::os::raw::c_uint,
+    pub fsr_offset: off_t,
+    pub fsr_length: off_t,
+}
+pub type fspecread_t = fspecread;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fbootstraptransfer {
+    pub fbt_offset: off_t,
+    pub fbt_length: usize,
+    pub fbt_buffer: *mut ::std::os::raw::c_void,
+}
+impl Default for fbootstraptransfer {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type fbootstraptransfer_t = fbootstraptransfer;
+#[repr(C, packed(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct log2phys {
+    pub l2p_flags: ::std::os::raw::c_uint,
+    pub l2p_contigbytes: off_t,
+    pub l2p_devoffset: off_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _filesec {
+    _unused: [u8; 0],
+}
+pub type filesec_t = *mut _filesec;
+pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
+pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
+pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
+pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
+pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
+pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
+pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
+pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
+pub type filesec_property_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn open(
-        __file: *const ::std::os::raw::c_char,
-        __oflag: ::std::os::raw::c_int,
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn openat(
-        __fd: ::std::os::raw::c_int,
-        __file: *const ::std::os::raw::c_char,
-        __oflag: ::std::os::raw::c_int,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn creat(__file: *const ::std::os::raw::c_char, __mode: mode_t) -> ::std::os::raw::c_int;
+    pub fn creat(arg1: *const ::std::os::raw::c_char, arg2: mode_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lockf(
-        __fd: ::std::os::raw::c_int,
-        __cmd: ::std::os::raw::c_int,
-        __len: off_t,
+    pub fn fcntl(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix_fadvise(
-        __fd: ::std::os::raw::c_int,
-        __offset: off_t,
-        __len: off_t,
-        __advise: ::std::os::raw::c_int,
+    pub fn openx_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: filesec_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix_fallocate(
-        __fd: ::std::os::raw::c_int,
-        __offset: off_t,
-        __len: off_t,
+    pub fn open_dprotected_np(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_int,
+        arg4: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn flock(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_init() -> filesec_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_free(arg1: filesec_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_get_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_query_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_set_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
+        arg3: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn filesec_unset_property(
+        arg1: filesec_t,
+        arg2: filesec_property_t,
     ) -> ::std::os::raw::c_int;
 }
 pub type XLogRecPtr = uint64;
@@ -10845,7 +12177,6 @@ pub struct HeapTupleFields {
 pub union HeapTupleFields__bindgen_ty_1 {
     pub t_cid: CommandId,
     pub t_xvac: TransactionId,
-    _bindgen_union_align: u32,
 }
 impl Default for HeapTupleFields__bindgen_ty_1 {
     fn default() -> Self {
@@ -10878,7 +12209,6 @@ pub struct HeapTupleHeaderData {
 pub union HeapTupleHeaderData__bindgen_ty_1 {
     pub t_heap: HeapTupleFields,
     pub t_datum: DatumTupleFields,
-    _bindgen_union_align: [u32; 3usize],
 }
 impl Default for HeapTupleHeaderData__bindgen_ty_1 {
     fn default() -> Self {
@@ -11506,115 +12836,20 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *const ::std::os::raw::c_char,
+    pub tm_zone: *mut ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct itimerspec {
-    pub it_interval: timespec,
-    pub it_value: timespec,
+#[pg_guard]
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock() -> clock_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn time(__timer: *mut time_t) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktime(__tp: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strftime(
-        __s: *mut ::std::os::raw::c_char,
-        __maxsize: usize,
-        __format: *const ::std::os::raw::c_char,
-        __tp: *const tm,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strftime_l(
-        __s: *mut ::std::os::raw::c_char,
-        __maxsize: usize,
-        __format: *const ::std::os::raw::c_char,
-        __tp: *const tm,
-        __loc: locale_t,
-    ) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime(__timer: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime(__timer: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime_r(
-        __tp: *const tm,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctime_r(
-        __timer: *const time_t,
-        __buf: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __daylight: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut __timezone: ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
-}
-#[pg_guard]
-extern "C" {
-    pub fn tzset();
-}
-#[pg_guard]
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
+    pub static mut getdate_err: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -11622,23 +12857,120 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn timegm(__tp: *mut tm) -> time_t;
+    pub static mut daylight: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timelocal(__tp: *mut tm) -> time_t;
+    pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn clock() -> clock_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn nanosleep(
-        __requested_time: *const timespec,
-        __remaining: *mut timespec,
-    ) -> ::std::os::raw::c_int;
+    pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
 }
+#[pg_guard]
+extern "C" {
+    pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime(arg1: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime(arg1: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktime(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strftime(
+        arg1: *mut ::std::os::raw::c_char,
+        arg2: usize,
+        arg3: *const ::std::os::raw::c_char,
+        arg4: *const tm,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strptime(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const ::std::os::raw::c_char,
+        arg3: *mut tm,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn time(arg1: *mut time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tzset();
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime_r(
+        arg1: *const tm,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ctime_r(
+        arg1: *const time_t,
+        arg2: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn posix2time(arg1: time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tzsetwall();
+}
+#[pg_guard]
+extern "C" {
+    pub fn time2posix(arg1: time_t) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timelocal(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timegm(arg1: *mut tm) -> time_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanosleep(__rqtp: *const timespec, __rmtp: *mut timespec) -> ::std::os::raw::c_int;
+}
+pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
+pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
+pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
+pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
+pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
+pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
+pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
+pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
+pub type clockid_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn clock_getres(__clock_id: clockid_t, __res: *mut timespec) -> ::std::os::raw::c_int;
@@ -11649,56 +12981,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
+}
+#[pg_guard]
+extern "C" {
     pub fn clock_settime(__clock_id: clockid_t, __tp: *const timespec) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock_nanosleep(
-        __clock_id: clockid_t,
-        __flags: ::std::os::raw::c_int,
-        __req: *const timespec,
-        __rem: *mut timespec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn clock_getcpuclockid(__pid: pid_t, __clock_id: *mut clockid_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_create(
-        __clock_id: clockid_t,
-        __evp: *mut sigevent,
-        __timerid: *mut timer_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_settime(
-        __timerid: timer_t,
-        __flags: ::std::os::raw::c_int,
-        __value: *const itimerspec,
-        __ovalue: *mut itimerspec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_gettime(__timerid: timer_t, __value: *mut itimerspec) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timespec_get(
-        __ts: *mut timespec,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn timespec_get(ts: *mut timespec, base: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type instr_time = timespec;
 #[repr(C)]
@@ -15078,82 +16369,104 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __ino_t,
-    pub d_off: __off_t,
-    pub d_reclen: ::std::os::raw::c_ushort,
-    pub d_type: ::std::os::raw::c_uchar,
-    pub d_name: [::std::os::raw::c_char; 256usize],
+    pub d_ino: __uint64_t,
+    pub d_seekoff: __uint64_t,
+    pub d_reclen: __uint16_t,
+    pub d_namlen: __uint16_t,
+    pub d_type: __uint8_t,
+    pub d_name: [::std::os::raw::c_char; 1024usize],
 }
 impl Default for dirent {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub const DT_UNKNOWN: ::std::os::raw::c_uint = 0;
-pub const DT_FIFO: ::std::os::raw::c_uint = 1;
-pub const DT_CHR: ::std::os::raw::c_uint = 2;
-pub const DT_DIR: ::std::os::raw::c_uint = 4;
-pub const DT_BLK: ::std::os::raw::c_uint = 6;
-pub const DT_REG: ::std::os::raw::c_uint = 8;
-pub const DT_LNK: ::std::os::raw::c_uint = 10;
-pub const DT_SOCK: ::std::os::raw::c_uint = 12;
-pub const DT_WHT: ::std::os::raw::c_uint = 14;
-pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __dirstream {
+pub struct _telldir {
     _unused: [u8; 0],
 }
-pub type DIR = __dirstream;
-#[pg_guard]
-extern "C" {
-    pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct DIR {
+    pub __dd_fd: ::std::os::raw::c_int,
+    pub __dd_loc: ::std::os::raw::c_long,
+    pub __dd_size: ::std::os::raw::c_long,
+    pub __dd_buf: *mut ::std::os::raw::c_char,
+    pub __dd_len: ::std::os::raw::c_int,
+    pub __dd_seek: ::std::os::raw::c_long,
+    pub __padding: ::std::os::raw::c_long,
+    pub __dd_flags: ::std::os::raw::c_int,
+    pub __dd_lock: __darwin_pthread_mutex_t,
+    pub __dd_td: *mut _telldir,
+}
+impl Default for DIR {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
-    pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
+    pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_opendir$INODE64"]
+    pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+    #[link_name = "\u{1}_readdir$INODE64"]
+    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_readdir_r$INODE64"]
     pub fn readdir_r(
-        __dirp: *mut DIR,
-        __entry: *mut dirent,
-        __result: *mut *mut dirent,
+        arg1: *mut DIR,
+        arg2: *mut dirent,
+        arg3: *mut *mut dirent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rewinddir(__dirp: *mut DIR);
+    #[link_name = "\u{1}_rewinddir$INODE64"]
+    pub fn rewinddir(arg1: *mut DIR);
 }
 #[pg_guard]
 extern "C" {
-    pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
+    #[link_name = "\u{1}_seekdir$INODE64"]
+    pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
 }
 #[pg_guard]
 extern "C" {
-    pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
+    #[link_name = "\u{1}_telldir$INODE64"]
+    pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_fdopendir$INODE64"]
+    pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_alphasort$INODE64"]
+    pub fn alphasort(arg1: *mut *const dirent, arg2: *mut *const dirent) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}_scandir$INODE64"]
     pub fn scandir(
-        __dir: *const ::std::os::raw::c_char,
-        __namelist: *mut *mut *mut dirent,
-        __selector: ::std::option::Option<
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut *mut dirent,
+        arg3: ::std::option::Option<
             unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
         >,
-        __cmp: ::std::option::Option<
+        arg4: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut *const dirent,
                 arg2: *mut *const dirent,
@@ -15163,16 +16476,29 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn alphasort(__e1: *mut *const dirent, __e2: *mut *const dirent) -> ::std::os::raw::c_int;
+    #[link_name = "\u{1}_scandir_b$INODE64"]
+    pub fn scandir_b(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *mut *mut *mut dirent,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
+    #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
     pub fn getdirentries(
-        __fd: ::std::os::raw::c_int,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-        __basep: *mut __off_t,
-    ) -> __ssize_t;
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut ::std::os::raw::c_char,
+        arg3: ::std::os::raw::c_int,
+        arg4: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}___opendir2$INODE64"]
+    pub fn __opendir2(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int)
+        -> *mut DIR;
 }
 pub type File = ::std::os::raw::c_int;
 #[pg_guard]
@@ -18354,7 +19680,6 @@ pub struct Value {
 pub union Value_ValUnion {
     pub ival: ::std::os::raw::c_int,
     pub str_: *mut ::std::os::raw::c_char,
-    _bindgen_union_align: u64,
 }
 impl Default for Value_ValUnion {
     fn default() -> Self {
@@ -22489,651 +23814,160 @@ extern "C" {
         nulls: *mut *mut bool,
     ) -> ::std::os::raw::c_int;
 }
-pub type sig_atomic_t = __sig_atomic_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-    _bindgen_union_align: u64,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __sigval_t = sigval;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub __pad0: ::std::os::raw::c_int,
-    pub _sifields: siginfo_t__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union siginfo_t__bindgen_ty_1 {
-    pub _pad: [::std::os::raw::c_int; 28usize],
-    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
-    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
-    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
-    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
-    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
-    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
-    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
-    _bindgen_union_align: [u64; 14usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
-    pub si_tid: ::std::os::raw::c_int,
-    pub si_overrun: ::std::os::raw::c_int,
-    pub si_sigval: __sigval_t,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-    pub si_sigval: __sigval_t,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
-    pub si_pid: __pid_t,
-    pub si_uid: __uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_utime: __clock_t,
-    pub si_stime: __clock_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_addr_lsb: ::std::os::raw::c_short,
-    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
-    pub _pkey: __uint32_t,
-    _bindgen_union_align: [u64; 2usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-    pub _lower: *mut ::std::os::raw::c_void,
-    pub _upper: *mut ::std::os::raw::c_void,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
-    pub si_band: ::std::os::raw::c_long,
-    pub si_fd: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
-    pub _call_addr: *mut ::std::os::raw::c_void,
-    pub _syscall: ::std::os::raw::c_int,
-    pub _arch: ::std::os::raw::c_uint,
-}
-impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for siginfo_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub const SI_ASYNCNL: ::std::os::raw::c_int = -60;
-pub const SI_DETHREAD: ::std::os::raw::c_int = -7;
-pub const SI_TKILL: ::std::os::raw::c_int = -6;
-pub const SI_SIGIO: ::std::os::raw::c_int = -5;
-pub const SI_ASYNCIO: ::std::os::raw::c_int = -4;
-pub const SI_MESGQ: ::std::os::raw::c_int = -3;
-pub const SI_TIMER: ::std::os::raw::c_int = -2;
-pub const SI_QUEUE: ::std::os::raw::c_int = -1;
-pub const SI_USER: ::std::os::raw::c_int = 0;
-pub const SI_KERNEL: ::std::os::raw::c_int = 128;
-pub type _bindgen_ty_10 = ::std::os::raw::c_int;
-pub const ILL_ILLOPC: ::std::os::raw::c_uint = 1;
-pub const ILL_ILLOPN: ::std::os::raw::c_uint = 2;
-pub const ILL_ILLADR: ::std::os::raw::c_uint = 3;
-pub const ILL_ILLTRP: ::std::os::raw::c_uint = 4;
-pub const ILL_PRVOPC: ::std::os::raw::c_uint = 5;
-pub const ILL_PRVREG: ::std::os::raw::c_uint = 6;
-pub const ILL_COPROC: ::std::os::raw::c_uint = 7;
-pub const ILL_BADSTK: ::std::os::raw::c_uint = 8;
-pub const ILL_BADIADDR: ::std::os::raw::c_uint = 9;
-pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
-pub const FPE_INTDIV: ::std::os::raw::c_uint = 1;
-pub const FPE_INTOVF: ::std::os::raw::c_uint = 2;
-pub const FPE_FLTDIV: ::std::os::raw::c_uint = 3;
-pub const FPE_FLTOVF: ::std::os::raw::c_uint = 4;
-pub const FPE_FLTUND: ::std::os::raw::c_uint = 5;
-pub const FPE_FLTRES: ::std::os::raw::c_uint = 6;
-pub const FPE_FLTINV: ::std::os::raw::c_uint = 7;
-pub const FPE_FLTSUB: ::std::os::raw::c_uint = 8;
-pub const FPE_FLTUNK: ::std::os::raw::c_uint = 14;
-pub const FPE_CONDTRAP: ::std::os::raw::c_uint = 15;
-pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
-pub const SEGV_MAPERR: ::std::os::raw::c_uint = 1;
-pub const SEGV_ACCERR: ::std::os::raw::c_uint = 2;
-pub const SEGV_BNDERR: ::std::os::raw::c_uint = 3;
-pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
-pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
-pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
-pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
-pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
-pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
-pub const BUS_OBJERR: ::std::os::raw::c_uint = 3;
-pub const BUS_MCEERR_AR: ::std::os::raw::c_uint = 4;
-pub const BUS_MCEERR_AO: ::std::os::raw::c_uint = 5;
-pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
-pub const CLD_EXITED: ::std::os::raw::c_uint = 1;
-pub const CLD_KILLED: ::std::os::raw::c_uint = 2;
-pub const CLD_DUMPED: ::std::os::raw::c_uint = 3;
-pub const CLD_TRAPPED: ::std::os::raw::c_uint = 4;
-pub const CLD_STOPPED: ::std::os::raw::c_uint = 5;
-pub const CLD_CONTINUED: ::std::os::raw::c_uint = 6;
-pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
-pub const POLL_IN: ::std::os::raw::c_uint = 1;
-pub const POLL_OUT: ::std::os::raw::c_uint = 2;
-pub const POLL_MSG: ::std::os::raw::c_uint = 3;
-pub const POLL_ERR: ::std::os::raw::c_uint = 4;
-pub const POLL_PRI: ::std::os::raw::c_uint = 5;
-pub const POLL_HUP: ::std::os::raw::c_uint = 6;
-pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
-pub type sigval_t = __sigval_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_value: __sigval_t,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub _sigev_un: sigevent__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigevent__bindgen_ty_1 {
-    pub _pad: [::std::os::raw::c_int; 12usize],
-    pub _tid: __pid_t,
-    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
-    _bindgen_union_align: [u64; 6usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
-    pub _attribute: *mut pthread_attr_t,
-}
-impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigevent__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sigevent_t = sigevent;
-pub const SIGEV_SIGNAL: ::std::os::raw::c_uint = 0;
-pub const SIGEV_NONE: ::std::os::raw::c_uint = 1;
-pub const SIGEV_THREAD: ::std::os::raw::c_uint = 2;
-pub const SIGEV_THREAD_ID: ::std::os::raw::c_uint = 4;
-pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
-pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[pg_guard]
 extern "C" {
-    pub fn __sysv_signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t)
-        -> __sighandler_t;
+    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
 }
 #[pg_guard]
 extern "C" {
-    pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ssignal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn siggetmask() -> ::std::os::raw::c_int;
-}
-pub type sig_t = __sighandler_t;
-#[pg_guard]
-extern "C" {
-    pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigaddset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigdelset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigismember(
-        __set: *const sigset_t,
-        __signo: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_handler: sigaction__bindgen_ty_1,
-    pub sa_mask: __sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigaction__bindgen_ty_1 {
-    pub sa_handler: __sighandler_t,
-    pub sa_sigaction: ::std::option::Option<
+    pub fn bsd_signal(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
-            arg2: *mut siginfo_t,
-            arg3: *mut ::std::os::raw::c_void,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
         ),
-    >,
-    _bindgen_union_align: u64,
-}
-impl Default for sigaction__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    >;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigprocmask(
-        __how: ::std::os::raw::c_int,
-        __set: *const sigset_t,
-        __oset: *mut sigset_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
+    pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaction(
-        __sig: ::std::os::raw::c_int,
-        __act: *const sigaction,
-        __oact: *mut sigaction,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigwait(
-        __set: *const sigset_t,
-        __sig: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigwaitinfo(__set: *const sigset_t, __info: *mut siginfo_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigtimedwait(
-        __set: *const sigset_t,
-        __info: *mut siginfo_t,
-        __timeout: *const timespec,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigqueue(
-        __pid: __pid_t,
-        __sig: ::std::os::raw::c_int,
-        __val: sigval,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpx_sw_bytes {
-    pub magic1: __uint32_t,
-    pub extended_size: __uint32_t,
-    pub xstate_bv: __uint64_t,
-    pub xstate_size: __uint32_t,
-    pub __glibc_reserved1: [__uint32_t; 7usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpxreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _xmmreg {
-    pub element: [__uint32_t; 4usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _fpstate {
-    pub cwd: __uint16_t,
-    pub swd: __uint16_t,
-    pub ftw: __uint16_t,
-    pub fop: __uint16_t,
-    pub rip: __uint64_t,
-    pub rdp: __uint64_t,
-    pub mxcsr: __uint32_t,
-    pub mxcr_mask: __uint32_t,
-    pub _st: [_fpxreg; 8usize],
-    pub _xmm: [_xmmreg; 16usize],
-    pub __glibc_reserved1: [__uint32_t; 24usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigcontext {
-    pub r8: __uint64_t,
-    pub r9: __uint64_t,
-    pub r10: __uint64_t,
-    pub r11: __uint64_t,
-    pub r12: __uint64_t,
-    pub r13: __uint64_t,
-    pub r14: __uint64_t,
-    pub r15: __uint64_t,
-    pub rdi: __uint64_t,
-    pub rsi: __uint64_t,
-    pub rbp: __uint64_t,
-    pub rbx: __uint64_t,
-    pub rdx: __uint64_t,
-    pub rax: __uint64_t,
-    pub rcx: __uint64_t,
-    pub rsp: __uint64_t,
-    pub rip: __uint64_t,
-    pub eflags: __uint64_t,
-    pub cs: ::std::os::raw::c_ushort,
-    pub gs: ::std::os::raw::c_ushort,
-    pub fs: ::std::os::raw::c_ushort,
-    pub __pad0: ::std::os::raw::c_ushort,
-    pub err: __uint64_t,
-    pub trapno: __uint64_t,
-    pub oldmask: __uint64_t,
-    pub cr2: __uint64_t,
-    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
-    pub __reserved1: [__uint64_t; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigcontext__bindgen_ty_1 {
-    pub fpstate: *mut _fpstate,
-    pub __fpstate_word: __uint64_t,
-    _bindgen_union_align: u64,
-}
-impl Default for sigcontext__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl Default for sigcontext {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _xsave_hdr {
-    pub xstate_bv: __uint64_t,
-    pub __glibc_reserved1: [__uint64_t; 2usize],
-    pub __glibc_reserved2: [__uint64_t; 5usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _ymmh_state {
-    pub ymmh_space: [__uint32_t; 64usize],
-}
-impl Default for _ymmh_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _xstate {
-    pub fpstate: _fpstate,
-    pub xstate_hdr: _xsave_hdr,
-    pub ymmh: _ymmh_state,
-}
-impl Default for _xstate {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigreturn(__scp: *mut sigcontext) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct stack_t {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_flags: ::std::os::raw::c_int,
-    pub ss_size: usize,
-}
-impl Default for stack_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type greg_t = ::std::os::raw::c_longlong;
-pub type gregset_t = [greg_t; 23usize];
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_fpxreg {
-    pub significand: [::std::os::raw::c_ushort; 4usize],
-    pub exponent: ::std::os::raw::c_ushort,
-    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_xmmreg {
-    pub element: [__uint32_t; 4usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _libc_fpstate {
-    pub cwd: __uint16_t,
-    pub swd: __uint16_t,
-    pub ftw: __uint16_t,
-    pub fop: __uint16_t,
-    pub rip: __uint64_t,
-    pub rdp: __uint64_t,
-    pub mxcsr: __uint32_t,
-    pub mxcr_mask: __uint32_t,
-    pub _st: [_libc_fpxreg; 8usize],
-    pub _xmm: [_libc_xmmreg; 16usize],
-    pub __glibc_reserved1: [__uint32_t; 24usize],
-}
-pub type fpregset_t = *mut _libc_fpstate;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct mcontext_t {
-    pub gregs: gregset_t,
-    pub fpregs: fpregset_t,
-    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
-}
-impl Default for mcontext_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ucontext_t {
-    pub uc_flags: ::std::os::raw::c_ulong,
-    pub uc_link: *mut ucontext_t,
-    pub uc_stack: stack_t,
-    pub uc_mcontext: mcontext_t,
-    pub uc_sigmask: sigset_t,
-    pub __fpregs_mem: _libc_fpstate,
-    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
-}
-impl Default for ucontext_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn siginterrupt(
-        __sig: ::std::os::raw::c_int,
-        __interrupt: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-pub const SS_ONSTACK: ::std::os::raw::c_uint = 1;
-pub const SS_DISABLE: ::std::os::raw::c_uint = 2;
-pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
-#[pg_guard]
-extern "C" {
-    pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigstack(__ss: *mut sigstack, __oss: *mut sigstack) -> ::std::os::raw::c_int;
+    pub fn pthread_kill(arg1: pthread_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn pthread_sigmask(
-        __how: ::std::os::raw::c_int,
-        __newmask: *const __sigset_t,
-        __oldmask: *mut __sigset_t,
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigset_t,
+        arg3: *mut sigset_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_kill(
-        __threadid: pthread_t,
-        __signo: ::std::os::raw::c_int,
+    pub fn sigaction(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigaction,
+        arg3: *mut sigaction,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+    pub fn sigaddset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+    pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigdelset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn siginterrupt(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigismember(arg1: *const sigset_t, arg2: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigprocmask(
+        arg1: ::std::os::raw::c_int,
+        arg2: *const sigset_t,
+        arg3: *mut sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigset(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    ) -> ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+        ),
+    >;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigwait(
+        arg1: *const sigset_t,
+        arg2: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigvec(
+        arg1: ::std::os::raw::c_int,
+        arg2: *mut sigvec,
+        arg3: *mut sigvec,
+    ) -> ::std::os::raw::c_int;
 }
 pub type pg_time_t = int64;
 #[repr(C)]
@@ -23781,8 +24615,9 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_un {
+    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 108usize],
+    pub sun_path: [::std::os::raw::c_char; 104usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -24481,7 +25316,6 @@ pub struct LWLock {
 pub union LWLockPadded {
     pub lock: LWLock,
     pub pad: [::std::os::raw::c_char; 128usize],
-    _bindgen_union_align: [u32; 32usize],
 }
 impl Default for LWLockPadded {
     fn default() -> Self {
@@ -24493,7 +25327,6 @@ impl Default for LWLockPadded {
 pub union LWLockMinimallyPadded {
     pub lock: LWLock,
     pub pad: [::std::os::raw::c_char; 32usize],
-    _bindgen_union_align: [u32; 8usize],
 }
 impl Default for LWLockMinimallyPadded {
     fn default() -> Self {
@@ -25877,7 +26710,6 @@ pub union PgStat_Msg {
     pub msg_deadlock: PgStat_MsgDeadlock,
     pub msg_tempfile: PgStat_MsgTempFile,
     pub msg_checksumfailure: PgStat_MsgChecksumFailure,
-    _bindgen_union_align: [u64; 125usize],
 }
 impl Default for PgStat_Msg {
     fn default() -> Self {
@@ -28072,7 +28904,6 @@ impl Default for ExpandedArrayHeader {
 pub union AnyArrayType {
     pub flt: ArrayType,
     pub xpn: ExpandedArrayHeader,
-    _bindgen_union_align: [u64; 17usize],
 }
 impl Default for AnyArrayType {
     fn default() -> Self {
@@ -30559,7 +31390,6 @@ pub union relopt_value__bindgen_ty_1 {
     pub real_val: f64,
     pub enum_val: ::std::os::raw::c_int,
     pub string_val: *mut ::std::os::raw::c_char,
-    _bindgen_union_align: u64,
 }
 impl Default for relopt_value__bindgen_ty_1 {
     fn default() -> Self {
@@ -30958,7 +31788,6 @@ pub union SharedInvalidationMessage {
     pub sm: SharedInvalSmgrMsg,
     pub rm: SharedInvalRelmapMsg,
     pub sn: SharedInvalSnapshotMsg,
-    _bindgen_union_align: [u32; 4usize],
 }
 impl Default for SharedInvalidationMessage {
     fn default() -> Self {
@@ -33904,7 +34733,6 @@ pub union CollectedCommand__bindgen_ty_1 {
     pub createopc: CollectedCommand__bindgen_ty_1__bindgen_ty_5,
     pub atscfg: CollectedCommand__bindgen_ty_1__bindgen_ty_6,
     pub defprivs: CollectedCommand__bindgen_ty_1__bindgen_ty_7,
-    _bindgen_union_align: [u64; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -41310,7 +42138,6 @@ pub union ReorderBufferChange__bindgen_ty_1 {
     pub snapshot: Snapshot,
     pub command_id: CommandId,
     pub tuplecid: ReorderBufferChange__bindgen_ty_1__bindgen_ty_4,
-    _bindgen_union_align: [u64; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -54125,7 +54952,6 @@ pub union JsonbValue__bindgen_ty_1 {
     pub object: JsonbValue__bindgen_ty_1__bindgen_ty_3,
     pub binary: JsonbValue__bindgen_ty_1__bindgen_ty_4,
     pub datetime: JsonbValue__bindgen_ty_1__bindgen_ty_5,
-    _bindgen_union_align: [u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -55603,11 +56429,6 @@ impl Default for __va_list_tag {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __locale_data {
-    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -178,30 +178,29 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & 'static [u8 ; 107usize] = b" '--prefix=/Users/e_ridge/.pgx/13.2/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS : & 'static [u8 ; 842usize] = b" '--prefix=/home/ana/.pgx/13.2/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert' 'CC=gcc' 'CXX=g++' 'PKG_CONFIG=pkg-config' 'PKG_CONFIG_PATH=/nix/store/sarpzwx0p98frys3ck7201cpnzvsg03z-zlib-1.2.11-dev/lib/pkgconfig:/nix/store/28mf2sqki1dmrlzikwpikrhwyhp3xd31-ncurses-6.2-dev/lib/pkgconfig:/nix/store/apxpi7w14qkvbkpiy89lryarxv9svngy-openssl-1.1.1k-dev/lib/pkgconfig:/nix/store/gss20qxmklmwarli44nfjjbnwhjnng2d-libxml2-2.9.10-dev/lib/pkgconfig:/nix/store/gz0fp1iyi55asghp725spxqnx2x1q0cw-icu4c-67.1-dev/lib/pkgconfig:/nix/store/11sbip0qhqzmw1k0vlxs6nm4ivqzchyn-systemd-247.6-dev/lib/pkgconfig:/nix/store/11sbip0qhqzmw1k0vlxs6nm4ivqzchyn-systemd-247.6-dev/share/pkgconfig:/nix/store/j6ff2y31l0vrz389z5rxb65rhz8j51xj-libossp-uuid-1.6.2/lib/pkgconfig:/nix/store/7c28s5fvha37hn3cx8w35619lsh63d9g-icu4c-68.2-dev/lib/pkgconfig'\0" ;
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &'static [u8; 6usize] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_BACKTRACE_SYMBOLS: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
-pub const HAVE_COPYFILE: u32 = 1;
-pub const HAVE_COPYFILE_H: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_RTLD_GLOBAL: u32 = 1;
 pub const HAVE_DECL_RTLD_NOW: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_EXECINFO_H: u32 = 1;
+pub const HAVE_EXPLICIT_BZERO: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -211,11 +210,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -224,10 +223,8 @@ pub const HAVE_IFADDRS_H: u32 = 1;
 pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
-pub const HAVE_KQUEUE: u32 = 1;
 pub const HAVE_LANGINFO_H: u32 = 1;
 pub const HAVE_LIBM: u32 = 1;
 pub const HAVE_LIBREADLINE: u32 = 1;
@@ -235,17 +232,17 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LINK: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
-pub const HAVE_MEMSET_S: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
 pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
+pub const HAVE_PPOLL: u32 = 1;
 pub const HAVE_PREAD: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_PWRITE: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
@@ -254,7 +251,11 @@ pub const HAVE_READLINE_READLINE_H: u32 = 1;
 pub const HAVE_READLINK: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
+pub const HAVE_RL_COMPLETION_SUPPRESS_QUOTE: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_FILENAME_QUOTE_CHARACTERS: u32 = 1;
+pub const HAVE_RL_FILENAME_QUOTING_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SPINLOCKS: u32 = 1;
@@ -262,11 +263,10 @@ pub const HAVE_SRANDOM: u32 = 1;
 pub const HAVE_STDBOOL_H: u32 = 1;
 pub const HAVE_STDINT_H: u32 = 1;
 pub const HAVE_STDLIB_H: u32 = 1;
+pub const HAVE_STRCHRNUL: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOF: u32 = 1;
@@ -274,32 +274,28 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_UN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
-pub const HAVE_SYS_EVENT_H: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
+pub const HAVE_SYS_PRCTL_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
 pub const HAVE_USELOCALE: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE_X86_64_POPCNTQ: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
@@ -316,7 +312,6 @@ pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
 pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const INT64_MODIFIER: &'static [u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &'static [u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
@@ -332,7 +327,8 @@ pub const PG_MINORVERSION_NUM: u32 = 2;
 pub const PG_USE_STDBOOL: u32 = 1;
 pub const PG_VERSION: &'static [u8; 5usize] = b"13.2\0";
 pub const PG_VERSION_NUM: u32 = 130002;
-pub const PG_VERSION_STR : & 'static [u8 ; 114usize] = b"PostgreSQL 13.2 on x86_64-apple-darwin20.3.0, compiled by Apple clang version 12.0.0 (clang-1200.0.32.29), 64-bit\0" ;
+pub const PG_VERSION_STR: &'static [u8; 77usize] =
+    b"PostgreSQL 13.2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -340,13 +336,11 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -361,510 +355,211 @@ pub const PG_SOMAXCONN: u32 = 10000;
 pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &'static [u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &'static [u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
-pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
-pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 32;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &'static [u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _I386_SIGNAL_H_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const FP_PREC_24B: u32 = 0;
-pub const FP_PREC_53B: u32 = 2;
-pub const FP_PREC_64B: u32 = 3;
-pub const FP_RND_NEAR: u32 = 0;
-pub const FP_RND_DOWN: u32 = 1;
-pub const FP_RND_UP: u32 = 2;
-pub const FP_CHOP: u32 = 3;
-pub const FP_STATE_BYTES: u32 = 512;
-pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
-pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
-pub const __LASTBRANCH_MAX: u32 = 32;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_CURRENT: u32 = 5;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
+pub const P_tmpdir: &'static [u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -875,7 +570,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -899,88 +594,147 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
@@ -1010,375 +764,355 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &'static [u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &'static [u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &'static [u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &'static [u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_MASTER_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _CTYPE_H: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MAX: u32 = 45;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MAX: u32 = 45;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1390,269 +1124,49 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &'static [u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &'static [u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &'static [u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &'static [u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &'static [u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &'static [u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &'static [u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const _PATH_PWD: &'static [u8; 5usize] = b"/etc\0";
-pub const _PATH_PASSWD: &'static [u8; 12usize] = b"/etc/passwd\0";
-pub const _PASSWD: &'static [u8; 7usize] = b"passwd\0";
-pub const _PATH_MASTERPASSWD: &'static [u8; 19usize] = b"/etc/master.passwd\0";
-pub const _PATH_MASTERPASSWD_LOCK: &'static [u8; 10usize] = b"/etc/ptmp\0";
-pub const _MASTERPASSWD: &'static [u8; 14usize] = b"master.passwd\0";
-pub const _PATH_MP_DB: &'static [u8; 12usize] = b"/etc/pwd.db\0";
-pub const _MP_DB: &'static [u8; 7usize] = b"pwd.db\0";
-pub const _PATH_SMP_DB: &'static [u8; 13usize] = b"/etc/spwd.db\0";
-pub const _SMP_DB: &'static [u8; 8usize] = b"spwd.db\0";
-pub const _PATH_PWD_MKDB: &'static [u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
-pub const _PW_KEYBYNAME: u8 = 49u8;
-pub const _PW_KEYBYNUM: u8 = 50u8;
-pub const _PW_KEYBYUID: u8 = 51u8;
-pub const _PASSWORD_EFMT1: u8 = 95u8;
-pub const _PASSWORD_LEN: u32 = 128;
-pub const _PASSWORD_NOUID: u32 = 1;
-pub const _PASSWORD_NOGID: u32 = 2;
-pub const _PASSWORD_NOCHG: u32 = 4;
-pub const _PASSWORD_NOEXP: u32 = 8;
-pub const _PASSWORD_WARNDAYS: u32 = 14;
-pub const _PASSWORD_CHGNOW: i32 = -1;
+pub const _PWD_H: u32 = 1;
+pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
 pub const PG_BACKEND_VERSIONSTR: &'static [u8; 28usize] = b"postgres (PostgreSQL) 13.2\n\0";
 pub const EXE: &'static [u8; 1usize] = b"\0";
@@ -1660,11 +1174,18 @@ pub const DEVNULL: &'static [u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
 pub const PG_STRERROR_R_BUFLEN: u32 = 256;
 pub const PG_IOLBF: u32 = 1;
-pub const FP_SUPERNORMAL: u32 = 6;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1678,13 +1199,8 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const _JBLEN: u32 = 37;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1754,153 +1270,139 @@ pub const LP_DEAD: u32 = 3;
 pub const SpecTokenOffsetNumber: u32 = 65534;
 pub const MovedPartitionsOffsetNumber: u32 = 65533;
 pub const FIELDNO_HEAPTUPLEDATA_DATA: u32 = 3;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const FirstGenbkiObjectId: u32 = 10000;
 pub const FirstBootstrapObjectId: u32 = 12000;
 pub const FirstNormalObjectId: u32 = 16384;
@@ -2204,8 +1706,24 @@ pub const FIELDNO_HEAPTUPLETABLESLOT_OFF: u32 = 2;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_TUPLE: u32 = 1;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_OFF: u32 = 4;
 pub const BITS_PER_BITMAPWORD: u32 = 64;
-pub const CLOCKS_PER_SEC: u32 = 1000000;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ISNULL: u32 = 4;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ARGS: u32 = 6;
 pub const PG_MAGIC_FUNCTION_NAME_STRING: &'static [u8; 14usize] = b"Pg_magic_func\0";
@@ -2254,121 +1772,84 @@ pub const OUTER_VAR: u32 = 65001;
 pub const INDEX_VAR: u32 = 65002;
 pub const PRS2_OLD_VARNO: u32 = 1;
 pub const PRS2_NEW_VARNO: u32 = 2;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 8192;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
 pub const DSM_IMPL_WINDOWS: u32 = 3;
@@ -2399,25 +1880,9 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &'static [u8; 10usize] = b"pgsql_tmp\0";
 pub const SHARED_TUPLESTORE_SINGLE_PASS: u32 = 1;
@@ -2531,7 +1996,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const REINDEXOPT_REPORT_PROGRESS: u32 = 2;
 pub const MaxAllocHugeSize: u32 = 0;
@@ -2550,6 +2014,85 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2568,13 +2111,7 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -2761,7 +2298,6 @@ pub const F_HAS_GARBAGE: u32 = 16;
 pub const GIST_PAGE_ID: u32 = 65409;
 pub const EOH_HEADER_MAGIC: i32 = -1;
 pub const EA_MAGIC: u32 = 689375833;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &'static [u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3389,429 +2925,195 @@ pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
 pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
-    _bindgen_union_align: [u64; 16usize],
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+    _bindgen_union_align: u32,
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
+}
+impl Default for _G_fpos_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __fpos_t = _G_fpos_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
+}
+impl Default for _G_fpos64_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
-}
-impl Default for __darwin_pthread_handler_rec {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_attr_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[pg_guard]
-extern "C" {
-    pub fn renameat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn renamex_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn renameatx_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 #[pg_guard]
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdout: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stderr: *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn clearerr(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fgets(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut FILE,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __mode: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn freopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut FILE,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fseek(
-        arg1: *mut FILE,
-        arg2: ::std::os::raw::c_long,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn perror(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3822,39 +3124,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn rewind(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setvbuf(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sscanf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    pub fn renameat(
+        __oldfd: ::std::os::raw::c_int,
+        __old: *const ::std::os::raw::c_char,
+        __newfd: ::std::os::raw::c_int,
+        __new: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3863,135 +3137,207 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vfprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vprintf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn popen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __svfscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flockfile(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn funlockfile(arg1: *mut FILE);
-}
-#[pg_guard]
-extern "C" {
-    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn tempnam(
         __dir: *const ::std::os::raw::c_char,
-        __prefix: *const ::std::os::raw::c_char,
+        __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-pub type off_t = __darwin_off_t;
 #[pg_guard]
 extern "C" {
-    pub fn fseeko(
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
         __stream: *mut FILE,
-        __offset: off_t,
-        __whence: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
+        -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmemopen(
+        __s: *mut ::std::os::raw::c_void,
+        __len: usize,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn open_memstream(
+        __bufloc: *mut *mut ::std::os::raw::c_char,
+        __sizeloc: *mut usize,
+    ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setvbuf(
+        __stream: *mut FILE,
+        __buf: *mut ::std::os::raw::c_char,
+        __modes: ::std::os::raw::c_int,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> off_t;
+    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn setlinebuf(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fprintf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vfprintf(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vprintf(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vsprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn snprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vsnprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn vdprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sscanf(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_fscanf"]
+    pub fn fscanf1(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_scanf"]
+    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_sscanf"]
+    pub fn sscanf1(
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
         ...
     ) -> ::std::os::raw::c_int;
@@ -3999,2037 +3345,299 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn vfscanf(
-        __stream: *mut FILE,
+        __s: *mut FILE,
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vscanf(
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vsnprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn vsscanf(
-        __str: *const ::std::os::raw::c_char,
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
-        arg1: *mut __va_list_tag,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn dprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    #[link_name = "\u{1}__isoc99_vfscanf"]
+    pub fn vfscanf1(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn vdprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
+    #[link_name = "\u{1}__isoc99_vscanf"]
+    pub fn vscanf1(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__isoc99_vsscanf"]
+    pub fn vsscanf1(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgets(
+        __s: *mut ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __getdelim(
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn getdelim(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __delimiter: ::std::os::raw::c_int,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn getline(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmemopen(
-        __buf: *mut ::std::os::raw::c_void,
+    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __s: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fread_unlocked(
+        __ptr: *mut ::std::os::raw::c_void,
         __size: usize,
-        __mode: *const ::std::os::raw::c_char,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fwrite_unlocked(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: usize,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseek(
+        __stream: *mut FILE,
+        __off: ::std::os::raw::c_long,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rewind(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fseeko(
+        __stream: *mut FILE,
+        __off: __off_t,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ftello(__stream: *mut FILE) -> __off_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearerr_unlocked(__stream: *mut FILE);
+}
+#[pg_guard]
+extern "C" {
+    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn perror(__s: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn popen(
+        __command: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn open_memstream(
-        __bufp: *mut *mut ::std::os::raw::c_char,
-        __sizep: *mut usize,
-    ) -> *mut FILE;
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
+    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+    pub fn flockfile(__stream: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn asprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn funlockfile(__stream: *mut FILE);
 }
 #[pg_guard]
 extern "C" {
-    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fmtcheck(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-#[pg_guard]
-extern "C" {
-    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setbuffer(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn vasprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn zopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn funopen(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg3: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg4: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: fpos_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> fpos_t,
-        >,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-        >,
-    ) -> *mut FILE;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __snprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __vsprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __vsnprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        arg6: *mut __va_list_tag,
-    ) -> ::std::os::raw::c_int;
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_i386_thread_state {
-    pub __eax: ::std::os::raw::c_uint,
-    pub __ebx: ::std::os::raw::c_uint,
-    pub __ecx: ::std::os::raw::c_uint,
-    pub __edx: ::std::os::raw::c_uint,
-    pub __edi: ::std::os::raw::c_uint,
-    pub __esi: ::std::os::raw::c_uint,
-    pub __ebp: ::std::os::raw::c_uint,
-    pub __esp: ::std::os::raw::c_uint,
-    pub __ss: ::std::os::raw::c_uint,
-    pub __eflags: ::std::os::raw::c_uint,
-    pub __eip: ::std::os::raw::c_uint,
-    pub __cs: ::std::os::raw::c_uint,
-    pub __ds: ::std::os::raw::c_uint,
-    pub __es: ::std::os::raw::c_uint,
-    pub __fs: ::std::os::raw::c_uint,
-    pub __gs: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_fp_control {
-    pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-}
-impl __darwin_fp_control {
-    #[inline]
-    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
-    }
-    #[inline]
-    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 2u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
-    }
-    #[inline]
-    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(10usize, 2u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __invalid: ::std::os::raw::c_ushort,
-        __denorm: ::std::os::raw::c_ushort,
-        __zdiv: ::std::os::raw::c_ushort,
-        __ovrfl: ::std::os::raw::c_ushort,
-        __undfl: ::std::os::raw::c_ushort,
-        __precis: ::std::os::raw::c_ushort,
-        __pc: ::std::os::raw::c_ushort,
-        __rc: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
-            __invalid as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
-            __denorm as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
-            __zdiv as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
-            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
-            __ovrfl as u64
-        });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
-            __undfl as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
-            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
-            __precis as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 2u8, {
-            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
-            __pc as u64
-        });
-        __bindgen_bitfield_unit.set(10usize, 2u8, {
-            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
-            __rc as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-pub type __darwin_fp_control_t = __darwin_fp_control;
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_fp_status {
-    pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-}
-impl __darwin_fp_status {
-    #[inline]
-    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(6usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(9usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(10usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
-    }
-    #[inline]
-    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(11usize, 3u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(14usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
-    }
-    #[inline]
-    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(15usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __invalid: ::std::os::raw::c_ushort,
-        __denorm: ::std::os::raw::c_ushort,
-        __zdiv: ::std::os::raw::c_ushort,
-        __ovrfl: ::std::os::raw::c_ushort,
-        __undfl: ::std::os::raw::c_ushort,
-        __precis: ::std::os::raw::c_ushort,
-        __stkflt: ::std::os::raw::c_ushort,
-        __errsumm: ::std::os::raw::c_ushort,
-        __c0: ::std::os::raw::c_ushort,
-        __c1: ::std::os::raw::c_ushort,
-        __c2: ::std::os::raw::c_ushort,
-        __tos: ::std::os::raw::c_ushort,
-        __c3: ::std::os::raw::c_ushort,
-        __busy: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
-            __invalid as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
-            __denorm as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
-            __zdiv as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
-            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
-            __ovrfl as u64
-        });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
-            __undfl as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
-            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
-            __precis as u64
-        });
-        __bindgen_bitfield_unit.set(6usize, 1u8, {
-            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
-            __stkflt as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
-            __errsumm as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 1u8, {
-            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
-            __c0 as u64
-        });
-        __bindgen_bitfield_unit.set(9usize, 1u8, {
-            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
-            __c1 as u64
-        });
-        __bindgen_bitfield_unit.set(10usize, 1u8, {
-            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
-            __c2 as u64
-        });
-        __bindgen_bitfield_unit.set(11usize, 3u8, {
-            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
-            __tos as u64
-        });
-        __bindgen_bitfield_unit.set(14usize, 1u8, {
-            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
-            __c3 as u64
-        });
-        __bindgen_bitfield_unit.set(15usize, 1u8, {
-            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
-            __busy as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-pub type __darwin_fp_status_t = __darwin_fp_status;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mmst_reg {
-    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
-    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_xmm_reg {
-    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_ymm_reg {
-    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_zmm_reg {
-    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
-}
-impl Default for __darwin_zmm_reg {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_opmask_reg {
-    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_float_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-}
-impl Default for __darwin_i386_float_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_avx_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-}
-impl Default for __darwin_i386_avx_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_i386_avx512_state {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_k0: __darwin_opmask_reg,
-    pub __fpu_k1: __darwin_opmask_reg,
-    pub __fpu_k2: __darwin_opmask_reg,
-    pub __fpu_k3: __darwin_opmask_reg,
-    pub __fpu_k4: __darwin_opmask_reg,
-    pub __fpu_k5: __darwin_opmask_reg,
-    pub __fpu_k6: __darwin_opmask_reg,
-    pub __fpu_k7: __darwin_opmask_reg,
-    pub __fpu_zmmh0: __darwin_ymm_reg,
-    pub __fpu_zmmh1: __darwin_ymm_reg,
-    pub __fpu_zmmh2: __darwin_ymm_reg,
-    pub __fpu_zmmh3: __darwin_ymm_reg,
-    pub __fpu_zmmh4: __darwin_ymm_reg,
-    pub __fpu_zmmh5: __darwin_ymm_reg,
-    pub __fpu_zmmh6: __darwin_ymm_reg,
-    pub __fpu_zmmh7: __darwin_ymm_reg,
-}
-impl Default for __darwin_i386_avx512_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_i386_exception_state {
-    pub __trapno: __uint16_t,
-    pub __cpu: __uint16_t,
-    pub __err: __uint32_t,
-    pub __faultvaddr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_debug_state32 {
-    pub __dr0: ::std::os::raw::c_uint,
-    pub __dr1: ::std::os::raw::c_uint,
-    pub __dr2: ::std::os::raw::c_uint,
-    pub __dr3: ::std::os::raw::c_uint,
-    pub __dr4: ::std::os::raw::c_uint,
-    pub __dr5: ::std::os::raw::c_uint,
-    pub __dr6: ::std::os::raw::c_uint,
-    pub __dr7: ::std::os::raw::c_uint,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __x86_instruction_state {
-    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
-    pub __insn_offset: ::std::os::raw::c_int,
-    pub __out_of_synch: ::std::os::raw::c_int,
-    pub __insn_bytes: [__uint8_t; 2380usize],
-    pub __insn_cacheline: [__uint8_t; 64usize],
-}
-impl Default for __x86_instruction_state {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __last_branch_record {
-    pub __from_ip: __uint64_t,
-    pub __to_ip: __uint64_t,
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __bindgen_padding_0: u32,
-}
-impl __last_branch_record {
-    #[inline]
-    pub fn __mispredict(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___mispredict(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __tsx_abort(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __in_tsx(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___in_tsx(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __cycle_count(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set___cycle_count(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(3usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __reserved(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
-    }
-    #[inline]
-    pub fn set___reserved(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(19usize, 13u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __mispredict: __uint32_t,
-        __tsx_abort: __uint32_t,
-        __in_tsx: __uint32_t,
-        __cycle_count: __uint32_t,
-        __reserved: __uint32_t,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
-            __mispredict as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
-            __tsx_abort as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
-            __in_tsx as u64
-        });
-        __bindgen_bitfield_unit.set(3usize, 16u8, {
-            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
-            __cycle_count as u64
-        });
-        __bindgen_bitfield_unit.set(19usize, 13u8, {
-            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
-            __reserved as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __last_branch_state {
-    pub __lbr_count: ::std::os::raw::c_int,
-    pub _bitfield_align_1: [u32; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __lbrs: [__last_branch_record; 32usize],
-}
-impl __last_branch_state {
-    #[inline]
-    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn __reserved(&self) -> __uint32_t {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
-    }
-    #[inline]
-    pub fn set___reserved(&mut self, val: __uint32_t) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 30u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        __lbr_supported_tsx: __uint32_t,
-        __lbr_supported_cycle_count: __uint32_t,
-        __reserved: __uint32_t,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
-            __lbr_supported_tsx as u64
-        });
-        __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let __lbr_supported_cycle_count: u32 =
-                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
-            __lbr_supported_cycle_count as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 30u8, {
-            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
-            __reserved as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __x86_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_thread_state64 {
-    pub __rax: __uint64_t,
-    pub __rbx: __uint64_t,
-    pub __rcx: __uint64_t,
-    pub __rdx: __uint64_t,
-    pub __rdi: __uint64_t,
-    pub __rsi: __uint64_t,
-    pub __rbp: __uint64_t,
-    pub __rsp: __uint64_t,
-    pub __r8: __uint64_t,
-    pub __r9: __uint64_t,
-    pub __r10: __uint64_t,
-    pub __r11: __uint64_t,
-    pub __r12: __uint64_t,
-    pub __r13: __uint64_t,
-    pub __r14: __uint64_t,
-    pub __r15: __uint64_t,
-    pub __rip: __uint64_t,
-    pub __rflags: __uint64_t,
-    pub __cs: __uint64_t,
-    pub __fs: __uint64_t,
-    pub __gs: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_thread_full_state64 {
-    pub __ss64: __darwin_x86_thread_state64,
-    pub __ds: __uint64_t,
-    pub __es: __uint64_t,
-    pub __ss: __uint64_t,
-    pub __gsbase: __uint64_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_float_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-}
-impl Default for __darwin_x86_float_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_avx_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_ymmh8: __darwin_xmm_reg,
-    pub __fpu_ymmh9: __darwin_xmm_reg,
-    pub __fpu_ymmh10: __darwin_xmm_reg,
-    pub __fpu_ymmh11: __darwin_xmm_reg,
-    pub __fpu_ymmh12: __darwin_xmm_reg,
-    pub __fpu_ymmh13: __darwin_xmm_reg,
-    pub __fpu_ymmh14: __darwin_xmm_reg,
-    pub __fpu_ymmh15: __darwin_xmm_reg,
-}
-impl Default for __darwin_x86_avx_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_x86_avx512_state64 {
-    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
-    pub __fpu_fcw: __darwin_fp_control,
-    pub __fpu_fsw: __darwin_fp_status,
-    pub __fpu_ftw: __uint8_t,
-    pub __fpu_rsrv1: __uint8_t,
-    pub __fpu_fop: __uint16_t,
-    pub __fpu_ip: __uint32_t,
-    pub __fpu_cs: __uint16_t,
-    pub __fpu_rsrv2: __uint16_t,
-    pub __fpu_dp: __uint32_t,
-    pub __fpu_ds: __uint16_t,
-    pub __fpu_rsrv3: __uint16_t,
-    pub __fpu_mxcsr: __uint32_t,
-    pub __fpu_mxcsrmask: __uint32_t,
-    pub __fpu_stmm0: __darwin_mmst_reg,
-    pub __fpu_stmm1: __darwin_mmst_reg,
-    pub __fpu_stmm2: __darwin_mmst_reg,
-    pub __fpu_stmm3: __darwin_mmst_reg,
-    pub __fpu_stmm4: __darwin_mmst_reg,
-    pub __fpu_stmm5: __darwin_mmst_reg,
-    pub __fpu_stmm6: __darwin_mmst_reg,
-    pub __fpu_stmm7: __darwin_mmst_reg,
-    pub __fpu_xmm0: __darwin_xmm_reg,
-    pub __fpu_xmm1: __darwin_xmm_reg,
-    pub __fpu_xmm2: __darwin_xmm_reg,
-    pub __fpu_xmm3: __darwin_xmm_reg,
-    pub __fpu_xmm4: __darwin_xmm_reg,
-    pub __fpu_xmm5: __darwin_xmm_reg,
-    pub __fpu_xmm6: __darwin_xmm_reg,
-    pub __fpu_xmm7: __darwin_xmm_reg,
-    pub __fpu_xmm8: __darwin_xmm_reg,
-    pub __fpu_xmm9: __darwin_xmm_reg,
-    pub __fpu_xmm10: __darwin_xmm_reg,
-    pub __fpu_xmm11: __darwin_xmm_reg,
-    pub __fpu_xmm12: __darwin_xmm_reg,
-    pub __fpu_xmm13: __darwin_xmm_reg,
-    pub __fpu_xmm14: __darwin_xmm_reg,
-    pub __fpu_xmm15: __darwin_xmm_reg,
-    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
-    pub __fpu_reserved1: ::std::os::raw::c_int,
-    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
-    pub __fpu_ymmh0: __darwin_xmm_reg,
-    pub __fpu_ymmh1: __darwin_xmm_reg,
-    pub __fpu_ymmh2: __darwin_xmm_reg,
-    pub __fpu_ymmh3: __darwin_xmm_reg,
-    pub __fpu_ymmh4: __darwin_xmm_reg,
-    pub __fpu_ymmh5: __darwin_xmm_reg,
-    pub __fpu_ymmh6: __darwin_xmm_reg,
-    pub __fpu_ymmh7: __darwin_xmm_reg,
-    pub __fpu_ymmh8: __darwin_xmm_reg,
-    pub __fpu_ymmh9: __darwin_xmm_reg,
-    pub __fpu_ymmh10: __darwin_xmm_reg,
-    pub __fpu_ymmh11: __darwin_xmm_reg,
-    pub __fpu_ymmh12: __darwin_xmm_reg,
-    pub __fpu_ymmh13: __darwin_xmm_reg,
-    pub __fpu_ymmh14: __darwin_xmm_reg,
-    pub __fpu_ymmh15: __darwin_xmm_reg,
-    pub __fpu_k0: __darwin_opmask_reg,
-    pub __fpu_k1: __darwin_opmask_reg,
-    pub __fpu_k2: __darwin_opmask_reg,
-    pub __fpu_k3: __darwin_opmask_reg,
-    pub __fpu_k4: __darwin_opmask_reg,
-    pub __fpu_k5: __darwin_opmask_reg,
-    pub __fpu_k6: __darwin_opmask_reg,
-    pub __fpu_k7: __darwin_opmask_reg,
-    pub __fpu_zmmh0: __darwin_ymm_reg,
-    pub __fpu_zmmh1: __darwin_ymm_reg,
-    pub __fpu_zmmh2: __darwin_ymm_reg,
-    pub __fpu_zmmh3: __darwin_ymm_reg,
-    pub __fpu_zmmh4: __darwin_ymm_reg,
-    pub __fpu_zmmh5: __darwin_ymm_reg,
-    pub __fpu_zmmh6: __darwin_ymm_reg,
-    pub __fpu_zmmh7: __darwin_ymm_reg,
-    pub __fpu_zmmh8: __darwin_ymm_reg,
-    pub __fpu_zmmh9: __darwin_ymm_reg,
-    pub __fpu_zmmh10: __darwin_ymm_reg,
-    pub __fpu_zmmh11: __darwin_ymm_reg,
-    pub __fpu_zmmh12: __darwin_ymm_reg,
-    pub __fpu_zmmh13: __darwin_ymm_reg,
-    pub __fpu_zmmh14: __darwin_ymm_reg,
-    pub __fpu_zmmh15: __darwin_ymm_reg,
-    pub __fpu_zmm16: __darwin_zmm_reg,
-    pub __fpu_zmm17: __darwin_zmm_reg,
-    pub __fpu_zmm18: __darwin_zmm_reg,
-    pub __fpu_zmm19: __darwin_zmm_reg,
-    pub __fpu_zmm20: __darwin_zmm_reg,
-    pub __fpu_zmm21: __darwin_zmm_reg,
-    pub __fpu_zmm22: __darwin_zmm_reg,
-    pub __fpu_zmm23: __darwin_zmm_reg,
-    pub __fpu_zmm24: __darwin_zmm_reg,
-    pub __fpu_zmm25: __darwin_zmm_reg,
-    pub __fpu_zmm26: __darwin_zmm_reg,
-    pub __fpu_zmm27: __darwin_zmm_reg,
-    pub __fpu_zmm28: __darwin_zmm_reg,
-    pub __fpu_zmm29: __darwin_zmm_reg,
-    pub __fpu_zmm30: __darwin_zmm_reg,
-    pub __fpu_zmm31: __darwin_zmm_reg,
-}
-impl Default for __darwin_x86_avx512_state64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_exception_state64 {
-    pub __trapno: __uint16_t,
-    pub __cpu: __uint16_t,
-    pub __err: __uint32_t,
-    pub __faultvaddr: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_debug_state64 {
-    pub __dr0: __uint64_t,
-    pub __dr1: __uint64_t,
-    pub __dr2: __uint64_t,
-    pub __dr3: __uint64_t,
-    pub __dr4: __uint64_t,
-    pub __dr5: __uint64_t,
-    pub __dr6: __uint64_t,
-    pub __dr7: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_x86_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_float_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_avx_state,
-}
-impl Default for __darwin_mcontext_avx32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_32 {
-    pub __es: __darwin_i386_exception_state,
-    pub __ss: __darwin_i386_thread_state,
-    pub __fs: __darwin_i386_avx512_state,
-}
-impl Default for __darwin_mcontext_avx512_32 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_float_state64,
-}
-impl Default for __darwin_mcontext64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_float_state64,
-}
-impl Default for __darwin_mcontext64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_avx_state64,
-}
-impl Default for __darwin_mcontext_avx64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_avx_state64,
-}
-impl Default for __darwin_mcontext_avx64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_64 {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_state64,
-    pub __fs: __darwin_x86_avx512_state64,
-}
-impl Default for __darwin_mcontext_avx512_64 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __darwin_mcontext_avx512_64_full {
-    pub __es: __darwin_x86_exception_state64,
-    pub __ss: __darwin_x86_thread_full_state64,
-    pub __fs: __darwin_x86_avx512_state64,
-}
-impl Default for __darwin_mcontext_avx512_64_full {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-    _bindgen_union_align: u64,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    _bindgen_union_align: u64,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-pub type rusage_info_current = rusage_info_v5;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setpriority(
-        arg1: ::std::os::raw::c_int,
-        arg2: id_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-    _bindgen_union_align: u32,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn waitpid(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn waitid(
-        arg1: idtype_t,
-        arg2: id_t,
-        arg3: *mut siginfo_t,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait3(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut rusage,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wait4(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut rusage,
-    ) -> pid_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -6050,7 +3658,595 @@ pub struct lldiv_t {
 }
 #[pg_guard]
 extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+    pub fn __ctype_get_mb_cur_max() -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtod(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtof(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtold(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtol(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoul(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtouq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoll(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strtoull(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[pg_guard]
+extern "C" {
+    pub fn select(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *mut timeval,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pselect(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *const timespec,
+        __sigmask: *const __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __bindgen_anon_1: __pthread_cond_s__bindgen_ty_1,
+    pub __bindgen_anon_2: __pthread_cond_s__bindgen_ty_2,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __pthread_cond_s__bindgen_ty_1 {
+    pub __wseq: ::std::os::raw::c_ulonglong,
+    pub __wseq32: __pthread_cond_s__bindgen_ty_1__bindgen_ty_1,
+    _bindgen_union_align: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_cond_s__bindgen_ty_1__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __pthread_cond_s__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __pthread_cond_s__bindgen_ty_2 {
+    pub __g1_start: ::std::os::raw::c_ulonglong,
+    pub __g1_start32: __pthread_cond_s__bindgen_ty_2__bindgen_ty_1,
+    _bindgen_union_align: u64,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_cond_s__bindgen_ty_2__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __pthread_cond_s__bindgen_ty_2 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 7usize],
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 5usize],
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+    _bindgen_union_align: [u64; 6usize],
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 7usize],
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: u64,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+    _bindgen_union_align: [u64; 4usize],
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+    _bindgen_union_align: u32,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn random() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom(__seed: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn initstate(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srandom_r(
+        __seed: ::std::os::raw::c_uint,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn initstate_r(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setstate_r(
+        __statebuf: *mut ::std::os::raw::c_char,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand(__seed: ::std::os::raw::c_uint);
+}
+#[pg_guard]
+extern "C" {
+    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48() -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48(__seedval: ::std::os::raw::c_long);
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[pg_guard]
+extern "C" {
+    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn srand48_r(
+        __seedval: ::std::os::raw::c_long,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn seed48_r(
+        __seed16v: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lcong48_r(
+        __param: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -6059,13 +4255,9 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn calloc(
-        __count: ::std::os::raw::c_ulong,
+        __nmemb: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -6076,11 +4268,23 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+    pub fn reallocarray(
+        __ptr: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
+}
+#[pg_guard]
+extern "C" {
+    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -6092,74 +4296,247 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
     pub fn abort();
 }
 #[pg_guard]
 extern "C" {
-    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+    pub fn at_quick_exit(
+        __func: ::std::option::Option<unsafe extern "C" fn()>,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+    pub fn on_exit(
+        __func: ::std::option::Option<
+            unsafe extern "C" fn(
+                __status: ::std::os::raw::c_int,
+                __arg: *mut ::std::os::raw::c_void,
+            ),
+        >,
+        __arg: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn exit(__status: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+    pub fn quick_exit(__status: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+    pub fn _Exit(__status: ::std::os::raw::c_int);
 }
+#[pg_guard]
+extern "C" {
+    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setenv(
+        __name: *const ::std::os::raw::c_char,
+        __value: *const ::std::os::raw::c_char,
+        __replace: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clearenv() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkstemps(
+        __template: *mut ::std::os::raw::c_char,
+        __suffixlen: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn realpath(
+        __name: *const ::std::os::raw::c_char,
+        __resolved: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[pg_guard]
 extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
+    );
 }
 #[pg_guard]
 extern "C" {
-    pub fn exit(arg1: ::std::os::raw::c_int);
+    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
+    pub fn lldiv(
+        __numer: ::std::os::raw::c_longlong,
+        __denom: ::std::os::raw::c_longlong,
+    ) -> lldiv_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qecvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qfcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qgcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ecvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fcvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qecvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn qfcvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -6167,594 +4544,70 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
-}
-#[pg_guard]
-extern "C" {
     pub fn mbtowc(
-        arg1: *mut wchar_t,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: usize,
+        __pwc: *mut wchar_t,
+        __s: *const ::std::os::raw::c_char,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
+    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
+    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn srand(arg1: ::std::os::raw::c_uint);
+    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtod(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtof(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtol(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtold(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoll(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoul(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtoull(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn _Exit(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn drand48() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ecvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn getsubopt(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+        __optionp: *mut *mut ::std::os::raw::c_char,
+        __tokens: *const *mut ::std::os::raw::c_char,
+        __valuep: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn initstate(
-        arg1: ::std::os::raw::c_uint,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ptsname_r(
-        fildes: ::std::os::raw::c_int,
-        buffer: *mut ::std::os::raw::c_char,
-        buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-    pub fn realpath(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __overwrite: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setkey(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn srand48(arg1: ::std::os::raw::c_long);
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandom(arg1: ::std::os::raw::c_uint);
-}
-#[pg_guard]
-extern "C" {
-    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[pg_guard]
-extern "C" {
-    pub fn arc4random() -> u32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_stir();
-}
-#[pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bsearch_b(
-        __key: *const ::std::os::raw::c_void,
-        __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+    pub fn memcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cgetcap(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetclose() -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetfirst(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetmatch(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetnext(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetnum(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetstr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cgetustr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_daemon$1050"]
-    pub fn daemon(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn devname_r(
-        arg1: dev_t,
-        arg2: mode_t,
-        buf: *mut ::std::os::raw::c_char,
-        len: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getbsize(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_long,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprogname() -> *const ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn heapsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn heapsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mergesort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mergesort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn psort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn qsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn qsort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn radixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sradixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sranddev();
-}
-#[pg_guard]
-extern "C" {
-    pub fn srandomdev();
-}
-#[pg_guard]
-extern "C" {
-    pub fn reallocf(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
+    pub fn memmove(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtonum(
-        __numstr: *const ::std::os::raw::c_char,
-        __minval: ::std::os::raw::c_longlong,
-        __maxval: ::std::os::raw::c_longlong,
-        __errstrp: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_longlong;
+    pub fn memccpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strtoq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strtouq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
+    pub fn memset(
+        __s: *mut ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -6769,40 +4622,40 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn memcpy(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmove(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset(
-        __b: *mut ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
+    pub fn strcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strncat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -6814,43 +4667,6 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcspn(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strncat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
     pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
@@ -6859,17 +4675,68 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strncpy(
-        __dst: *mut ::std::os::raw::c_char,
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm(
+        __dest: *mut ::std::os::raw::c_char,
         __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[pg_guard]
+extern "C" {
+    pub fn strcoll_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __l: locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strxfrm_l(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+        __l: locale_t,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strndup(
+        __string: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strpbrk(
+    pub fn strchr(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
@@ -6881,170 +4748,164 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn strspn(
+    pub fn strcspn(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __reject: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
     pub fn strstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
+        __haystack: *const ::std::os::raw::c_char,
+        __needle: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strtok(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strxfrm(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn __strtok_r(
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
     pub fn strtok_r(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
-        __lasts: *mut *mut ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    #[link_name = "\u{1}__xpg_strerror_r"]
     pub fn strerror_r(
         __errnum: ::std::os::raw::c_int,
-        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buf: *mut ::std::os::raw::c_char,
         __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn strerror_l(
+        __errnum: ::std::os::raw::c_int,
+        __l: locale_t,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memccpy(
-        __dst: *mut ::std::os::raw::c_void,
+    pub fn bcmp(
+        __s1: *const ::std::os::raw::c_void,
+        __s2: *const ::std::os::raw::c_void,
+        __n: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn bcopy(
         __src: *const ::std::os::raw::c_void,
+        __dest: *mut ::std::os::raw::c_void,
+        __n: usize,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
+}
+#[pg_guard]
+extern "C" {
+    pub fn index(
+        __s: *const ::std::os::raw::c_char,
         __c: ::std::os::raw::c_int,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn stpcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn stpncpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
+    pub fn rindex(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strndup(
+    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strcasecmp(
         __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strncasecmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn strcasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[pg_guard]
-extern "C" {
-    pub fn memset_s(
-        __s: *mut ::std::os::raw::c_void,
-        __smax: rsize_t,
-        __c: ::std::os::raw::c_int,
-        __n: rsize_t,
-    ) -> errno_t;
+    pub fn strncasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __n: usize,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn memmem(
-        __big: *const ::std::os::raw::c_void,
-        __big_len: usize,
-        __little: *const ::std::os::raw::c_void,
-        __little_len: usize,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern4(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern4: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern8(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern8: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn memset_pattern16(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern16: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn strcasestr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strnstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-        __len: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
 }
 #[pg_guard]
 extern "C" {
@@ -7055,158 +4916,67 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn swab(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: isize,
-    );
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timingsafe_bcmp(
-        __b1: *const ::std::os::raw::c_void,
-        __b2: *const ::std::os::raw::c_void,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn strsignal_r(
-        __sig: ::std::os::raw::c_int,
-        __strsignalbuf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcmp(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bcopy(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-    );
-}
-#[pg_guard]
-extern "C" {
-    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-}
-#[pg_guard]
-extern "C" {
-    pub fn index(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn __stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rindex(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strcasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+    pub fn stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
-#[pg_guard]
-extern "C" {
-    pub fn strncasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-pub type max_align_t = u128;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[pg_guard]
 extern "C" {
-    pub fn __darwin_check_fd_set_overflow(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[pg_guard]
-extern "C" {
-    pub fn __error() -> *mut ::std::os::raw::c_int;
+    pub fn __errno_location() -> *mut ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7230,8 +5000,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -7243,14 +5013,34 @@ impl Default for lconv {
 }
 #[pg_guard]
 extern "C" {
+    pub fn setlocale(
+        __category: ::std::os::raw::c_int,
+        __locale: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
     pub fn localeconv() -> *mut lconv;
 }
 #[pg_guard]
 extern "C" {
-    pub fn setlocale(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn newlocale(
+        __category_mask: ::std::os::raw::c_int,
+        __locale: *const ::std::os::raw::c_char,
+        __base: locale_t,
+    ) -> locale_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn duplocale(__dataset: locale_t) -> locale_t;
+}
+#[pg_guard]
+extern "C" {
+    pub fn freelocale(__dataset: locale_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn uselocale(__dataset: locale_t) -> locale_t;
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
 pub type int8 = ::std::os::raw::c_schar;
@@ -7363,115 +5153,167 @@ impl Default for PGAlignedXLogBlock {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const _ISupper: ::std::os::raw::c_uint = 256;
+pub const _ISlower: ::std::os::raw::c_uint = 512;
+pub const _ISalpha: ::std::os::raw::c_uint = 1024;
+pub const _ISdigit: ::std::os::raw::c_uint = 2048;
+pub const _ISxdigit: ::std::os::raw::c_uint = 4096;
+pub const _ISspace: ::std::os::raw::c_uint = 8192;
+pub const _ISprint: ::std::os::raw::c_uint = 16384;
+pub const _ISgraph: ::std::os::raw::c_uint = 32768;
+pub const _ISblank: ::std::os::raw::c_uint = 1;
+pub const _IScntrl: ::std::os::raw::c_uint = 2;
+pub const _ISpunct: ::std::os::raw::c_uint = 4;
+pub const _ISalnum: ::std::os::raw::c_uint = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
-    pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
+    pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
+    pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
+    pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __maskrune(
-        arg1: __darwin_ct_rune_t,
-        arg2: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
+    pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+    pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-pub type socklen_t = __darwin_socklen_t;
-pub type sa_family_t = __uint8_t;
+#[pg_guard]
+extern "C" {
+    pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -7483,71 +5325,67 @@ impl Default for iovec {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
-}
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const MSG_OOB: ::std::os::raw::c_uint = 1;
+pub const MSG_PEEK: ::std::os::raw::c_uint = 2;
+pub const MSG_DONTROUTE: ::std::os::raw::c_uint = 4;
+pub const MSG_CTRUNC: ::std::os::raw::c_uint = 8;
+pub const MSG_PROXY: ::std::os::raw::c_uint = 16;
+pub const MSG_TRUNC: ::std::os::raw::c_uint = 32;
+pub const MSG_DONTWAIT: ::std::os::raw::c_uint = 64;
+pub const MSG_EOR: ::std::os::raw::c_uint = 128;
+pub const MSG_WAITALL: ::std::os::raw::c_uint = 256;
+pub const MSG_FIN: ::std::os::raw::c_uint = 512;
+pub const MSG_SYN: ::std::os::raw::c_uint = 1024;
+pub const MSG_CONFIRM: ::std::os::raw::c_uint = 2048;
+pub const MSG_RST: ::std::os::raw::c_uint = 4096;
+pub const MSG_ERRQUEUE: ::std::os::raw::c_uint = 8192;
+pub const MSG_NOSIGNAL: ::std::os::raw::c_uint = 16384;
+pub const MSG_MORE: ::std::os::raw::c_uint = 32768;
+pub const MSG_WAITFORONE: ::std::os::raw::c_uint = 65536;
+pub const MSG_BATCH: ::std::os::raw::c_uint = 262144;
+pub const MSG_ZEROCOPY: ::std::os::raw::c_uint = 67108864;
+pub const MSG_FASTOPEN: ::std::os::raw::c_uint = 536870912;
+pub const MSG_CMSG_CLOEXEC: ::std::os::raw::c_uint = 1073741824;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -7556,225 +5394,239 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+}
+pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn accept(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn bind(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sockaddr,
-        arg3: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn connect(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sockaddr,
-        arg3: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpeername(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockname(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
-        arg3: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsockopt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_void,
-        arg5: *mut socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn listen(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recv(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recvfrom(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-        arg5: *mut sockaddr,
-        arg6: *mut socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn recvmsg(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut msghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn send(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendmsg(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const msghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sendto(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: usize,
-        arg4: ::std::os::raw::c_int,
-        arg5: *const sockaddr,
-        arg6: socklen_t,
-    ) -> isize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setsockopt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_void,
-        arg5: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn shutdown(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
+pub const SHUT_RD: ::std::os::raw::c_uint = 0;
+pub const SHUT_WR: ::std::os::raw::c_uint = 1;
+pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn socket(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
+        __domain: ::std::os::raw::c_int,
+        __type: ::std::os::raw::c_int,
+        __protocol: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn socketpair(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
+        __domain: ::std::os::raw::c_int,
+        __type: ::std::os::raw::c_int,
+        __protocol: ::std::os::raw::c_int,
+        __fds: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sendfile(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: off_t,
-        arg4: *mut off_t,
-        arg5: *mut sf_hdtr,
-        arg6: ::std::os::raw::c_int,
+    pub fn bind(
+        __fd: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-}
-#[pg_guard]
-extern "C" {
-    pub fn connectx(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sa_endpoints_t,
-        arg3: sae_associd_t,
-        arg4: ::std::os::raw::c_uint,
-        arg5: *const iovec,
-        arg6: ::std::os::raw::c_uint,
-        arg7: *mut usize,
-        arg8: *mut sae_connid_t,
+    pub fn getsockname(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __len: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn disconnectx(
-        arg1: ::std::os::raw::c_int,
-        arg2: sae_associd_t,
-        arg3: sae_connid_t,
+    pub fn connect(
+        __fd: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
+#[pg_guard]
+extern "C" {
+    pub fn getpeername(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __len: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn send(
+        __fd: ::std::os::raw::c_int,
+        __buf: *const ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recv(
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendto(
+        __fd: ::std::os::raw::c_int,
+        __buf: *const ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+        __addr: *const sockaddr,
+        __addr_len: socklen_t,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recvfrom(
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __flags: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __addr_len: *mut socklen_t,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sendmsg(
+        __fd: ::std::os::raw::c_int,
+        __message: *const msghdr,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn recvmsg(
+        __fd: ::std::os::raw::c_int,
+        __message: *mut msghdr,
+        __flags: ::std::os::raw::c_int,
+    ) -> isize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getsockopt(
+        __fd: ::std::os::raw::c_int,
+        __level: ::std::os::raw::c_int,
+        __optname: ::std::os::raw::c_int,
+        __optval: *mut ::std::os::raw::c_void,
+        __optlen: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setsockopt(
+        __fd: ::std::os::raw::c_int,
+        __level: ::std::os::raw::c_int,
+        __optname: ::std::os::raw::c_int,
+        __optval: *const ::std::os::raw::c_void,
+        __optlen: socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn accept(
+        __fd: ::std::os::raw::c_int,
+        __addr: *mut sockaddr,
+        __addr_len: *mut socklen_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn shutdown(
+        __fd: ::std::os::raw::c_int,
+        __how: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isfdtype(
+        __fd: ::std::os::raw::c_int,
+        __fdtype: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -7789,12 +5641,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -7802,113 +5648,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[pg_guard]
-extern "C" {
-    pub fn setipv4sourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: in_addr,
-        arg3: in_addr,
-        arg4: u32,
-        arg5: u32,
-        arg6: *mut in_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipv4sourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: in_addr,
-        arg3: in_addr,
-        arg4: *mut u32,
-        arg5: *mut u32,
-        arg6: *mut in_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setsourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: u32,
-        arg3: *mut sockaddr,
-        arg4: socklen_t,
-        arg5: u32,
-        arg6: u32,
-        arg7: *mut sockaddr_storage,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getsourcefilter(
-        arg1: ::std::os::raw::c_int,
-        arg2: u32,
-        arg3: *mut sockaddr,
-        arg4: socklen_t,
-        arg5: *mut u32,
-        arg6: *mut u32,
-        arg7: *mut sockaddr_storage,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: ::std::os::raw::c_uint = 0;
+pub const IPPROTO_ICMP: ::std::os::raw::c_uint = 1;
+pub const IPPROTO_IGMP: ::std::os::raw::c_uint = 2;
+pub const IPPROTO_IPIP: ::std::os::raw::c_uint = 4;
+pub const IPPROTO_TCP: ::std::os::raw::c_uint = 6;
+pub const IPPROTO_EGP: ::std::os::raw::c_uint = 8;
+pub const IPPROTO_PUP: ::std::os::raw::c_uint = 12;
+pub const IPPROTO_UDP: ::std::os::raw::c_uint = 17;
+pub const IPPROTO_IDP: ::std::os::raw::c_uint = 22;
+pub const IPPROTO_TP: ::std::os::raw::c_uint = 29;
+pub const IPPROTO_DCCP: ::std::os::raw::c_uint = 33;
+pub const IPPROTO_IPV6: ::std::os::raw::c_uint = 41;
+pub const IPPROTO_RSVP: ::std::os::raw::c_uint = 46;
+pub const IPPROTO_GRE: ::std::os::raw::c_uint = 47;
+pub const IPPROTO_ESP: ::std::os::raw::c_uint = 50;
+pub const IPPROTO_AH: ::std::os::raw::c_uint = 51;
+pub const IPPROTO_MTP: ::std::os::raw::c_uint = 92;
+pub const IPPROTO_BEETPH: ::std::os::raw::c_uint = 94;
+pub const IPPROTO_ENCAP: ::std::os::raw::c_uint = 98;
+pub const IPPROTO_PIM: ::std::os::raw::c_uint = 103;
+pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
+pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
+pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
+pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
+pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
+pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
+pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
+pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
+pub const IPPROTO_FRAGMENT: ::std::os::raw::c_uint = 44;
+pub const IPPROTO_ICMPV6: ::std::os::raw::c_uint = 58;
+pub const IPPROTO_NONE: ::std::os::raw::c_uint = 59;
+pub const IPPROTO_DSTOPTS: ::std::os::raw::c_uint = 60;
+pub const IPPROTO_MH: ::std::os::raw::c_uint = 135;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: ::std::os::raw::c_uint = 7;
+pub const IPPORT_DISCARD: ::std::os::raw::c_uint = 9;
+pub const IPPORT_SYSTAT: ::std::os::raw::c_uint = 11;
+pub const IPPORT_DAYTIME: ::std::os::raw::c_uint = 13;
+pub const IPPORT_NETSTAT: ::std::os::raw::c_uint = 15;
+pub const IPPORT_FTP: ::std::os::raw::c_uint = 21;
+pub const IPPORT_TELNET: ::std::os::raw::c_uint = 23;
+pub const IPPORT_SMTP: ::std::os::raw::c_uint = 25;
+pub const IPPORT_TIMESERVER: ::std::os::raw::c_uint = 37;
+pub const IPPORT_NAMESERVER: ::std::os::raw::c_uint = 42;
+pub const IPPORT_WHOIS: ::std::os::raw::c_uint = 43;
+pub const IPPORT_MTP: ::std::os::raw::c_uint = 57;
+pub const IPPORT_TFTP: ::std::os::raw::c_uint = 69;
+pub const IPPORT_RJE: ::std::os::raw::c_uint = 77;
+pub const IPPORT_FINGER: ::std::os::raw::c_uint = 79;
+pub const IPPORT_TTYLINK: ::std::os::raw::c_uint = 87;
+pub const IPPORT_SUPDUP: ::std::os::raw::c_uint = 95;
+pub const IPPORT_EXECSERVER: ::std::os::raw::c_uint = 512;
+pub const IPPORT_LOGINSERVER: ::std::os::raw::c_uint = 513;
+pub const IPPORT_CMDSERVER: ::std::os::raw::c_uint = 514;
+pub const IPPORT_EFSSERVER: ::std::os::raw::c_uint = 520;
+pub const IPPORT_BIFFUDP: ::std::os::raw::c_uint = 512;
+pub const IPPORT_WHOSERVER: ::std::os::raw::c_uint = 513;
+pub const IPPORT_ROUTESERVER: ::std::os::raw::c_uint = 520;
+pub const IPPORT_RESERVED: ::std::os::raw::c_uint = 1024;
+pub const IPPORT_USERRESERVED: ::std::os::raw::c_uint = 5000;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
     _bindgen_union_align: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
@@ -7921,22 +5741,6 @@ impl Default for in6_addr {
         unsafe { ::std::mem::zeroed() }
     }
 }
-pub type in6_addr_t = in6_addr;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
-    pub sin6_family: sa_family_t,
-    pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
-    pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
-}
-impl Default for sockaddr_in6 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
 #[pg_guard]
 extern "C" {
     pub static in6addr_any: in6_addr;
@@ -7945,21 +5749,40 @@ extern "C" {
 extern "C" {
     pub static in6addr_loopback: in6_addr;
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: u32,
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
+impl Default for sockaddr_in6 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
-#[pg_guard]
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -7974,303 +5797,79 @@ impl Default for ipv6_mreq {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ntohl(__netlong: u32) -> u32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *mut *mut cmsghdr,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn ntohs(__netshort: u16) -> u16;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_append(
-        arg1: *mut cmsghdr,
-        arg2: *const __uint8_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn htonl(__hostlong: u32) -> u32;
 }
 #[pg_guard]
 extern "C" {
-    pub fn inet6_option_alloc(
-        arg1: *mut cmsghdr,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> *mut __uint8_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_option_next(
-        arg1: *const cmsghdr,
-        arg2: *mut *mut __uint8_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_option_find(
-        arg1: *const cmsghdr,
-        arg2: *mut *mut __uint8_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> usize;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut cmsghdr;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_add(
-        arg1: *mut cmsghdr,
-        arg2: *const in6_addr,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_lasthop(
-        arg1: *mut cmsghdr,
-        arg2: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_getaddr(arg1: *mut cmsghdr, arg2: ::std::os::raw::c_int) -> *mut in6_addr;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rthdr_getflags(
-        arg1: *const cmsghdr,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_append(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: __uint8_t,
-        arg5: socklen_t,
-        arg6: __uint8_t,
-        arg7: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_finish(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_set_val(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_next(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut __uint8_t,
-        arg5: *mut socklen_t,
-        arg6: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_find(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: __uint8_t,
-        arg5: *mut socklen_t,
-        arg6: *mut *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_opt_get_val(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: socklen_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_space(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> socklen_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_init(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_void;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_add(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *const in6_addr,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_reverse(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn inet6_rth_getaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut in6_addr;
+    pub fn htons(__hostshort: u16) -> u16;
 }
 #[pg_guard]
 extern "C" {
     pub fn bindresvport(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr_in,
+        __sockfd: ::std::os::raw::c_int,
+        __sock_in: *mut sockaddr_in,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bindresvport_sa(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sockaddr,
+    pub fn bindresvport6(
+        __sockfd: ::std::os::raw::c_int,
+        __sock_in: *mut sockaddr_in6,
     ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct hostent {
-    pub h_name: *mut ::std::os::raw::c_char,
-    pub h_aliases: *mut *mut ::std::os::raw::c_char,
-    pub h_addrtype: ::std::os::raw::c_int,
-    pub h_length: ::std::os::raw::c_int,
-    pub h_addr_list: *mut *mut ::std::os::raw::c_char,
-}
-impl Default for hostent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct servent {
-    pub s_name: *mut ::std::os::raw::c_char,
-    pub s_aliases: *mut *mut ::std::os::raw::c_char,
-    pub s_port: ::std::os::raw::c_int,
-    pub s_proto: *mut ::std::os::raw::c_char,
-}
-impl Default for servent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct protoent {
-    pub p_name: *mut ::std::os::raw::c_char,
-    pub p_aliases: *mut *mut ::std::os::raw::c_char,
-    pub p_proto: ::std::os::raw::c_int,
-}
-impl Default for protoent {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -8286,167 +5885,7 @@ impl Default for rpcent {
 }
 #[pg_guard]
 extern "C" {
-    pub fn endhostent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endnetent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endprotoent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn endservent();
-}
-#[pg_guard]
-extern "C" {
-    pub fn freeaddrinfo(arg1: *mut addrinfo);
-}
-#[pg_guard]
-extern "C" {
-    pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getaddrinfo(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const addrinfo,
-        arg4: *mut *mut addrinfo,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: socklen_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostent() -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnameinfo(
-        arg1: *const sockaddr,
-        arg2: socklen_t,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: socklen_t,
-        arg5: *mut ::std::os::raw::c_char,
-        arg6: socklen_t,
-        arg7: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getnetent() -> *mut netent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getprotoent() -> *mut protoent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyname(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservbyport(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getservent() -> *mut servent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sethostent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setnetent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setprotoent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setservent(arg1: ::std::os::raw::c_int);
-}
-#[pg_guard]
-extern "C" {
-    pub fn freehostent(arg1: *mut hostent);
-}
-#[pg_guard]
-extern "C" {
-    pub fn gethostbyname2(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipnodebyaddr(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getipnodebyname(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut hostent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getrpcent() -> *mut rpcent;
-}
-#[pg_guard]
-extern "C" {
-    pub fn setrpcent(stayopen: ::std::os::raw::c_int);
+    pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
@@ -8454,28 +5893,348 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn herror(arg1: *const ::std::os::raw::c_char);
+    pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+    pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
 }
 #[pg_guard]
 extern "C" {
-    pub fn innetgr(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-        arg4: *const ::std::os::raw::c_char,
+    pub fn getrpcent() -> *mut rpcent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getnetgrent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+    pub fn getrpcbynumber_r(
+        __number: ::std::os::raw::c_int,
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getrpcent_r(
+        __result_buf: *mut rpcent,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut rpcent,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn herror(__str: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hostent {
+    pub h_name: *mut ::std::os::raw::c_char,
+    pub h_aliases: *mut *mut ::std::os::raw::c_char,
+    pub h_addrtype: ::std::os::raw::c_int,
+    pub h_length: ::std::os::raw::c_int,
+    pub h_addr_list: *mut *mut ::std::os::raw::c_char,
+}
+impl Default for hostent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sethostent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endhostent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent() -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyaddr(
+        __addr: *const ::std::os::raw::c_void,
+        __len: __socklen_t,
+        __type: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2(
+        __name: *const ::std::os::raw::c_char,
+        __af: ::std::os::raw::c_int,
+    ) -> *mut hostent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostent_r(
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyaddr_r(
+        __addr: *const ::std::os::raw::c_void,
+        __len: __socklen_t,
+        __type: ::std::os::raw::c_int,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gethostbyname2_r(
+        __name: *const ::std::os::raw::c_char,
+        __af: ::std::os::raw::c_int,
+        __result_buf: *mut hostent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut hostent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endnetent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent() -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetent_r(
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyaddr_r(
+        __net: u32,
+        __type: ::std::os::raw::c_int,
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut netent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut netent,
+        __h_errnop: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct servent {
+    pub s_name: *mut ::std::os::raw::c_char,
+    pub s_aliases: *mut *mut ::std::os::raw::c_char,
+    pub s_port: ::std::os::raw::c_int,
+    pub s_proto: *mut ::std::os::raw::c_char,
+}
+impl Default for servent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setservent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endservent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent() -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname(
+        __name: *const ::std::os::raw::c_char,
+        __proto: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport(
+        __port: ::std::os::raw::c_int,
+        __proto: *const ::std::os::raw::c_char,
+    ) -> *mut servent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservent_r(
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __proto: *const ::std::os::raw::c_char,
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getservbyport_r(
+        __port: ::std::os::raw::c_int,
+        __proto: *const ::std::os::raw::c_char,
+        __result_buf: *mut servent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut servent,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct protoent {
+    pub p_name: *mut ::std::os::raw::c_char,
+    pub p_aliases: *mut *mut ::std::os::raw::c_char,
+    pub p_proto: ::std::os::raw::c_int,
+}
+impl Default for protoent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
+}
+#[pg_guard]
+extern "C" {
+    pub fn endprotoent();
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent() -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotoent_r(
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobyname_r(
+        __name: *const ::std::os::raw::c_char,
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getprotobynumber_r(
+        __proto: ::std::os::raw::c_int,
+        __result_buf: *mut protoent,
+        __buf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut protoent,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -8483,58 +6242,187 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+    pub fn getnetgrent(
+        __hostp: *mut *mut ::std::os::raw::c_char,
+        __userp: *mut *mut ::std::os::raw::c_char,
+        __domainp: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn innetgr(
+        __netgroup: *const ::std::os::raw::c_char,
+        __host: *const ::std::os::raw::c_char,
+        __user: *const ::std::os::raw::c_char,
+        __domain: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnetgrent_r(
+        __hostp: *mut *mut ::std::os::raw::c_char,
+        __userp: *mut *mut ::std::os::raw::c_char,
+        __domainp: *mut *mut ::std::os::raw::c_char,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rcmd(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_ushort,
+        __locuser: *const ::std::os::raw::c_char,
+        __remuser: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rcmd_af(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_ushort,
+        __locuser: *const ::std::os::raw::c_char,
+        __remuser: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rexec(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_int,
+        __name: *const ::std::os::raw::c_char,
+        __pass: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rexec_af(
+        __ahost: *mut *mut ::std::os::raw::c_char,
+        __rport: ::std::os::raw::c_int,
+        __name: *const ::std::os::raw::c_char,
+        __pass: *const ::std::os::raw::c_char,
+        __cmd: *const ::std::os::raw::c_char,
+        __fd2p: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ruserok(
+        __rhost: *const ::std::os::raw::c_char,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ruserok_af(
+        __rhost: *const ::std::os::raw::c_char,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iruserok(
+        __raddr: u32,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn iruserok_af(
+        __raddr: *const ::std::os::raw::c_void,
+        __suser: ::std::os::raw::c_int,
+        __remuser: *const ::std::os::raw::c_char,
+        __locuser: *const ::std::os::raw::c_char,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rresvport_af(
+        __alport: *mut ::std::os::raw::c_int,
+        __af: sa_family_t,
+    ) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct passwd {
-    pub pw_name: *mut ::std::os::raw::c_char,
-    pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: uid_t,
-    pub pw_gid: gid_t,
-    pub pw_change: __darwin_time_t,
-    pub pw_class: *mut ::std::os::raw::c_char,
-    pub pw_gecos: *mut ::std::os::raw::c_char,
-    pub pw_dir: *mut ::std::os::raw::c_char,
-    pub pw_shell: *mut ::std::os::raw::c_char,
-    pub pw_expire: __darwin_time_t,
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
 }
-impl Default for passwd {
+impl Default for addrinfo {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwuid(arg1: uid_t) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuid_r(
-        arg1: uid_t,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
+    pub fn getaddrinfo(
+        __name: *const ::std::os::raw::c_char,
+        __service: *const ::std::os::raw::c_char,
+        __req: *const addrinfo,
+        __pai: *mut *mut addrinfo,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwnam_r(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
-    ) -> ::std::os::raw::c_int;
+    pub fn freeaddrinfo(__ai: *mut addrinfo);
 }
 #[pg_guard]
 extern "C" {
-    pub fn getpwent() -> *mut passwd;
+    pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getnameinfo(
+        __sa: *const sockaddr,
+        __salen: socklen_t,
+        __host: *mut ::std::os::raw::c_char,
+        __hostlen: socklen_t,
+        __serv: *mut ::std::os::raw::c_char,
+        __servlen: socklen_t,
+        __flags: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct passwd {
+    pub pw_name: *mut ::std::os::raw::c_char,
+    pub pw_passwd: *mut ::std::os::raw::c_char,
+    pub pw_uid: __uid_t,
+    pub pw_gid: __gid_t,
+    pub pw_gecos: *mut ::std::os::raw::c_char,
+    pub pw_dir: *mut ::std::os::raw::c_char,
+    pub pw_shell: *mut ::std::os::raw::c_char,
+}
+impl Default for passwd {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
@@ -8544,86 +6432,63 @@ extern "C" {
 extern "C" {
     pub fn endpwent();
 }
-pub type uuid_t = __darwin_uuid_t;
-pub type uuid_string_t = __darwin_uuid_string_t;
 #[pg_guard]
 extern "C" {
-    pub static UUID_NULL: uuid_t;
+    pub fn getpwent() -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
+    pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_compare(
-        uu1: *mut ::std::os::raw::c_uchar,
-        uu2: *mut ::std::os::raw::c_uchar,
+    pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpwent_r(
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_generate_early_random(out: *mut ::std::os::raw::c_uchar);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_parse(
-        in_: *mut ::std::os::raw::c_char,
-        uu: *mut ::std::os::raw::c_uchar,
+    pub fn getpwuid_r(
+        __uid: __uid_t,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
+    pub fn getpwnam_r(
+        __name: *const ::std::os::raw::c_char,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn uuid_unparse_lower(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn uuid_unparse_upper(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-}
-#[pg_guard]
-extern "C" {
-    pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn user_from_uid(arg1: uid_t, arg2: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
-}
-#[pg_guard]
-extern "C" {
-    pub fn getpwuuid_r(
-        arg1: *mut ::std::os::raw::c_uchar,
-        arg2: *mut passwd,
-        arg3: *mut ::std::os::raw::c_char,
-        arg4: usize,
-        arg5: *mut *mut passwd,
+    pub fn fgetpwent_r(
+        __stream: *mut FILE,
+        __resultbuf: *mut passwd,
+        __buffer: *mut ::std::os::raw::c_char,
+        __buflen: usize,
+        __result: *mut *mut passwd,
     ) -> ::std::os::raw::c_int;
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -8978,783 +6843,347 @@ extern "C" {
 extern "C" {
     pub fn pg_srand48(seed: ::std::os::raw::c_long);
 }
+#[pg_guard]
+extern "C" {
+    pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn getpeereid(
+        sock: ::std::os::raw::c_int,
+        uid: *mut uid_t,
+        gid: *mut gid_t,
+    ) -> ::std::os::raw::c_int;
+}
 pub type float_t = f32;
 pub type double_t = f64;
 #[pg_guard]
 extern "C" {
-    pub fn __math_errhandling() -> ::std::os::raw::c_int;
+    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
+    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosf(arg1: f32) -> f32;
+    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acos(arg1: f64) -> f64;
+    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosl(arg1: u128) -> u128;
+    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinf(arg1: f32) -> f32;
+    pub fn acos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asin(arg1: f64) -> f64;
+    pub fn __acos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinl(arg1: u128) -> u128;
+    pub fn asin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanf(arg1: f32) -> f32;
+    pub fn __asin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan(arg1: f64) -> f64;
+    pub fn atan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanl(arg1: u128) -> u128;
+    pub fn __atan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+    pub fn atan2(__y: f64, __x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2(arg1: f64, arg2: f64) -> f64;
+    pub fn __atan2(__y: f64, __x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
+    pub fn cos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosf(arg1: f32) -> f32;
+    pub fn __cos(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cos(arg1: f64) -> f64;
+    pub fn sin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosl(arg1: u128) -> u128;
+    pub fn __sin(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinf(arg1: f32) -> f32;
+    pub fn tan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sin(arg1: f64) -> f64;
+    pub fn __tan(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinl(arg1: u128) -> u128;
+    pub fn cosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanf(arg1: f32) -> f32;
+    pub fn __cosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tan(arg1: f64) -> f64;
+    pub fn sinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanl(arg1: u128) -> u128;
+    pub fn __sinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acoshf(arg1: f32) -> f32;
+    pub fn tanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acosh(arg1: f64) -> f64;
+    pub fn __tanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn acoshl(arg1: u128) -> u128;
+    pub fn acosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinhf(arg1: f32) -> f32;
+    pub fn __acosh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinh(arg1: f64) -> f64;
+    pub fn asinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn asinhl(arg1: u128) -> u128;
+    pub fn __asinh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanhf(arg1: f32) -> f32;
+    pub fn atanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanh(arg1: f64) -> f64;
+    pub fn __atanh(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn atanhl(arg1: u128) -> u128;
+    pub fn exp(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn coshf(arg1: f32) -> f32;
+    pub fn __exp(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn cosh(arg1: f64) -> f64;
+    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn coshl(arg1: u128) -> u128;
+    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinhf(arg1: f32) -> f32;
+    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinh(arg1: f64) -> f64;
+    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sinhl(arg1: u128) -> u128;
+    pub fn log(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanhf(arg1: f32) -> f32;
+    pub fn __log(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanh(arg1: f64) -> f64;
+    pub fn log10(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tanhl(arg1: u128) -> u128;
+    pub fn __log10(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expf(arg1: f32) -> f32;
+    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp(arg1: f64) -> f64;
+    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expl(arg1: u128) -> u128;
+    pub fn expm1(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2f(arg1: f32) -> f32;
+    pub fn __expm1(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2(arg1: f64) -> f64;
+    pub fn log1p(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn exp2l(arg1: u128) -> u128;
+    pub fn __log1p(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1f(arg1: f32) -> f32;
+    pub fn logb(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1(arg1: f64) -> f64;
+    pub fn __logb(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn expm1l(arg1: u128) -> u128;
+    pub fn exp2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logf(arg1: f32) -> f32;
+    pub fn __exp2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log(arg1: f64) -> f64;
+    pub fn log2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logl(arg1: u128) -> u128;
+    pub fn __log2(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10f(arg1: f32) -> f32;
+    pub fn pow(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10(arg1: f64) -> f64;
+    pub fn __pow(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log10l(arg1: u128) -> u128;
+    pub fn sqrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2f(arg1: f32) -> f32;
+    pub fn __sqrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2(arg1: f64) -> f64;
+    pub fn hypot(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log2l(arg1: u128) -> u128;
+    pub fn __hypot(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1pf(arg1: f32) -> f32;
+    pub fn cbrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1p(arg1: f64) -> f64;
+    pub fn __cbrt(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn log1pl(arg1: u128) -> u128;
+    pub fn ceil(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logbf(arg1: f32) -> f32;
+    pub fn __ceil(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logb(arg1: f64) -> f64;
+    pub fn fabs(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn logbl(arg1: u128) -> u128;
+    pub fn __fabs(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+    pub fn floor(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn __floor(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
+    pub fn fmod(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn __fmod(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
+    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+    pub fn drem(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn __drem(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
+    pub fn significand(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __significand(__x: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn copysign(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
+    pub fn __copysign(__x: f64, __y: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabs(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fabsl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrt(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn cbrtl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypot(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn pow(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn powl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrt(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sqrtl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erff(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erf(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn erfcl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lgammal(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn tgammal(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceilf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceil(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn ceill(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floor(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn floorl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyint(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nearbyintl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rint(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn rintl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn round(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn roundl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncf(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn trunc(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn truncl(arg1: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmod(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainder(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysign(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdim(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmax(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminf(arg1: f32, arg2: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmin(arg1: f64, arg2: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fminl(arg1: u128, arg2: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __inff() -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __inf() -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __infl() -> u128;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __nan() -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp10f(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __exp10(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cospif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __cospi(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinpif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sinpi(arg1: f64) -> f64;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanpif(arg1: f32) -> f32;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __tanpi(arg1: f64) -> f64;
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincosf_stret(arg1: f32) -> __float2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincos_stret(arg1: f64) -> __double2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincospif_stret(arg1: f32) -> __float2;
-}
-#[pg_guard]
-extern "C" {
-    pub fn __sincospi_stret(arg1: f64) -> __double2;
+    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -9762,7 +7191,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __j0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn j1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9770,7 +7207,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn y0(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9778,31 +7223,47 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub fn __y1(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
     pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn scalb(arg1: f64, arg2: f64) -> f64;
+    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub static mut signgam: ::std::os::raw::c_int;
+    pub fn erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn __erf(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn drem(arg1: f64, arg2: f64) -> f64;
+    pub fn __erfc(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn lgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
@@ -9810,25 +7271,1369 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn significand(arg1: f64) -> f64;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
-}
-impl Default for exception {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+    pub fn __gamma(arg1: f64) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn explicit_bzero(buf: *mut ::std::os::raw::c_void, len: usize);
+    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafter(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafter(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttoward(__x: f64, __y: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainder(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainder(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyint(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn round(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __round(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn trunc(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __trunc(__x: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdim(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdim(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmax(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmax(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmin(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmin(__x: f64, __y: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalb(__x: f64, __n: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalb(__x: f64, __n: f64) -> f64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atan2f(__y: f32, __x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atan2f(__y: f32, __x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cosf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn coshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __coshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acoshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acoshf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanhf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log10f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log10f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expm1f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expm1f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log1pf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log1pf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logbf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logbf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn exp2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log2f(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn powf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __powf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sqrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sqrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn hypotf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __hypotf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cbrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cbrtf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ceilf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ceilf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fabsf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fabsf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn floorf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __floorf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmodf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmodf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dremf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __dremf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significandf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __significandf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn copysignf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __copysignf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y1f(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erff(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erff(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfcf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __gammaf(arg1: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainderf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainderf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyintf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __roundf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn truncf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __truncf(__x: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdimf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdimf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fminf(__x: f32, __y: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbf(__x: f32, __n: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbf(__x: f32, __n: f32) -> f32;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atan2l(__y: u128, __x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atan2l(__y: u128, __x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cosl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn coshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __coshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn acoshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __acoshl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __asinhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn atanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __atanhl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log10l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log10l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn expm1l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __expm1l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log1pl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log1pl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn logbl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __logbl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn exp2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __exp2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn log2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __log2l(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn powl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __powl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sqrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __sqrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn hypotl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __hypotl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn cbrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __cbrtl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ceill(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ceill(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fabsl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fabsl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn floorl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __floorl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmodl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmodl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn dreml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __dreml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn significandl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __significandl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn copysignl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __copysignl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn j1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __j1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y0l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn y1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __y1l(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn erfcl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __erfcl(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn tgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __tgammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __gammal(arg1: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn rintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __rintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remainderl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn nearbyintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __nearbyintl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn roundl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __roundl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn truncl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __truncl(__x: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fdiml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fminl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fminl(__x: u128, __y: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn scalbl(__x: u128, __n: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __scalbl(__x: u128, __n: u128) -> u128;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut signgam: ::std::os::raw::c_int;
+}
+pub const FP_NAN: ::std::os::raw::c_uint = 0;
+pub const FP_INFINITE: ::std::os::raw::c_uint = 1;
+pub const FP_ZERO: ::std::os::raw::c_uint = 2;
+pub const FP_SUBNORMAL: ::std::os::raw::c_uint = 3;
+pub const FP_NORMAL: ::std::os::raw::c_uint = 4;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
 }
 #[pg_guard]
 extern "C" {
@@ -9950,28 +8755,39 @@ extern "C" {
         include_command_not_found: bool,
     ) -> bool;
 }
-pub type jmp_buf = [::std::os::raw::c_int; 37usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 38usize];
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
+}
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
-    pub fn setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
+    pub fn __sigsetjmp(
+        __env: *mut __jmp_buf_tag,
+        __savemask: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _setjmp(arg1: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn _setjmp(__env: *mut __jmp_buf_tag) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn _longjmp(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
+    pub fn longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
 }
 #[pg_guard]
 extern "C" {
-    pub fn longjmperror();
+    pub fn _longjmp(__env: *mut __jmp_buf_tag, __val: ::std::os::raw::c_int);
 }
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[pg_guard]
 extern "C" {
     pub fn errstart(elevel: ::std::os::raw::c_int, domain: *const ::std::os::raw::c_char) -> bool;
@@ -11692,239 +10508,83 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
+#[pg_guard]
+extern "C" {
+    pub fn fcntl(
+        __fd: ::std::os::raw::c_int,
+        __cmd: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fbootstraptransfer {
-    pub fbt_offset: off_t,
-    pub fbt_length: usize,
-    pub fbt_buffer: *mut ::std::os::raw::c_void,
-}
-impl Default for fbootstraptransfer {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-pub type fbootstraptransfer_t = fbootstraptransfer;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn open(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __oflag: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn openat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
+        __fd: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __oflag: ::std::os::raw::c_int,
         ...
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn creat(arg1: *const ::std::os::raw::c_char, arg2: mode_t) -> ::std::os::raw::c_int;
+    pub fn creat(__file: *const ::std::os::raw::c_char, __mode: mode_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn fcntl(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        ...
+    pub fn lockf(
+        __fd: ::std::os::raw::c_int,
+        __cmd: ::std::os::raw::c_int,
+        __len: off_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn openx_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: filesec_t,
+    pub fn posix_fadvise(
+        __fd: ::std::os::raw::c_int,
+        __offset: off_t,
+        __len: off_t,
+        __advise: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn open_dprotected_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn flock(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int)
-        -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_init() -> filesec_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_free(arg1: filesec_t);
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_get_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_query_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_set_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
-        arg3: *const ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn filesec_unset_property(
-        arg1: filesec_t,
-        arg2: filesec_property_t,
+    pub fn posix_fallocate(
+        __fd: ::std::os::raw::c_int,
+        __offset: off_t,
+        __len: off_t,
     ) -> ::std::os::raw::c_int;
 }
 pub type XLogRecPtr = uint64;
@@ -12846,32 +11506,18 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
-#[pg_guard]
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-#[pg_guard]
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-#[pg_guard]
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[pg_guard]
 extern "C" {
@@ -12879,48 +11525,88 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+    pub fn time(__timer: *mut time_t) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+    pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
 }
 #[pg_guard]
 extern "C" {
-    pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn gmtime(arg1: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn localtime(arg1: *const time_t) -> *mut tm;
-}
-#[pg_guard]
-extern "C" {
-    pub fn mktime(arg1: *mut tm) -> time_t;
+    pub fn mktime(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
     pub fn strftime(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: *const ::std::os::raw::c_char,
-        arg4: *const tm,
+        __s: *mut ::std::os::raw::c_char,
+        __maxsize: usize,
+        __format: *const ::std::os::raw::c_char,
+        __tp: *const tm,
     ) -> usize;
 }
 #[pg_guard]
 extern "C" {
-    pub fn strptime(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut tm,
+    pub fn strftime_l(
+        __s: *mut ::std::os::raw::c_char,
+        __maxsize: usize,
+        __format: *const ::std::os::raw::c_char,
+        __tp: *const tm,
+        __loc: locale_t,
+    ) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime(__timer: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime(__timer: *const time_t) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn asctime_r(
+        __tp: *const tm,
+        __buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
-    pub fn time(arg1: *mut time_t) -> time_t;
+    pub fn ctime_r(
+        __timer: *const time_t,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[pg_guard]
 extern "C" {
@@ -12928,59 +11614,31 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn asctime_r(
-        arg1: *const tm,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub static mut daylight: ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn ctime_r(
-        arg1: *const time_t,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub static mut timezone: ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+    pub fn timegm(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+    pub fn timelocal(__tp: *mut tm) -> time_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn posix2time(arg1: time_t) -> time_t;
+    pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tzsetwall();
+    pub fn nanosleep(
+        __requested_time: *const timespec,
+        __remaining: *mut timespec,
+    ) -> ::std::os::raw::c_int;
 }
-#[pg_guard]
-extern "C" {
-    pub fn time2posix(arg1: time_t) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timelocal(arg1: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn timegm(arg1: *mut tm) -> time_t;
-}
-#[pg_guard]
-extern "C" {
-    pub fn nanosleep(__rqtp: *const timespec, __rmtp: *mut timespec) -> ::std::os::raw::c_int;
-}
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[pg_guard]
 extern "C" {
     pub fn clock_getres(__clock_id: clockid_t, __res: *mut timespec) -> ::std::os::raw::c_int;
@@ -12991,15 +11649,56 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-}
-#[pg_guard]
-extern "C" {
     pub fn clock_settime(__clock_id: clockid_t, __tp: *const timespec) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn timespec_get(ts: *mut timespec, base: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn clock_nanosleep(
+        __clock_id: clockid_t,
+        __flags: ::std::os::raw::c_int,
+        __req: *const timespec,
+        __rem: *mut timespec,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn clock_getcpuclockid(__pid: pid_t, __clock_id: *mut clockid_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_create(
+        __clock_id: clockid_t,
+        __evp: *mut sigevent,
+        __timerid: *mut timer_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_settime(
+        __timerid: timer_t,
+        __flags: ::std::os::raw::c_int,
+        __value: *const itimerspec,
+        __ovalue: *mut itimerspec,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_gettime(__timerid: timer_t, __value: *mut itimerspec) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn timespec_get(
+        __ts: *mut timespec,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 pub type instr_time = timespec;
 #[repr(C)]
@@ -16379,104 +15078,82 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
 }
+pub const DT_UNKNOWN: ::std::os::raw::c_uint = 0;
+pub const DT_FIFO: ::std::os::raw::c_uint = 1;
+pub const DT_CHR: ::std::os::raw::c_uint = 2;
+pub const DT_DIR: ::std::os::raw::c_uint = 4;
+pub const DT_BLK: ::std::os::raw::c_uint = 6;
+pub const DT_REG: ::std::os::raw::c_uint = 8;
+pub const DT_LNK: ::std::os::raw::c_uint = 10;
+pub const DT_SOCK: ::std::os::raw::c_uint = 12;
+pub const DT_WHT: ::std::os::raw::c_uint = 14;
+pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
+pub type DIR = __dirstream;
+#[pg_guard]
+extern "C" {
+    pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+    pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_opendir$INODE64"]
-    pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+    pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_readdir$INODE64"]
-    pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+    pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_readdir_r$INODE64"]
     pub fn readdir_r(
-        arg1: *mut DIR,
-        arg2: *mut dirent,
-        arg3: *mut *mut dirent,
+        __dirp: *mut DIR,
+        __entry: *mut dirent,
+        __result: *mut *mut dirent,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_rewinddir$INODE64"]
-    pub fn rewinddir(arg1: *mut DIR);
+    pub fn rewinddir(__dirp: *mut DIR);
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_seekdir$INODE64"]
-    pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+    pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_telldir$INODE64"]
-    pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+    pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_fdopendir$INODE64"]
-    pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+    pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_alphasort$INODE64"]
-    pub fn alphasort(arg1: *mut *const dirent, arg2: *mut *const dirent) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}_scandir$INODE64"]
     pub fn scandir(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut *mut dirent,
-        arg3: ::std::option::Option<
+        __dir: *const ::std::os::raw::c_char,
+        __namelist: *mut *mut *mut dirent,
+        __selector: ::std::option::Option<
             unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
         >,
-        arg4: ::std::option::Option<
+        __cmp: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut *const dirent,
                 arg2: *mut *const dirent,
@@ -16486,29 +15163,16 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_scandir_b$INODE64"]
-    pub fn scandir_b(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut *mut dirent,
-        arg3: *mut ::std::os::raw::c_void,
-        arg4: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
+    pub fn alphasort(__e1: *mut *const dirent, __e2: *mut *const dirent) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
     pub fn getdirentries(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    #[link_name = "\u{1}___opendir2$INODE64"]
-    pub fn __opendir2(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int)
-        -> *mut DIR;
+        __fd: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+        __basep: *mut __off_t,
+    ) -> __ssize_t;
 }
 pub type File = ::std::os::raw::c_int;
 #[pg_guard]
@@ -23825,160 +22489,651 @@ extern "C" {
         nulls: *mut *mut bool,
     ) -> ::std::os::raw::c_int;
 }
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
+    _bindgen_union_align: u64,
+}
+impl Default for sigval {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+    _bindgen_union_align: [u64; 14usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+    _bindgen_union_align: [u64; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub const SI_ASYNCNL: ::std::os::raw::c_int = -60;
+pub const SI_DETHREAD: ::std::os::raw::c_int = -7;
+pub const SI_TKILL: ::std::os::raw::c_int = -6;
+pub const SI_SIGIO: ::std::os::raw::c_int = -5;
+pub const SI_ASYNCIO: ::std::os::raw::c_int = -4;
+pub const SI_MESGQ: ::std::os::raw::c_int = -3;
+pub const SI_TIMER: ::std::os::raw::c_int = -2;
+pub const SI_QUEUE: ::std::os::raw::c_int = -1;
+pub const SI_USER: ::std::os::raw::c_int = 0;
+pub const SI_KERNEL: ::std::os::raw::c_int = 128;
+pub type _bindgen_ty_10 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: ::std::os::raw::c_uint = 1;
+pub const ILL_ILLOPN: ::std::os::raw::c_uint = 2;
+pub const ILL_ILLADR: ::std::os::raw::c_uint = 3;
+pub const ILL_ILLTRP: ::std::os::raw::c_uint = 4;
+pub const ILL_PRVOPC: ::std::os::raw::c_uint = 5;
+pub const ILL_PRVREG: ::std::os::raw::c_uint = 6;
+pub const ILL_COPROC: ::std::os::raw::c_uint = 7;
+pub const ILL_BADSTK: ::std::os::raw::c_uint = 8;
+pub const ILL_BADIADDR: ::std::os::raw::c_uint = 9;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: ::std::os::raw::c_uint = 1;
+pub const FPE_INTOVF: ::std::os::raw::c_uint = 2;
+pub const FPE_FLTDIV: ::std::os::raw::c_uint = 3;
+pub const FPE_FLTOVF: ::std::os::raw::c_uint = 4;
+pub const FPE_FLTUND: ::std::os::raw::c_uint = 5;
+pub const FPE_FLTRES: ::std::os::raw::c_uint = 6;
+pub const FPE_FLTINV: ::std::os::raw::c_uint = 7;
+pub const FPE_FLTSUB: ::std::os::raw::c_uint = 8;
+pub const FPE_FLTUNK: ::std::os::raw::c_uint = 14;
+pub const FPE_CONDTRAP: ::std::os::raw::c_uint = 15;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: ::std::os::raw::c_uint = 1;
+pub const SEGV_ACCERR: ::std::os::raw::c_uint = 2;
+pub const SEGV_BNDERR: ::std::os::raw::c_uint = 3;
+pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
+pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
+pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
+pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
+pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
+pub const BUS_OBJERR: ::std::os::raw::c_uint = 3;
+pub const BUS_MCEERR_AR: ::std::os::raw::c_uint = 4;
+pub const BUS_MCEERR_AO: ::std::os::raw::c_uint = 5;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: ::std::os::raw::c_uint = 1;
+pub const CLD_KILLED: ::std::os::raw::c_uint = 2;
+pub const CLD_DUMPED: ::std::os::raw::c_uint = 3;
+pub const CLD_TRAPPED: ::std::os::raw::c_uint = 4;
+pub const CLD_STOPPED: ::std::os::raw::c_uint = 5;
+pub const CLD_CONTINUED: ::std::os::raw::c_uint = 6;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
+pub const POLL_IN: ::std::os::raw::c_uint = 1;
+pub const POLL_OUT: ::std::os::raw::c_uint = 2;
+pub const POLL_MSG: ::std::os::raw::c_uint = 3;
+pub const POLL_ERR: ::std::os::raw::c_uint = 4;
+pub const POLL_PRI: ::std::os::raw::c_uint = 5;
+pub const POLL_HUP: ::std::os::raw::c_uint = 6;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+    _bindgen_union_align: [u64; 6usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: ::std::os::raw::c_uint = 0;
+pub const SIGEV_NONE: ::std::os::raw::c_uint = 1;
+pub const SIGEV_THREAD: ::std::os::raw::c_uint = 2;
+pub const SIGEV_THREAD_ID: ::std::os::raw::c_uint = 4;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[pg_guard]
 extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+    pub fn __sysv_signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t)
+        -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+    pub fn signal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn bsd_signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
+    pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn ssignal(__sig: ::std::os::raw::c_int, __handler: __sighandler_t) -> __sighandler_t;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_kill(arg1: pthread_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn pthread_sigmask(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigset_t,
-        arg3: *mut sigset_t,
-    ) -> ::std::os::raw::c_int;
+    pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaction(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigaction,
-        arg3: *mut sigaction,
-    ) -> ::std::os::raw::c_int;
+    pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaddset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
+    pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigdelset(arg1: *mut sigset_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn siggetmask() -> ::std::os::raw::c_int;
+}
+pub type sig_t = __sighandler_t;
+#[pg_guard]
+extern "C" {
+    pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn siginterrupt(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigismember(arg1: *const sigset_t, arg2: ::std::os::raw::c_int)
+    pub fn sigaddset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigdelset(__set: *mut sigset_t, __signo: ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigismember(
+        __set: *const sigset_t,
+        __signo: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+    _bindgen_union_align: u64,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[pg_guard]
 extern "C" {
     pub fn sigprocmask(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const sigset_t,
-        arg3: *mut sigset_t,
+        __how: ::std::os::raw::c_int,
+        __set: *const sigset_t,
+        __oset: *mut sigset_t,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigset(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
+    pub fn sigaction(
+        __sig: ::std::os::raw::c_int,
+        __act: *const sigaction,
+        __oact: *mut sigaction,
+    ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+    pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
     pub fn sigwait(
-        arg1: *const sigset_t,
-        arg2: *mut ::std::os::raw::c_int,
+        __set: *const sigset_t,
+        __sig: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
+    pub fn sigwaitinfo(__set: *const sigset_t, __info: *mut siginfo_t) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
-    pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
-    pub fn sigvec(
-        arg1: ::std::os::raw::c_int,
-        arg2: *mut sigvec,
-        arg3: *mut sigvec,
+    pub fn sigtimedwait(
+        __set: *const sigset_t,
+        __info: *mut siginfo_t,
+        __timeout: *const timespec,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigqueue(
+        __pid: __pid_t,
+        __sig: ::std::os::raw::c_int,
+        __val: sigval,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+    _bindgen_union_align: u64,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigreturn(__scp: *mut sigcontext) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn siginterrupt(
+        __sig: ::std::os::raw::c_int,
+        __interrupt: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+pub const SS_ONSTACK: ::std::os::raw::c_uint = 1;
+pub const SS_DISABLE: ::std::os::raw::c_uint = 2;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
+#[pg_guard]
+extern "C" {
+    pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[pg_guard]
+extern "C" {
+    pub fn sigstack(__ss: *mut sigstack, __oss: *mut sigstack) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pthread_sigmask(
+        __how: ::std::os::raw::c_int,
+        __newmask: *const __sigset_t,
+        __oldmask: *mut __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pthread_kill(
+        __threadid: pthread_t,
+        __signo: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
 }
 pub type pg_time_t = int64;
 #[repr(C)]
@@ -24626,9 +23781,8 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -56449,6 +55603,11 @@ impl Default for __va_list_tag {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -28,13 +28,13 @@ no-default-features = true
 [dependencies]
 colored = "2.0.0"
 lazy_static = "1.4.0"
-libc = "0.2.89"
+libc = "0.2.94"
 pgx = { path = "../pgx", default-features = false, version= "0.1.20"}
 pgx-macros = { path = "../pgx-macros", version= "0.1.20"}
 pgx-utils = { path = "../pgx-utils", version= "0.1.20"}
 postgres = "0.19.1"
-regex = "1.4.5"
-serde = "1.0.124"
+regex = "1.5.2"
+serde = "1.0.125"
 serde_json = "1.0.64"
 shutdown_hooks = "0.1.0"
 time = "0.2.26"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -12,17 +12,17 @@ readme = "README.md"
 
 [dependencies]
 colored = "2.0.0"
-dirs = "3.0.1"
+dirs = "3.0.2"
 env_proxy = "0.4.1"
 proc-macro2 = "1.0.26"
 quote = "1.0.9"
-regex = "1.4.5"
+regex = "1.5.2"
 rttp_client = "0.1.0"
 serde = "1.0.125"
 serde_derive = "1.0.125"
 serde-xml-rs = "0.4.1"
 serde_json = "1.0.64"
-syn = { version = "1.0.69", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.71", features = [ "extra-traits", "full", "fold", "parsing" ] }
 toml = "0.5.8"
 unescape = "0.1.0"
 url = "2.2.1"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -26,7 +26,7 @@ macro_rules! exit_with_error {
     ($msg:expr,) => ({ exit_with_error!($msg) });
     ($fmt:expr, $($arg:tt)+) => ({
         use colored::Colorize;
-        eprint!("{} ", "     [error]".bold().red());
+        eprint!("{} ", "      [error]".bold().red());
         eprintln!($fmt, $($arg)+);
         std::process::exit(1);
     });
@@ -102,7 +102,7 @@ pub fn createdb(
         return Ok(false);
     }
 
-    println!("{} database {}", "    Creating".bold().green(), dbname);
+    println!("{} database {}", "     Creating".bold().green(), dbname);
     let mut command = Command::new(pg_config.createdb_path()?);
     command
         .env_remove("PGDATABASE")

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -30,8 +30,8 @@ no-default-features = true
 enum-primitive-derive = "0.2.1"
 num-traits = "0.2.14"
 seahash = "4.1.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.1.20" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.1.20" }
+pgx-macros = { path = "../pgx-macros/", version = "0.1.21" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.1.21" }
 serde = { version = "1.0.125", features = [ "derive" ] }
 serde_cbor = "0.11.1"
 serde_json = "1.0.64"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = "1.0.64"
 time = "0.2.26"
 atomic-traits = "0.2.0"
 heapless = "0.6.1"
-hash32 = "0.2.1"
+hash32 = "=0.1.1"
 uuid = { version = "0.8.2", features = [ "v4" ] } 
 once_cell = "1.7.2"
 bitflags = "1.2.1"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = "1.0.64"
 time = "0.2.26"
 atomic-traits = "0.2.0"
 heapless = "0.6.1"
-hash32 = "0.1.1"
+hash32 = "0.2.1"
 uuid = { version = "0.8.2", features = [ "v4" ] } 
 once_cell = "1.7.2"
 bitflags = "1.2.1"

--- a/pgx/src/enum_helper.rs
+++ b/pgx/src/enum_helper.rs
@@ -30,10 +30,12 @@ pub fn lookup_enum_by_oid(enumval: pg_sys::Oid) -> (String, pg_sys::Oid, f32) {
     let en = unsafe { pgx_GETSTRUCT(tup) } as pg_sys::Form_pg_enum;
     let en = unsafe { en.as_ref() }.unwrap();
     let result = (
-        unsafe { std::ffi::CStr::from_ptr(en.enumlabel.data.as_ptr() as *const std::os::raw::c_char) }
-            .to_str()
-            .unwrap()
-            .to_string(),
+        unsafe {
+            std::ffi::CStr::from_ptr(en.enumlabel.data.as_ptr() as *const std::os::raw::c_char)
+        }
+        .to_str()
+        .unwrap()
+        .to_string(),
         en.enumtypid,
         en.enumsortorder as f32,
     );


### PR DESCRIPTION
`pgx` v0.1.21 is a minor feature release with the following features:

* aarch64 support was added (#127)
* add Nix flake (#124)
* `cargo-pgx pgx init` does `initdb` (#123)
* Improve handling of feature flags (#118)
* Allow overriding function names and returning schema-qualified type (#117)
* update dependencies (#122).
* (docs) Add caveat about reconnecting after updating extension (#116)

There were the following fixes:

* (`cargo-pgx`) on init, lazy fetch version list (#119)

To upgrade, please run:

```
$ cargo install cargo-pgx --version 0.1.21
```

Also, make sure to update your Cargo.toml dependencies.

Signed-off-by: Ana Hobden <operator@hoverbear.org>