### PR TITLE
feat: use naersk for nix builds

### DIFF
--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -5,7 +5,7 @@ let
 in
 
 naersk.lib."${hostPlatform.system}".buildPackage rec {
-  pname = cargoToml.package.name;
+  name = cargoToml.package.name;
   version = cargoToml.package.version;
 
   src = ../.;

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -12,7 +12,6 @@ naersk.lib."${hostPlatform.system}".buildPackage rec {
 
   cargoBuildOptions = final: final ++ [ "--package" "cargo-pgx" ];
   cargoTestOptions = final: final ++ [ "--package" "cargo-pgx" ];
-  cargoCheckOptions = "--package cargo-pgx";
 
   nativeBuildInputs = [
     pkg-config

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -1,34 +1,18 @@
-{ lib, rustPlatform, fetchFromGitHub, postgresql_10, postgresql_11, postgresql_12, postgresql_13, pkg-config, openssl, rustfmt, llvmPackages, }:
+{ lib, naersk, hostPlatform, fetchFromGitHub, postgresql_10, postgresql_11, postgresql_12, postgresql_13, pkg-config, openssl, rustfmt, llvmPackages, }:
 
-rustPlatform.buildRustPackage rec {
-  pname = "cargo-pgx";
-  version = "0.1.21";
+let
+  cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
+in
+
+naersk.lib."${hostPlatform.system}".buildPackage rec {
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
 
   src = ../.;
 
-  #cargoSha256 = lib.fakeSha256;
-  cargoSha256 = "sKfjOcuCa2QvqERSrNry1RTUTaZIXudON3Ky1UWp89w=";
-  cargoBuildFlags = [ "--package" "cargo-pgx" ];
-  cargoCheckFlags = [ "--package" "cargo-pgx" ];
-  cargoTestFlags = [ "--package" "cargo-pgx" ];
-
-  /*
-    TODO: pgx currently has to modify the postgres directory during development,
-    so we can't get tricky and use the existing PostgreSQL packages.
-
-    PGX_HOME = "./pgx";
-    postBuild = ''
-    cargo run --package cargo-pgx --bin cargo-pgx -- pgx init \
-    --pg10 ${postgresql_10}/bin/pg_config \
-    --pg11 ${postgresql_11}/bin/pg_config \
-    --pg12 ${postgresql_12}/bin/pg_config \
-    --pg13 ${postgresql_13}/bin/pg_config
-    '';
-    preFixup = ''
-    mv $(pwd)/pgx $out/pgx
-    ${makeWrapper} $out/bin/cargo-pgx $out/bin/cargo-pgx-wrapped --set PGX_HOME $out/pgx
-    '';
-  */
+  cargoBuildOptions = final: final ++ [ "--package" "cargo-pgx" ];
+  cargoTestOptions = final: final ++ [ "--package" "cargo-pgx" ];
+  cargoCheckOptions = "--package cargo-pgx";
 
   nativeBuildInputs = [
     pkg-config
@@ -40,8 +24,8 @@ rustPlatform.buildRustPackage rec {
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   meta = with lib; {
-    description = "Build PostgreSQL extensions with Rust.";
-    homepage = "https://github.com/zombodb/pgx";
+    description = cargoToml.package.description;
+    homepage = cargoToml.package.homepage;
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ hoverbear ];
   };

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,44 @@
 {
   "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1620316130,
+        "narHash": "sha256-sU0VS5oJS1FsHsZsLELAXc7G2eIelVuucRw+q5B1x9k=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "a3f40fe42cc6d267ff7518fa3199e99ff1444ac4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619894881,
-        "narHash": "sha256-9Dq/c+ewZxGkjpapY/zJ0GTmKvPjK6mnyziZyNjPsRg=",
+        "lastModified": 1620649258,
+        "narHash": "sha256-A+yiRATvdnZ4QaeSE2SQ8jz70f1kpC5xfeFttjn0o0E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4226837368068600e6afd11b5cbc6d586c7b5fa9",
+        "rev": "acd5e6707e93c6b0928c96bc43057e91fa0bcee0",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1620423841,
+        "narHash": "sha256-eHJDI4NLuyZzkwTZ/hWpd2kDPOd3EIdBMPHG4kkVXUs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c16380b5b46872c011d6aad9b7698e08fe6041a7",
         "type": "github"
       },
       "original": {
@@ -17,7 +49,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,11 @@
   description = "Postgres extensions in Rust.";
 
   inputs = {
+    naersk.url = "github:nmattia/naersk";
     nixpkgs.url = "github:NixOS/nixpkgs";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, naersk }:
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
@@ -28,7 +29,7 @@
         });
 
       overlay = final: prev: {
-        cargo-pgx = final.callPackage ./cargo-pgx { };
+        cargo-pgx = final.callPackage ./cargo-pgx { inherit naersk; };
       };
 
       devShell = forAllSystems (system:


### PR DESCRIPTION
In Nix, the nixpkgs [`rustPlatform.buildPackage`](https://nixos.org/manual/nixpkgs/stable/#compiling-rust-applications-with-cargo) has a number of warts. It uses "Fixed output derivations" which require us to maintain a bunch of SHA256 hashes of things.

[Naersk](https://github.com/nmattia/naersk) was recommended by @grahamc , it seems quite a bit more refined, doesn't require SHAs, etc. This lets us be pretty hands off with the nix stuff.