### PR TITLE
fix: Remove circular dependency from pgx-macro dev-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "clap",
  "colored",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "pgx-utils",
  "proc-macro-crate",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-parent"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "cargo-pgx",
  "pgx",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "colored",
  "lazy_static",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,8 +1358,6 @@ dependencies = [
 name = "pgx-macros"
 version = "0.2.0-beta.0"
 dependencies = [
- "pgx",
- "pgx-pg-sys",
  "pgx-utils",
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-parent"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -49,8 +49,8 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-cargo-pgx = { path = "cargo-pgx", version = "0.2.0-beta.0" }
-pgx = { path = "pgx", version = "0.2.0-beta.0", default-features = false }
-pgx-macros = { path = "pgx-macros", version = "0.2.0-beta.0" }
-pgx-pg-sys = { path = "pgx-pg-sys", version = "0.2.0-beta.0", default-features = false }
-pgx-tests = { path = "pgx-tests", version = "0.2.0-beta.0", default-features = false }
+cargo-pgx = { path = "cargo-pgx", version = "0.2.0-beta.1" }
+pgx = { path = "pgx", version = "0.2.0-beta.1", default-features = false }
+pgx-macros = { path = "pgx-macros", version = "0.2.0-beta.1" }
+pgx-pg-sys = { path = "pgx-pg-sys", version = "0.2.0-beta.1", default-features = false }
+pgx-tests = { path = "pgx-tests", version = "0.2.0-beta.1", default-features = false }

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -19,7 +19,7 @@ clap = { version = "2.33.3", features = [ "yaml" ] }
 colored = "2.0.0"
 env_proxy = "0.4.1"
 num_cpus = "1.13.0"
-pgx-utils = { path = "../pgx-utils", version = "0.2.0-beta.0" }
+pgx-utils = { path = "../pgx-utils", version = "0.2.0-beta.1" }
 proc-macro2 = { version = "1.0.29", features = [ "span-locations" ] }
 quote = "1.0.9"
 rayon = "1.5.1"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -15,11 +15,11 @@ pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.2.0-beta.0"
-pgx-macros = "0.2.0-beta.0"
+pgx = "0.2.0-beta.1"
+pgx-macros = "0.2.0-beta.1"
 
 [dev-dependencies]
-pgx-tests = "0.2.0-beta.0"
+pgx-tests = "0.2.0-beta.1"
 
 [profile.dev]
 panic = "unwind"

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -10,14 +10,6 @@ repository = "https://github.com/zombodb/pgx/pg-macros"
 documentation = "https://docs.rs/pgx-macros"
 readme = "README.md"
 
-# These aren't actually used except for in tests.
-[features]
-default = [ ]
-pg10 = [ "pgx/pg10", "pgx-pg-sys/pg10" ]
-pg11 = [ "pgx/pg11", "pgx-pg-sys/pg11" ]
-pg12 = [ "pgx/pg12", "pgx-pg-sys/pg12" ]
-pg13 = [ "pgx/pg13", "pgx-pg-sys/pg13" ]
-
 [lib]
 proc-macro = true
 
@@ -34,6 +26,4 @@ unescape = "0.1.0"
 proc-macro-crate = "1.0.0"
 
 [dev-dependencies]
-pgx = { path = "../pgx", version = "0.2.0-beta.0" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.2.0-beta.0" }
-serde = "1.0.117"
+serde = { version = "1.0.117", features = ["derive"] }

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -18,7 +18,7 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "0.2.0-beta.0" }
+pgx-utils = { path = "../pgx-utils", version = "0.2.0-beta.1" }
 proc-macro2 = "1.0.29"
 quote = "1.0.9"
 syn = { version = "1.0.76", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -164,7 +164,7 @@ If there is a schema inside a schema, the most specific schema is chosen.
 
 In this example, the created `example` function is in the `dsl_filters` schema.
 
-```rust
+```rust,ignore
 use pgx::*;
 
 #[pg_schema]
@@ -202,7 +202,7 @@ Accepts a String literal, a `name` attribute, and optionally others:
 
 You can declare some SQL without any positioning information, meaning it can end up anywhere in the generated SQL:
 
-```rust
+```rust,ignore
 use pgx_macros::extension_sql;
 
 extension_sql!(
@@ -215,7 +215,7 @@ extension_sql!(
 
 To cause the SQL to be output at the start of the generated SQL:
 
-```rust
+```rust,ignore
 use pgx_macros::extension_sql;
 
 extension_sql!(
@@ -229,7 +229,7 @@ extension_sql!(
 
 To cause the SQL to be output at the end of the generated SQL:
 
-```rust
+```rust,ignore
 use pgx_macros::extension_sql;
 
 extension_sql!(
@@ -243,7 +243,7 @@ extension_sql!(
 
 To declare the SQL dependant, or a dependency of, other items:
 
-```rust
+```rust,ignore
 use pgx_macros::extension_sql;
 
 struct Treat;
@@ -270,7 +270,7 @@ extension_sql!(r#"
 
 To declare the SQL defines some entity (**Caution:** This is not recommended usage):
 
-```rust
+```rust,ignore
 use pgx::stringinfo::StringInfo;
 use pgx::*;
 use pgx_utils::get_named_capture;
@@ -338,7 +338,7 @@ Accepts the same options as [`macro@extension_sql`]. `name` is automatically set
 
 You can declare some SQL without any positioning information, meaning it can end up anywhere in the generated SQL:
 
-```rust
+```rust,ignore
 use pgx_macros::extension_sql_file;
 extension_sql_file!(
     "../static/demo.sql",
@@ -347,7 +347,7 @@ extension_sql_file!(
 
 To override the default name:
 
-```rust
+```rust,ignore
 use pgx_macros::extension_sql_file;
 
 extension_sql_file!(
@@ -404,7 +404,7 @@ New types can be defined via [`macro@PostgresType`] or [`macro@PostgresEnum`].
 
 
 Without any arguments or returns:
-```rust
+```rust,ignore
 use pgx::*;
 #[pg_extern]
 fn foo() { todo!() }
@@ -413,7 +413,7 @@ fn foo() { todo!() }
 # Arguments
 It's possible to pass even complex arguments:
 
-```rust
+```rust,ignore
 use pgx::*;
 #[pg_extern]
 fn boop(
@@ -426,7 +426,7 @@ fn boop(
 
 It's possible to set argument defaults, set by PostgreSQL when the function is invoked:
 
-```rust
+```rust,ignore
 use pgx::*;
 #[pg_extern]
 fn boop(a: default!(i32, 11111)) { todo!() }
@@ -446,7 +446,7 @@ It accepts 2 arguments:
 
 **If the default SQL entity created by the extension:** ensure it is added to `requires` as a dependency:
 
-```rust
+```rust,ignore
 use pgx::*;
 #[pg_extern]
 fn default_value() -> i32 { todo!() }
@@ -463,7 +463,7 @@ fn do_it(
 
 It's possible to return even complex values, as well:
 
-```rust
+```rust,ignore
 use pgx::*;
 #[pg_extern]
 fn boop() -> i32 { todo!() }
@@ -477,7 +477,7 @@ fn floop() -> (i32, i32) { todo!() }
 
 Like in PostgreSQL, it's possible to return tables using iterators and the `name!()` macro:
 
-```rust
+```rust,ignore
 use pgx::*;
 #[pg_extern]
 fn floop() -> impl Iterator<Item = (name!(a, i32), name!(b, i32))> {
@@ -502,7 +502,7 @@ It accepts 2 arguments:
 `pg_sys::Oid` is a special cased type alias, in order to use it as an argument or return it must be
 passed with it's full module path (`pg_sys::Oid`) in order to be resolved.
 
-```rust
+```rust,ignore
 use pgx::*;
 
 #[pg_extern]
@@ -581,7 +581,7 @@ fn rewrite_item_fn(
 /**
 Generate necessary bindings for using the enum with PostgreSQL.
 
-```rust
+```rust,ignore
 # use pgx_pg_sys as pg_sys;
 use pgx::*;
 use serde::{Deserialize, Serialize};
@@ -664,7 +664,7 @@ fn impl_postgres_enum(ast: DeriveInput) -> proc_macro2::TokenStream {
 /**
 Generate necessary bindings for using the type with PostgreSQL.
 
-```rust
+```rust,ignore
 # use pgx_pg_sys as pg_sys;
 use pgx::*;
 use serde::{Deserialize, Serialize};
@@ -897,7 +897,7 @@ fn parse_postgres_type_args(attributes: &[Attribute]) -> HashSet<PostgresTypeAtt
 /**
 Generate necessary code using the type in operators like `==` and `!=`.
 
-```rust
+```rust,ignore
 # use pgx_pg_sys as pg_sys;
 use pgx::*;
 use serde::{Deserialize, Serialize};
@@ -918,7 +918,7 @@ pub fn postgres_eq(input: TokenStream) -> TokenStream {
 /**
 Generate necessary code using the type in operators like `>`, `<`, `<=`, and `>=`.
 
-```rust
+```rust,ignore
 # use pgx_pg_sys as pg_sys;
 use pgx::*;
 use serde::{Deserialize, Serialize};
@@ -942,7 +942,7 @@ pub fn postgres_ord(input: TokenStream) -> TokenStream {
 /**
 Generate necessary code for stable hashing the type so it can be used with `USING hash` indexes.
 
-```rust
+```rust,ignore
 # use pgx_pg_sys as pg_sys;
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -27,7 +27,7 @@ rustc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.4"
 once_cell = "1.8.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.2.0-beta.0" }
+pgx-macros = { path = "../pgx-macros/", version = "0.2.0-beta.1" }
 
 [build-dependencies]
 bindgen = "0.59.1"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -29,9 +29,9 @@ no-default-features = true
 colored = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2.101"
-pgx = { path = "../pgx", default-features = false, version= "0.2.0-beta.0" }
-pgx-macros = { path = "../pgx-macros", version= "0.2.0-beta.0" }
-pgx-utils = { path = "../pgx-utils", version= "0.2.0-beta.0" }
+pgx = { path = "../pgx", default-features = false, version= "0.2.0-beta.1" }
+pgx-macros = { path = "../pgx-macros", version= "0.2.0-beta.1" }
+pgx-utils = { path = "../pgx-utils", version= "0.2.0-beta.1" }
 postgres = "0.19.1"
 regex = "1.5.4"
 serde = "1.0.130"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.2.0-beta.0"
+version = "0.2.0-beta.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -32,9 +32,9 @@ rustc-args = ["--cfg", "docsrs"]
 enum-primitive-derive = "0.2.1"
 num-traits = "0.2.14"
 seahash = "4.1.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.2.0-beta.0" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.2.0-beta.0" }
-pgx-utils = { path = "../pgx-utils/", version = "0.2.0-beta.0" }
+pgx-macros = { path = "../pgx-macros/", version = "0.2.0-beta.1" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.2.0-beta.1" }
+pgx-utils = { path = "../pgx-utils/", version = "0.2.0-beta.1" }
 serde = { version = "1.0.130", features = [ "derive" ] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.67"


### PR DESCRIPTION
In #165 we added some doctests to `pgx-macros`.

It turns out that was quite foolish as they depended on `pgx`, creating a circular dependency which hits https://github.com/rust-lang/cargo/issues/4242, meaning we cannot publish.

This removes that.

I guess we will need to cut a `0.2.0-beta.1` since https://crates.io/crates/pgx-utils/0.2.0-beta.0 was released before this could be caught.

Unfortunately I have not found a way to determine if this will be an issue before publishing.