### PR TITLE
fix: attempt repair docsrs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ pg_test = [ "pgx-tests/pg_test" ]
 [package.metadata.docs.rs]
 features = ["pg13"]
 no-default-features = true
+# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -13,6 +13,10 @@ readme = "README.md"
 [lib]
 proc-macro = true
 
+[package.metadata.docs.rs]
+# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
+rustc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 pgx-utils = { path = "../pgx-utils", version = "0.1.22" }
 proc-macro2 = "1.0.28"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -21,6 +21,8 @@ pg13 = [ ]
 features = ["pg13"]
 no-default-features = true
 targets = ["x86_64-unknown-linux-gnu"]
+# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
+rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.6.4"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -25,6 +25,8 @@ pg13 = [ "pgx-pg-sys/pg13" ]
 [package.metadata.docs.rs]
 features = ["pg13"]
 no-default-features = true
+# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
+rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 enum-primitive-derive = "0.2.1"


### PR DESCRIPTION
Fixup the docsrs builds. We *did* correctly set `package.metadata.docs.rs.rustc-args = ["--cfg", "docsrs"]`  but we only did it on the root crate. This PR updates things to have it generously sprinkled in a few crates.