### PR TITLE
Add sigsetjmp extern for FreeBSD (fixes #179)

### DIFF
--- a/pgx-pg-sys/src/submodules/mod.rs
+++ b/pgx-pg-sys/src/submodules/mod.rs
@@ -20,7 +20,8 @@ extern "C" {
     ) -> std::os::raw::c_int;
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos",
+          target_os = "freebsd"))]
 extern "C" {
     pub(crate) fn sigsetjmp(
         env: *mut crate::sigjmp_buf,


### PR DESCRIPTION
This works for me on FreeBSD. Adding OpenBSD might be nice too, but I can't test that change right now.