### PR TITLE
Suggest rustfmt install

### DIFF
--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -642,7 +642,15 @@ fn rust_fmt(path: &PathBuf) -> Result<(), std::io::Error> {
     run_command(
         Command::new("rustfmt").arg(path).current_dir("."),
         "[bindings_diff]",
+    ).map_err(|e|
+        if e.kind() == std::io::ErrorKind::NotFound {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Failed to run `rustfmt`, is it installed?"
+            )
+        } else {
+            e
+        }
     )?;
-
     Ok(())
 }

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -546,14 +546,16 @@ fn build_shim_for_version(
         std::fs::copy(
             format!("{}/Makefile", shim_src.display()),
             format!("{}/Makefile", shim_dst.display()),
-        ).unwrap();
+        )
+        .unwrap();
     }
 
     if !std::path::Path::new(&format!("{}/pgx-cshim.c", shim_dst.display())).exists() {
         std::fs::copy(
             format!("{}/pgx-cshim.c", shim_src.display()),
             format!("{}/pgx-cshim.c", shim_dst.display()),
-        ).unwrap();
+        )
+        .unwrap();
     }
 
     let rc = run_command(
@@ -642,15 +644,16 @@ fn rust_fmt(path: &PathBuf) -> Result<(), std::io::Error> {
     run_command(
         Command::new("rustfmt").arg(path).current_dir("."),
         "[bindings_diff]",
-    ).map_err(|e|
+    )
+    .map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "Failed to run `rustfmt`, is it installed?"
+                "Failed to run `rustfmt`, is it installed?",
             )
         } else {
             e
         }
-    )?;
+    })?;
     Ok(())
 }


### PR DESCRIPTION
If the user doesn't have `rustfmt` installed, we now suggest it instead of reporting a not found like #174 

```rust
  [[bindings_diff]] "rustfmt" "/home/ana/git/pgx/target/debug/build/pgx-pg-sys-3b7f9824297db00e/out/pg11.rs"
        [error] Unable to write bindings file for pg11 to `/home/ana/git/pgx/target/debug/build/pgx-pg-sys-3b7f9824297db00e/out/pg11.rs`: Failed to run `rustfmt`, is it installed?
```