### PR TITLE
feat: support testname in cargo pgx test

### DIFF
--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -234,21 +234,21 @@ By default, `cargo pgx install` builds your extension in debug mode.  Specifying
 
 ```shell script
 $ cargo pgx install --help
-  cargo-pgx-pgx-install
-  install the extension from the current crate to the Postgres specified by whatever "pg_config" is currently on your
-  $PATH
+cargo-pgx-pgx-install
+install the extension from the current crate to the Postgres specified by whatever "pg_config" is currently on your
+$PATH
 
-  USAGE:
-      cargo-pgx pgx install [FLAGS]
+USAGE:
+    cargo-pgx pgx install [FLAGS]
 
-  FLAGS:
-      -h, --help       Prints help information
-      -r, --release    compile for release mode (default is debug)
-      -V, --version    Prints version information
+FLAGS:
+    -h, --help       Prints help information
+    -r, --release    compile for release mode (default is debug)
+    -V, --version    Prints version information
 
 OPTIONS:
-        --features <features>...    additional cargo features to activate (default is '--no-default-features')
-    -c, --pg_config <pg_config>     the `pg_config` path (default is first in $PATH)
+    --features <features>...    additional cargo features to activate (default is '--no-default-features')
+-c, --pg_config <pg_config>     the `pg_config` path (default is first in $PATH)
 ```
 
 ## Testing Your Extension
@@ -268,16 +268,16 @@ make to the database are not preserved.
 
 ```shell script
 $ cargo pgx test --help
-cargo-pgx-pgx-test
+cargo-pgx-test
 run the test suite for this crate
 
 USAGE:
-    cargo-pgx pgx test [FLAGS] [PG_VERSION]
+    cargo pgx test [FLAGS] [OPTIONS] [--] [ARGS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -r, --release    compile for release mode (default is debug)
-    -V, --version    Prints version information
+    -h, --help         Prints help information
+    -r, --release      compile for release mode (default is debug)
+    -V, --version      Prints version information
         --workspace    Test all packages in the workspace
 
 OPTIONS:
@@ -285,6 +285,7 @@ OPTIONS:
 
 ARGS:
     <PG_VERSION>    Do you want to test for Postgres 'pg10', 'pg11', 'pg12', 'pg13', or 'all' (default)?
+    <TESTNAME>      If specified, only run tests containing this string in their names
 ```
 
 ## Building an Installation Package

--- a/cargo-pgx/src/cli.yml
+++ b/cargo-pgx/src/cli.yml
@@ -165,6 +165,10 @@ subcommands:
                     value_name: PG_VERSION
                     takes_value: true
                     help: Do you want to test for Postgres 'pg10', 'pg11', 'pg12', 'pg13', or 'all' (default)?
+                - testname:
+                    value_name: TESTNAME
+                    takes_value: true
+                    help: If specified, only run tests containing this string in their names
                 - release:
                     short: r
                     long: release

--- a/cargo-pgx/src/commands/test.rs
+++ b/cargo-pgx/src/commands/test.rs
@@ -10,6 +10,7 @@ pub fn test_extension(
     pg_config: &PgConfig,
     is_release: bool,
     additional_features: Vec<&str>,
+    testname: Option<&str>,
 ) -> Result<(), std::io::Error> {
     let major_version = pg_config.major_version()?;
     let target_dir = get_target_dir();
@@ -35,6 +36,10 @@ pub fn test_extension(
 
     if is_release {
         command.arg("--release");
+    }
+
+    if let Some(testname) = testname {
+        command.arg(testname);
     }
 
     eprintln!("{:?}", command);

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -205,9 +205,11 @@ fn do_it() -> std::result::Result<(), std::io::Error> {
                     .values_of("features")
                     .map(|v| v.collect())
                     .unwrap_or(vec![]);
+                let testname = test
+                    .value_of("testname");
                 let pgx = Pgx::from_config()?;
                 for pg_config in pgx.iter(PgConfigSelector::new(pgver)) {
-                    test_extension(pg_config?, is_release, features.clone())?
+                    test_extension(pg_config?, is_release, features.clone(), testname)?
                 }
                 Ok(())
             }


### PR DESCRIPTION
Allow users to specify a `TESTNAME` with `cargo pgx test` like they can with `cargo test`.

Makes the following valid:

```rust
cd pgx-tests/
cargo pgx test pg13 array_i64_sliced
```

While preserving old behavior.

```rust
❯ cargo pgx test --help
cargo-pgx-test 0.1.22
run the test suite for this crate

USAGE:
    cargo pgx test [FLAGS] [OPTIONS] [--] [ARGS]

# ...

ARGS:
    <PG_VERSION>    Do you want to test for Postgres 'pg10', 'pg11', 'pg12', 'pg13', or 'all' (default)?
    <TESTNAME>      If specified, only run tests containing this string in their names
```

This is compatible with `cargo test`'s behavior:

```rust
❯ cargo test --help
cargo-test 
Execute all unit and integration tests and build examples of a local package

USAGE:
    cargo test [OPTIONS] [TESTNAME] [-- <args>...]

# ...

ARGS:
    <TESTNAME>    If specified, only run tests containing this string in their names
    <args>...     Arguments for the test binary

Run `cargo help test` for more detailed information.

```
