### PR TITLE
Use CASCADE while creating extension

### DIFF
--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -465,7 +465,10 @@ fn create_extension() {
     let (mut client, _) = client();
 
     client
-        .simple_query(&format!("CREATE EXTENSION {};", get_extension_name()))
+        .simple_query(&format!(
+            "CREATE EXTENSION {} CASCADE;",
+            get_extension_name()
+        ))
         .unwrap();
 }
 


### PR DESCRIPTION
Extensions might have dependencies on other extensions. If there are
no dependencies even then using "CASCADE" does not produce any side
effects. So add it wholesale without adding too much smarts.