### PR TITLE
fix: Mark is_a unsafe

### DIFF
--- a/pgx/src/list.rs
+++ b/pgx/src/list.rs
@@ -80,7 +80,7 @@ impl<T> PgList<T> {
 
     #[inline]
     pub fn get_ptr(&self, i: usize) -> Option<*mut T> {
-        if !self.is_empty() && !is_a(self.list as *mut pg_sys::Node, pg_sys::NodeTag_T_List) {
+        if !self.is_empty() && unsafe { !is_a(self.list as *mut pg_sys::Node, pg_sys::NodeTag_T_List) } {
             panic!("PgList does not contain pointers")
         }
         if self.list.is_null() || i >= self.len() {
@@ -92,7 +92,7 @@ impl<T> PgList<T> {
 
     #[inline]
     pub fn get_int(&self, i: usize) -> Option<i32> {
-        if !self.is_empty() && !is_a(self.list as *mut pg_sys::Node, pg_sys::NodeTag_T_IntList) {
+        if !self.is_empty() && unsafe { !is_a(self.list as *mut pg_sys::Node, pg_sys::NodeTag_T_IntList) } {
             panic!("PgList does not contain ints")
         }
 
@@ -105,7 +105,7 @@ impl<T> PgList<T> {
 
     #[inline]
     pub fn get_oid(&self, i: usize) -> Option<pg_sys::Oid> {
-        if !self.is_empty() && !is_a(self.list as *mut pg_sys::Node, pg_sys::NodeTag_T_OidList) {
+        if !self.is_empty() && unsafe { !is_a(self.list as *mut pg_sys::Node, pg_sys::NodeTag_T_OidList) } {
             panic!("PgList does not contain oids")
         }
 

--- a/pgx/src/nodes.rs
+++ b/pgx/src/nodes.rs
@@ -6,10 +6,9 @@
 use crate::pg_sys;
 
 /// #define IsA(nodeptr,_type_)            (nodeTag(nodeptr) == T_##_type_)
-#[allow(clippy::not_unsafe_ptr_arg_deref)] // ok b/c we check that nodeptr isn't null
 #[inline]
-pub fn is_a(nodeptr: *mut pg_sys::Node, tag: pg_sys::NodeTag) -> bool {
-    !nodeptr.is_null() && unsafe { nodeptr.as_ref().unwrap().type_ == tag }
+pub unsafe fn is_a(nodeptr: *mut pg_sys::Node, tag: pg_sys::NodeTag) -> bool {
+    !nodeptr.is_null() && nodeptr.as_ref().unwrap().type_ == tag
 }
 
 pub fn node_to_string<'a>(nodeptr: *mut pg_sys::Node) -> Option<&'a str> {

--- a/pgx/src/trigger_support.rs
+++ b/pgx/src/trigger_support.rs
@@ -8,7 +8,7 @@ use crate::{is_a, pg_sys};
 #[inline]
 pub fn called_as_trigger(fcinfo: pg_sys::FunctionCallInfo) -> bool {
     let fcinfo = unsafe { fcinfo.as_ref() }.expect("fcinfo was null");
-    !fcinfo.context.is_null() && is_a(fcinfo.context, pg_sys::NodeTag_T_TriggerData)
+    !fcinfo.context.is_null() && unsafe { is_a(fcinfo.context, pg_sys::NodeTag_T_TriggerData) }
 }
 
 #[inline]


### PR DESCRIPTION
Closes #215 .

Like #210, we should probably circle back and document how to use these safely.