### PR TITLE
chore: pgx-pg-sys optionally don't mutate source tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ pg_test = [ "pgx-tests/pg_test" ]
 [package.metadata.docs.rs]
 features = ["pg13"]
 no-default-features = true
+rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 cargo-pgx = { path = "cargo-pgx" }

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -103,35 +103,37 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             format!("unable to generate oids for pg{}", major_version)
         );
 
-        let mut bindings_file = out_dir.clone();
-        bindings_file.push(&format!("pg{}.rs", major_version));
-        handle_result!(
-            write_rs_file(
-                rewritten_items,
-                &bindings_file,
-                quote! {
-                    use crate as pg_sys;
-                    use pgx_macros::*;
-                    use crate::PgNode;
-                }
-            ),
-            format!(
-                "Unable to write bindings file for pg{} to `{}`",
-                major_version,
-                bindings_file.display()
-            )
-        );
+        if std::env::var("PGX_PG_SYS_SKIP_BINDING_REWRITE").unwrap_or("false".into()) != "1" {
+            let mut bindings_file = out_dir.clone();
+            bindings_file.push(&format!("pg{}.rs", major_version));
+            handle_result!(
+                write_rs_file(
+                    rewritten_items,
+                    &bindings_file,
+                    quote! {
+                        use crate as pg_sys;
+                        use pgx_macros::*;
+                        use crate::PgNode;
+                    }
+                ),
+                format!(
+                    "Unable to write bindings file for pg{} to `{}`",
+                    major_version,
+                    bindings_file.display()
+                )
+            );
 
-        let mut oids_file = out_dir.clone();
-        oids_file.push(&format!("pg{}_oids.rs", major_version));
-        handle_result!(
-            write_rs_file(oids, &oids_file, quote! {}),
-            format!(
-                "Unable to write oids file for pg{} to `{}`",
-                major_version,
-                oids_file.display()
-            )
-        );
+            let mut oids_file = out_dir.clone();
+            oids_file.push(&format!("pg{}_oids.rs", major_version));
+            handle_result!(
+                write_rs_file(oids, &oids_file, quote! {}),
+                format!(
+                    "Unable to write oids file for pg{} to `{}`",
+                    major_version,
+                    oids_file.display()
+                )
+            );
+        };
     });
 
     // compile the cshim for each binding

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -541,16 +541,20 @@ fn build_shim_for_version(
     eprintln!("shim_dst={}", shim_dst.display());
 
     std::fs::create_dir_all(shim_dst).unwrap();
-    std::fs::copy(
-        format!("{}/Makefile", shim_src.display()),
-        format!("{}/Makefile", shim_dst.display()),
-    )
-    .unwrap();
-    std::fs::copy(
-        format!("{}/pgx-cshim.c", shim_src.display()),
-        format!("{}/pgx-cshim.c", shim_dst.display()),
-    )
-    .unwrap();
+
+    if !std::path::Path::new(&format!("{}/Makefile", shim_dst.display())).exists() {
+        std::fs::copy(
+            format!("{}/Makefile", shim_src.display()),
+            format!("{}/Makefile", shim_dst.display()),
+        ).unwrap();
+    }
+
+    if !std::path::Path::new(&format!("{}/pgx-cshim.c", shim_dst.display())).exists() {
+        std::fs::copy(
+            format!("{}/pgx-cshim.c", shim_src.display()),
+            format!("{}/pgx-cshim.c", shim_dst.display()),
+        ).unwrap();
+    }
 
     let rc = run_command(
         Command::new("make")

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -504,7 +504,11 @@ fn run_bindgen(
     syn::parse_file(bindings.to_string().as_str()).map_err(|e| From::from(e))
 }
 
-fn build_shim(shim_src: &PathBuf, shim_dst: &PathBuf, pg_config: &PgConfig) -> Result<(), std::io::Error> {
+fn build_shim(
+    shim_src: &PathBuf,
+    shim_dst: &PathBuf,
+    pg_config: &PgConfig,
+) -> Result<(), std::io::Error> {
     let major_version = pg_config.major_version()?;
     let mut libpgx_cshim: PathBuf = shim_dst.clone();
 
@@ -524,7 +528,11 @@ fn build_shim(shim_src: &PathBuf, shim_dst: &PathBuf, pg_config: &PgConfig) -> R
     Ok(())
 }
 
-fn build_shim_for_version(shim_src: &PathBuf, shim_dst: &PathBuf, pg_config: &PgConfig) -> Result<(), std::io::Error> {
+fn build_shim_for_version(
+    shim_src: &PathBuf,
+    shim_dst: &PathBuf,
+    pg_config: &PgConfig,
+) -> Result<(), std::io::Error> {
     let path_env = prefix_path(pg_config.parent_path());
     let major_version = pg_config.major_version()?;
 
@@ -536,11 +544,13 @@ fn build_shim_for_version(shim_src: &PathBuf, shim_dst: &PathBuf, pg_config: &Pg
     std::fs::copy(
         format!("{}/Makefile", shim_src.display()),
         format!("{}/Makefile", shim_dst.display()),
-    ).unwrap();
+    )
+    .unwrap();
     std::fs::copy(
         format!("{}/pgx-cshim.c", shim_src.display()),
         format!("{}/pgx-cshim.c", shim_dst.display()),
-    ).unwrap();
+    )
+    .unwrap();
 
     let rc = run_command(
         Command::new("make")

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -106,11 +106,12 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             format!("unable to generate oids for pg{}", major_version)
         );
 
-        let bindings_files = if std::env::var("PGX_PG_SYS_SKIP_BINDING_REWRITE").unwrap_or("false".into()) != "1" {
-            vec![out_dir.clone(), src_dir.clone()]
-        } else {
-            vec![out_dir.clone()]
-        };
+        let bindings_files =
+            if std::env::var("PGX_PG_SYS_SKIP_BINDING_REWRITE").unwrap_or("false".into()) != "1" {
+                vec![out_dir.clone(), src_dir.clone()]
+            } else {
+                vec![out_dir.clone()]
+            };
         for mut bindings_file in bindings_files {
             bindings_file.push(&format!("pg{}.rs", major_version));
             handle_result!(
@@ -140,7 +141,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                     oids_file.display()
                 )
             );
-        };
+        }
     });
 
     // compile the cshim for each binding

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -28,13 +28,32 @@ pub use submodules::*;
 //
 
 // feature gate each pg version module
-#[cfg(feature = "pg10")]
+#[cfg(all(feature = "pg10", not(docsrs)))]
+mod pg10 {
+    include!(concat!(env!("OUT_DIR"), "/pg10.rs"));
+}
+#[cfg(all(feature = "pg10", docsrs))]
 mod pg10;
-#[cfg(feature = "pg11")]
+
+#[cfg(all(feature = "pg11", not(docsrs)))]
+mod pg11 {
+    include!(concat!(env!("OUT_DIR"), "/pg11.rs"));
+}
+#[cfg(all(feature = "pg11", docsrs))]
 mod pg11;
-#[cfg(feature = "pg12")]
+
+#[cfg(all(feature = "pg12", not(docsrs)))]
+mod pg12 {
+    include!(concat!(env!("OUT_DIR"), "/pg12.rs"));
+}
+#[cfg(all(feature = "pg12", docsrs))]
 mod pg12;
-#[cfg(feature = "pg13")]
+
+#[cfg(all(feature = "pg13", not(docsrs)))]
+mod pg13 {
+    include!(concat!(env!("OUT_DIR"), "/pg13.rs"));
+}
+#[cfg(all(feature = "pg13", docsrs))]
 mod pg13;
 
 // export each module publicly


### PR DESCRIPTION
During sandboxed builds, or builds from a vendored Cargo dir, we often can't mutate our build directory.

This includes our `pg1{0,1,2,3}.rs` bindings as well as the `cshim` build phase.

* Add a `PGX_PG_SYS_SKIP_BINDING_REWRITE=1` option for binding code, so we can skip writing it.
* Stop cshim from mutating it's own build directory. Use the `$OUT_DIR` instead.