### PR TITLE
Verify cargo toml settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "rttp_client",
  "symbolic",
  "syn",
+ "toml",
  "unescape",
 ]
 

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -29,4 +29,5 @@ syn = { version = "1.0.75", features = [ "extra-traits", "full", "fold", "parsin
 unescape = "0.1.0"
 fork = "0.1.18"
 libloading = "0.7"
+toml = "0.5.8"
 symbolic = "8.3.0"

--- a/cargo-pgx/src/commands/schema.rs
+++ b/cargo-pgx/src/commands/schema.rs
@@ -296,7 +296,7 @@ fn toml_value_has_setting(
             None => false,
         }
     } else {
-        panic!("Got zero segments in cargo toml setting to search for.")
+        panic!("Got zero segments in Cargo.toml setting to search for.")
     }
 }
 

--- a/cargo-pgx/src/commands/schema.rs
+++ b/cargo-pgx/src/commands/schema.rs
@@ -283,12 +283,12 @@ pub(crate) fn generate_schema(
 fn toml_value_has_setting(
     target: &toml::Value,
     segments: &[&str],
-    expected_value: toml::Value,
+    expected_value: &toml::Value,
 ) -> bool {
     if let Some(segment) = segments.first() {
         let rest = &segments[1..];
         match target.get(&segment) {
-            Some(existing_value) if existing_value == &expected_value => true,
+            Some(existing_value) if existing_value == expected_value => true,
             Some(existing_value @ toml::Value::Table(_)) => {
                 toml_value_has_setting(existing_value, rest, expected_value)
             }
@@ -322,11 +322,12 @@ fn check_cargo_toml_settings(
     let cargo_toml: toml::Value = toml::from_str(&cargo_toml_contents)?;
 
     for (setting, expected_value) in expected_settings {
-        if !toml_value_has_setting(&cargo_toml, setting, expected_value) {
+        if !toml_value_has_setting(&cargo_toml, setting, &expected_value) {
             println!(
-                "{} custom Cargo.toml setting `{}`. (having trouble? `cargo pgx schema --help` details settings needed)",
+                "{} custom Cargo.toml setting `{}`, expected `{}`. (having trouble? `cargo pgx schema --help` details settings needed)",
                 "   Detecting".bold().green(),
                 setting.join("."),
+                expected_value,
             );
         }
     }


### PR DESCRIPTION
Output informational messages if a `cargo pgx schema` is run on an extension whose `Cargo.toml` does not include the required `Cargo.toml` settings.