### PR TITLE
chore: ensure GitHub can blend

### DIFF
--- a/.github/workflows/will-it-blend.yml
+++ b/.github/workflows/will-it-blend.yml
@@ -42,4 +42,4 @@ jobs:
 
       # just see if the code checks out okay
       - name: cargo check
-        run: RUST_BACKTRACE=1 cargo check --all --features "pg${{ matrix.version }}"
+        run: RUST_BACKTRACE=1 cargo check --all --features "pg${{ matrix.version }} pg_test"


### PR DESCRIPTION
In #165 we made it so running `cargo check --features pg13` no longer worked for the root of `pgx-tests`, `cargo check --features "pg13 pg_test"` is required there as it only inserts the required `__pgx_marker` if the `pg_test` feature is enabled.