### PR TITLE
repare-release: 0.2.0-beta.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 dependencies = [
  "clap",
  "colored",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 dependencies = [
  "pgx",
  "pgx-pg-sys",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-parent"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 dependencies = [
  "cargo-pgx",
  "pgx",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 dependencies = [
  "colored",
  "lazy_static",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-parent"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -49,8 +49,8 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-cargo-pgx = { path = "cargo-pgx" }
-pgx = { path = "pgx", default-features = false }
-pgx-macros = { path = "pgx-macros" }
-pgx-pg-sys = { path = "pgx-pg-sys", default-features = false }
-pgx-tests = { path = "pgx-tests", default-features = false }
+cargo-pgx = { path = "cargo-pgx", version = "0.2.0-beta.0" }
+pgx = { path = "pgx", version = "0.2.0-beta.0", default-features = false }
+pgx-macros = { path = "pgx-macros", version = "0.2.0-beta.0" }
+pgx-pg-sys = { path = "pgx-pg-sys", version = "0.2.0-beta.0", default-features = false }
+pgx-tests = { path = "pgx-tests", version = "0.2.0-beta.0", default-features = false }

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -19,7 +19,7 @@ clap = { version = "2.33.3", features = [ "yaml" ] }
 colored = "2.0.0"
 env_proxy = "0.4.1"
 num_cpus = "1.13.0"
-pgx-utils = { path = "../pgx-utils", version = "0.1.22" }
+pgx-utils = { path = "../pgx-utils", version = "0.2.0-beta.0" }
 proc-macro2 = { version = "1.0.29", features = [ "span-locations" ] }
 quote = "1.0.9"
 rayon = "1.5.1"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -15,11 +15,11 @@ pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.1.22"
-pgx-macros = "0.1.22"
+pgx = "0.2.0-beta.0"
+pgx-macros = "0.2.0-beta.0"
 
 [dev-dependencies]
-pgx-tests = "0.1.22"
+pgx-tests = "0.2.0-beta.0"
 
 [profile.dev]
 panic = "unwind"

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -19,7 +19,6 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../../pgx/pgx/", default-features = false }
-pgx-macros = "0.1.21"
 serde = "1.0.130"
 
 [dev-dependencies]

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -26,7 +26,7 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "0.1.22" }
+pgx-utils = { path = "../pgx-utils", version = "0.2.0-beta.0" }
 proc-macro2 = "1.0.29"
 quote = "1.0.9"
 syn = { version = "1.0.76", features = [ "extra-traits", "full", "fold", "parsing" ] }
@@ -34,6 +34,6 @@ unescape = "0.1.0"
 proc-macro-crate = "1.0.0"
 
 [dev-dependencies]
-pgx = { path = "../pgx", version = "0.1.21" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.1.21" }
+pgx = { path = "../pgx", version = "0.2.0-beta.0" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.2.0-beta.0" }
 serde = "1.0.117"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -27,14 +27,14 @@ rustc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.4"
 once_cell = "1.8.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.1.22" }
+pgx-macros = { path = "../pgx-macros/", version = "0.2.0-beta.0" }
 
 [build-dependencies]
 bindgen = "0.59.1"
 build-deps = "0.1.4"
 colored = "2.0.0"
 num_cpus = "1.13.0"
-pgx-utils = { path = "../pgx-utils/", version = "0.1.22" }
+pgx-utils = { path = "../pgx-utils/", version = "0.2.0-beta.0" }
 proc-macro2 = "1.0.29"
 quote = "1.0.9"
 rayon = "1.5.1"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -29,9 +29,9 @@ no-default-features = true
 colored = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2.101"
-pgx = { path = "../pgx", default-features = false, version= "0.1.22" }
-pgx-macros = { path = "../pgx-macros", version= "0.1.22" }
-pgx-utils = { path = "../pgx-utils", version= "0.1.22" }
+pgx = { path = "../pgx", default-features = false, version= "0.2.0-beta.0" }
+pgx-macros = { path = "../pgx-macros", version= "0.2.0-beta.0" }
+pgx-utils = { path = "../pgx-utils", version= "0.2.0-beta.0" }
 postgres = "0.19.1"
 regex = "1.5.4"
 serde = "1.0.130"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.1.22"
+version = "0.2.0-beta.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -32,9 +32,9 @@ rustc-args = ["--cfg", "docsrs"]
 enum-primitive-derive = "0.2.1"
 num-traits = "0.2.14"
 seahash = "4.1.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.1.22" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.1.22" }
-pgx-utils = { path = "../pgx-utils/", version = "0.1.22" }
+pgx-macros = { path = "../pgx-macros/", version = "0.2.0-beta.0" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.2.0-beta.0" }
+pgx-utils = { path = "../pgx-utils/", version = "0.2.0-beta.0" }
 serde = { version = "1.0.130", features = [ "derive" ] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.67"


### PR DESCRIPTION
## Features

* The `pgx` SQL generation system has been rewritten! It now uses the proc macro system and has several breaking changes. **Please refer to the migration guide below.** (#165, #197)
* The PostgreSQL `uuid` type is now supported! (#172)
* `cargo pgx test` now accepts an optional testname. `cargo pgx test specific::path` works just like `cargo test`! (#186)
* `pgx-pg-sys` now suggests you install `rustfmt` if you don't have it. (#193)
* `cargo pgx schema` will now emit informational messages if extension `Cargo.toml` settings are not what is expected. (#209)
* `cargo pgx test` now has a `--workspace` argument matching the equivalent on `cargo test`. (#169)

## Other changes

* **fix:** Marked several functions as unsafe as they had undefined behavior when passed invalid pointers. (#210, #216, #217)\
* Type `oid`s don't need to be looked up in functions that don't use them. (#168)
* Added an aggregate example. (#187)
* Updated many of our dependencies. (#191)
* More documentation has been added to several macros and SQL generation related types. (#192, #158, #219)
* An `articles/` directory now exists in the repo and includes links to different articles written about `pgx`. (#198)
* Document our MSRV (#157)

# Migration Guide

1. Update your `cargo-pgx`: `cargo install --force cargo-pgx --version 0.2.0-beta.0`
2. In your `Cargo.toml`, set `crate-type` to include `"rlib"` and `profile.dev.lto` to be `"thin"`:
  
   ```toml
   [lib]
   crate-type = ["cdylib", "rlib"]
   
   [profile.dev]
   lto = "thin"
   ```
3. Tell `cargo-pgx` to force update your `.cargo/`  and `src/bin` files it needs: `cargo pgx schema -f`
4. Remove any `sql/*.generated.sql`  files, as well as the `load-order.txt`.
5. For each `sql/*.sql` remaining, insert `extension_sql_file!("../sql/that_file.sql");` into your `src/lib.rs`
6. If the files depend on entities which already exist, you might need to set a `requires` attribute:
   ```rust
   extension_sql_file!("../sql/that_file.sql", requires = [ dogs::parts::Floof, some_fn, ]);
   ```
7. For any `mod floof { fn boop() { todo!() } }` style blocks you were using to infer schema name (making that function `floof.boop`), decorate the schema with `#[pg_schema]`:
  
   ```rust
   #[pg_schema]
   mod floof {
       fn boop() {
           todo!()
       }
   }
   ```
8. For any functions have a custom `sql` block for (like below), update that to use `pgxsql` now:
   ```rust
   /// ```sql <-- Change this to `pgxsql`
   /// CREATE OR REPLACE FUNCTION  ....
   /// ```
   #[pg_extern]
   fn dot_dot_dot() { todo!() }
   ```
9. Run `cargo pgx schema` again!

If you have any trouble, try running `cargo pgx schema -v` and investigating the output. We made sure to update the `cargo doc` output of `pgx` with updated usage for the various macros and derives, they might have some advice, too.

You can ask us questions via issues here or [Discord](https://discord.gg/hPb93Y9) if you get stuck.

# Thanks!

Thanks to @JLockerman (from @Timescale) & @kpumuk for contributions! Also thanks to our early testers @rustprooflabs and @comdiv.