### PR TITLE
feat: --pg_config in cargo-pgx package/install

### DIFF
--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -248,6 +248,7 @@ $ cargo pgx install --help
 
 OPTIONS:
         --features <features>...    additional cargo features to activate (default is '--no-default-features')
+    -c, --pg_config <pg_config>     the `pg_config` path (default is first in $PATH)
 ```
 
 ## Testing Your Extension
@@ -319,7 +320,8 @@ $ cargo pgx package --help
      -V, --version    Prints version information
 
 OPTIONS:
-        --features <features>...    additional cargo features to activate (default is '--no-default-features')
+        --features <features>...        additional cargo features to activate (default is '--no-default-features')
+        -c, --pg_config <pg_config>     the `pg_config` path (default is first in $PATH)
 ```
 
 ## Dump Your Extension Schema

--- a/cargo-pgx/src/cli.yml
+++ b/cargo-pgx/src/cli.yml
@@ -77,18 +77,28 @@ subcommands:
                     short: r
                     long: release
                     help: compile for release mode (default is debug)
+                - pg_config:
+                    short: c
+                    long: pg_config
+                    takes_value: true
+                    help: the `pg_config` path (default is first in $PATH)
                 - features:
                     long: features
                     help: additional cargo features to activate (default is '--no-default-features')
                     takes_value: true
                     multiple: true
           - package:
-              about: create an installation package directory (in ./target/[debug|release]/extname-pgXX/) for the Postgres installation specified by whatever "pg_config" is currently on your $PATH
+              about: create an installation package directory (in ./target/[debug|release]/extname-pgXX/).
               args:
                 - debug:
                     short: d
                     long: debug
                     help: compile for debug mode (default is release)
+                - pg_config:
+                    short: c
+                    long: pg_config
+                    takes_value: true
+                    help: the `pg_config` path (default is first in $PATH)
                 - features:
                     long: features
                     help: additional cargo features to activate (default is '--no-default-features')

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -147,8 +147,11 @@ fn do_it() -> std::result::Result<(), std::io::Error> {
                         }
                     },
 
-                    // otherwise, the user just ran "cargo pgx install", and we use whatever "pg_config" is on the path
-                    Err(_) => PgConfig::from_path(),
+                    // otherwise, the user just ran "cargo pgx install", and we use whatever "pg_config" is configured
+                    Err(_) => match install.value_of("pg_config") {
+                        None => PgConfig::from_path(),
+                        Some(config) => PgConfig::new(PathBuf::from(config)),
+                    },
                 };
 
                 install_extension(&pg_config, is_release, None, features)
@@ -159,8 +162,10 @@ fn do_it() -> std::result::Result<(), std::io::Error> {
                     .values_of("features")
                     .map(|v| v.collect())
                     .unwrap_or(vec![]);
-                let pg_config = PgConfig::from_path(); // use whatever "pg_config" is on the path
-
+                let pg_config = match package.value_of("pg_config") {
+                    None => PgConfig::from_path(),
+                    Some(config) => PgConfig::new(PathBuf::from(config)),
+                };
                 package_extension(&pg_config, is_debug, features)
             }
             ("run", Some(run)) => {

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
             ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check ${./.}
             touch $out # it worked!
           '';
+          pkgs-cargo-pgx = pkgs.cargo-pgx.out;
         });
     };
 }


### PR DESCRIPTION
Allows users to set `--pg_config` during the `cargo-pgx pgx install` and `cargo-pgx pgx package` commands.

Also slips the crate output into the nix checks, so I don't accidentally push bad code as much.