### PR TITLE
Don't look up the type oid for types that never use it

### DIFF
--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -7,6 +7,7 @@ use std::ops::{Deref, DerefMut};
 #[derive(Debug)]
 pub struct Date(time::Date);
 impl FromDatum for Date {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Date> {
         if is_null {

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -13,6 +13,7 @@ use std::ffi::CStr;
 /// If implementing this, also implement `IntoDatum` for the reverse
 /// conversion.
 pub trait FromDatum {
+    const NEEDS_TYPID: bool = true;
     /// ## Safety
     ///
     /// This method is inherently unsafe as the `datum` argument can represent an arbitrary
@@ -56,6 +57,7 @@ pub trait FromDatum {
 
 /// for pg_sys::Datum
 impl FromDatum for pg_sys::Datum {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(
         datum: pg_sys::Datum,
@@ -72,6 +74,7 @@ impl FromDatum for pg_sys::Datum {
 
 /// for bool
 impl FromDatum for bool {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<bool> {
         if is_null {
@@ -84,6 +87,7 @@ impl FromDatum for bool {
 
 /// for `"char"`
 impl FromDatum for i8 {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i8> {
         if is_null {
@@ -96,6 +100,7 @@ impl FromDatum for i8 {
 
 /// for smallint
 impl FromDatum for i16 {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i16> {
         if is_null {
@@ -108,6 +113,7 @@ impl FromDatum for i16 {
 
 /// for integer
 impl FromDatum for i32 {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i32> {
         if is_null {
@@ -120,6 +126,7 @@ impl FromDatum for i32 {
 
 /// for oid
 impl FromDatum for u32 {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<u32> {
         if is_null {
@@ -132,6 +139,7 @@ impl FromDatum for u32 {
 
 /// for bigint
 impl FromDatum for i64 {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i64> {
         if is_null {
@@ -144,6 +152,7 @@ impl FromDatum for i64 {
 
 /// for real
 impl FromDatum for f32 {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f32> {
         if is_null {
@@ -156,6 +165,7 @@ impl FromDatum for f32 {
 
 /// for double precision
 impl FromDatum for f64 {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f64> {
         if is_null {
@@ -168,6 +178,7 @@ impl FromDatum for f64 {
 
 /// for text, varchar
 impl<'a> FromDatum for &'a str {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a str> {
         if is_null {
@@ -212,6 +223,7 @@ impl<'a> FromDatum for &'a str {
 ///
 /// This returns a **copy**, allocated and managed by Rust, of the underlying `varlena` Datum
 impl FromDatum for String {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(
         datum: pg_sys::Datum,
@@ -227,6 +239,7 @@ impl FromDatum for String {
 }
 
 impl FromDatum for char {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<char> {
         let refstr: Option<&str> = FromDatum::from_datum(datum, is_null, typoid);
@@ -239,6 +252,7 @@ impl FromDatum for char {
 
 /// for cstring
 impl<'a> FromDatum for &'a std::ffi::CStr {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a CStr> {
         if is_null {
@@ -255,6 +269,7 @@ impl<'a> FromDatum for &'a std::ffi::CStr {
 
 /// for bytea
 impl<'a> FromDatum for &'a [u8] {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: usize, is_null: bool, _typoid: u32) -> Option<&'a [u8]> {
         if is_null {
@@ -296,6 +311,7 @@ impl<'a> FromDatum for &'a [u8] {
 }
 
 impl FromDatum for Vec<u8> {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: usize, is_null: bool, typoid: u32) -> Option<Vec<u8>> {
         if is_null {
@@ -318,6 +334,7 @@ impl FromDatum for Vec<u8> {
 
 /// for NULL -- always converts to a `None`, even if the is_null argument is false
 impl FromDatum for () {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(_datum: pg_sys::Datum, _is_null: bool, _: pg_sys::Oid) -> Option<()> {
         None
@@ -326,6 +343,7 @@ impl FromDatum for () {
 
 /// for user types
 impl<T> FromDatum for PgBox<T> {
+    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<PgBox<T>> {
         if is_null {

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -4,6 +4,7 @@
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
 
 impl FromDatum for pg_sys::BOX {
+    const NEEDS_TYPID: bool = false;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -43,6 +43,7 @@ where
     A: FromDatum + IntoDatum,
     B: FromDatum + IntoDatum,
 {
+    const NEEDS_TYPID: bool = A::NEEDS_TYPID || B::NEEDS_TYPID;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
@@ -73,6 +74,7 @@ where
     B: FromDatum + IntoDatum,
     C: FromDatum + IntoDatum,
 {
+    const NEEDS_TYPID: bool = A::NEEDS_TYPID || B::NEEDS_TYPID || C::NEEDS_TYPID;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -276,6 +276,7 @@ impl<T> FromDatum for PgVarlena<T>
 where
     T: Copy + Sized,
 {
+    const NEEDS_TYPID: bool = false;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
         if is_null {
             None

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -82,7 +82,15 @@ mod pg_10_11 {
     pub fn pg_getarg<T: FromDatum>(fcinfo: pg_sys::FunctionCallInfo, num: usize) -> Option<T> {
         let datum = unsafe { fcinfo.as_ref() }.unwrap().arg[num];
         let isnull = pg_arg_is_null(fcinfo, num);
-        unsafe { T::from_datum(datum, isnull, crate::get_getarg_type(fcinfo, num)) }
+        unsafe {
+            let typid =
+                if T::NEEDS_TYPID {
+                    crate::get_getarg_type(fcinfo, num)
+                } else {
+                    pg_sys::InvalidOid
+                };
+            T::from_datum(datum, isnull, typid)
+        }
     }
 
     #[inline]
@@ -119,10 +127,16 @@ mod pg_12_13 {
     pub fn pg_getarg<T: FromDatum>(fcinfo: pg_sys::FunctionCallInfo, num: usize) -> Option<T> {
         let datum = get_nullable_datum(fcinfo, num);
         unsafe {
+            let typid =
+                if T::NEEDS_TYPID {
+                    crate::get_getarg_type(fcinfo, num)
+                } else {
+                    pg_sys::InvalidOid
+                };
             T::from_datum(
                 datum.value,
                 datum.isnull,
-                crate::get_getarg_type(fcinfo, num),
+                typid,
             )
         }
     }

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -298,6 +298,7 @@ impl Clone for PgRelation {
 }
 
 impl FromDatum for PgRelation {
+    const NEEDS_TYPID: bool = false;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<PgRelation> {
         if is_null {
             None


### PR DESCRIPTION
Getting function argument type oids can be surprisingly expensive; one Promscale benchmark measures it as taking over 10% of runtime (@cevian should have more info). Fortunately, most types do not actually make use of this information, and the `getarg_type()` call can be optimized out if this fact is known. This commit adds an opt-in method for declaring that a type does not make use of the `typeoid` in `from_datum()`, and updates `pg_getarg()` to make use of this information.

This commit makes the following changes:
 1. It adds a `const` boolean to `FromDatum` called `NEEDS_TYPID`. This boolean is defaulted to `true`. Types that never use the `typeoid` parameter to `from_datum()` can override this to `false`.
 2. `pg_getarg()` updated to look at `T::NEEDS_TYPID` before calling `get_getarg_type()`. If `T::NEEDS_TYPID == true` it calls `get_getarg_type()` like it currently does for all types; if it is `false` it instead passes `InvalidOid` as the (unused) `typeoid` argument to `from_datum()`.
 3. It edits a number of built in types to make use of this optimization.

Since this feature is both opt-in and backwards compatible, it should not break any downstream users.