### PR TITLE
Use thin lto in debug to ensure symbols are properly exported.

### DIFF
--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -23,6 +23,7 @@ pgx-tests = "0.1.22"
 
 [profile.dev]
 panic = "unwind"
+lto = "fat"
 
 [profile.release]
 panic = "unwind"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -23,7 +23,7 @@ pgx-tests = "0.1.22"
 
 [profile.dev]
 panic = "unwind"
-lto = "fat"
+lto = "thin"
 
 [profile.release]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -15,18 +15,17 @@ pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg_test = []
 
 [dependencies]
-pgx = { git = "https://github.com/zombodb/pgx", branch = "develop" }
-pgx-macros = { git = "https://github.com/zombodb/pgx", branch = "develop" }
+pgx = "0.1.22"
+pgx-macros = "0.1.22"
 
 [dev-dependencies]
-pgx-tests = { git = "https://github.com/zombodb/pgx", branch = "develop" }
-pgx-utils = { git = "https://github.com/zombodb/pgx", branch = "develop" }
-pgx-pg-sys = { git = "https://github.com/zombodb/pgx", branch = "develop" }
+pgx-tests = "0.1.22"
 tempdir = "0.3.7"
 once_cell = "1.7.2"
 
 [profile.dev]
 panic = "unwind"
+lto = "thin"
 
 [profile.release]
 panic = "unwind"

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -28,6 +28,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 #[profile.dev]
 #panic = "unwind"
+#lto = "fat"
 #
 #[profile.release]
 #panic = "unwind"

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -26,12 +26,12 @@ serde = "1.0.130"
 pgx-tests = { path = "../../../pgx/pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
-#[profile.dev]
-#panic = "unwind"
-#lto = "fat"
-#
-#[profile.release]
-#panic = "unwind"
-#opt-level = 3
-#lto = "fat"
-#codegen-units = 1
+# [profile.dev]
+# panic = "unwind"
+# lto = "thin"
+
+# [profile.release]
+# panic = "unwind"
+# opt-level = 3
+# lto = "fat"
+# codegen-units = 1

--- a/pgx-examples/bgworker/Cargo.toml
+++ b/pgx-examples/bgworker/Cargo.toml
@@ -28,6 +28,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/bytea/Cargo.toml
+++ b/pgx-examples/bytea/Cargo.toml
@@ -27,6 +27,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/custom_sql/Cargo.toml
+++ b/pgx-examples/custom_sql/Cargo.toml
@@ -27,6 +27,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/custom_types/Cargo.toml
+++ b/pgx-examples/custom_types/Cargo.toml
@@ -28,6 +28,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/errors/Cargo.toml
+++ b/pgx-examples/errors/Cargo.toml
@@ -26,6 +26,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/operators/Cargo.toml
+++ b/pgx-examples/operators/Cargo.toml
@@ -28,6 +28,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/schemas/Cargo.toml
+++ b/pgx-examples/schemas/Cargo.toml
@@ -27,6 +27,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/shmem/Cargo.toml
+++ b/pgx-examples/shmem/Cargo.toml
@@ -28,6 +28,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/spi/Cargo.toml
+++ b/pgx-examples/spi/Cargo.toml
@@ -26,6 +26,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/srf/Cargo.toml
+++ b/pgx-examples/srf/Cargo.toml
@@ -27,6 +27,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/strings/Cargo.toml
+++ b/pgx-examples/strings/Cargo.toml
@@ -26,6 +26,7 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
+# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/triggers/Cargo.toml
+++ b/pgx-examples/triggers/Cargo.toml
@@ -26,7 +26,8 @@ pgx-tests = { path = "../../../pgx/pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 #[profile.dev]
 #panic = "unwind"
-#
+# lto = "thin"
+
 #[profile.release]
 #panic = "unwind"
 #opt-level = 3


### PR DESCRIPTION
This resolves the issues found in #207.

This lets us work around what seems to be https://github.com/rust-lang/rust/issues/50007. I note that we may in the future encounter a scenario where we actually want `"fat"` but have not seen evidence of that being needed yet.