### PR TITLE
jcrist1 generic tuples

### DIFF
--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -72,6 +72,29 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_get_tuple() {
+        Spi::execute(|client| {
+            let res = client
+                .select(
+                    "SELECT 42::bigint, 'hello', null, 23, 3.141::real",
+                    None,
+                    None,
+                )
+                .next()
+                .expect("Should be at least one entry but none returned!")
+                .get_tuple::<(i64, String, bool, i32, f32)>();
+            let (opt_i64, opt_string, opt_bool, opt_i32, opt_f32) = res;
+            assert_eq!(
+                (opt_i64, opt_string, opt_bool, opt_i32),
+                (Some(42), Some(String::from("hello")), None, Some(23))
+            );
+            assert!(
+                (opt_f32.expect("float entry should be some but wasn't!") - 3.141).abs() < 1.0e-7
+            );
+        });
+    }
+
+    #[pg_test]
     fn test_spi_get_one() {
         Spi::execute(|client| {
             let i = client

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -50,3 +50,5 @@ petgraph = "0.6.0"
 eyre = "0.6.5"
 tracing = "0.1.29"
 tracing-error = "0.2.0"
+tuple_tricks = { git = "https://github.com/jcrist1/tuple_tricks", branch = "main }
+make_tuple_traits = { git = "https://github.com/jcrist1/tuple_tricks", branch = "main }

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -50,5 +50,5 @@ petgraph = "0.6.0"
 eyre = "0.6.5"
 tracing = "0.1.29"
 tracing-error = "0.2.0"
-tuple_tricks = { git = "https://github.com/jcrist1/tuple_tricks", branch = "main }
-make_tuple_traits = { git = "https://github.com/jcrist1/tuple_tricks", branch = "main }
+tuple_tricks = { git = "https://github.com/jcrist1/tuple_tricks", branch = "main" }
+make_tuple_traits = { git = "https://github.com/jcrist1/tuple_tricks", branch = "main" }

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -5,10 +5,12 @@
 
 use crate::{pg_sys, FromDatum, IntoDatum, Json, PgMemoryContexts, PgOid};
 use enum_primitive_derive::*;
+use make_tuple_traits::mark_tuples;
 use num_traits::FromPrimitive;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
+use tuple_tricks::{NestTuple, PreviousTuple, UnnestTuple};
 
 #[derive(Debug, Primitive)]
 pub enum SpiOk {
@@ -458,6 +460,48 @@ impl SpiTupleTable {
     }
 }
 
+mark_tuples!(Marked);
+pub trait TupleDatum {
+    type OptionedTuple;
+    fn get_tuple(spi_heap_tuple_data: &SpiHeapTupleData) -> (Self::OptionedTuple, usize);
+}
+
+impl<A: FromDatum> TupleDatum for (A,) {
+    type OptionedTuple = (Option<A>,);
+    fn get_tuple(spi_heap_tuple_data: &SpiHeapTupleData) -> ((Option<A>,), usize) {
+        let opt_a = spi_heap_tuple_data
+            .by_ordinal(1)
+            .expect("Unable to get element 1 of heap tuple data")
+            .value::<A>();
+        ((opt_a,), 1)
+    }
+}
+impl<T, PrevTuple, Head, PrevOptionedTuple, PrevOptionedTupleNested> TupleDatum for T
+where
+    T: Marked + PreviousTuple<TailTuple = PrevTuple, Head = Head>,
+    Head: FromDatum,
+    PrevTuple: TupleDatum<OptionedTuple = PrevOptionedTuple>,
+    PrevOptionedTuple: NestTuple<Nested = PrevOptionedTupleNested>,
+    (PrevOptionedTupleNested, Option<Head>): UnnestTuple,
+{
+    type OptionedTuple = <(PrevOptionedTupleNested, Option<Head>) as UnnestTuple>::Unnested;
+    fn get_tuple(spi_heap_tuple_data: &SpiHeapTupleData) -> (Self::OptionedTuple, usize) {
+        let (prev_optioned_tupled, last_index) =
+            <PrevTuple as TupleDatum>::get_tuple(spi_heap_tuple_data);
+        let new_index = last_index + 1;
+        let prev_optioned_tupled_nested = prev_optioned_tupled.nest();
+        let new_datum = spi_heap_tuple_data
+            .by_ordinal(new_index)
+            .expect(&format!(
+                "Unnable to get element {} of heap tuple data",
+                new_index
+            ))
+            .value::<Head>();
+        let unnested_new = (prev_optioned_tupled_nested, new_datum).unnest();
+        (unnested_new, new_index)
+    }
+}
+
 impl SpiHeapTupleData {
     /// Create a new `SpiHeapTupleData` from its constituent parts
     pub unsafe fn new(tupdesc: pg_sys::TupleDesc, htup: *mut pg_sys::HeapTupleData) -> Self {
@@ -597,47 +641,13 @@ impl SpiHeapTupleData {
             }
         }
     }
-}
 
-mark_tuples!(Marked);
-pub trait TupleDatum {
-    type OptionedTuple;
-    fn get_tuple(spi_heap_tuple_data: &SpiHeapTupleData) -> (Self::OptionedTuple, usize);
-}
-
-impl<A: FromDatum> TupleDatum for (A,) {
-    type OptionedTuple = (Option<A>,);
-    fn get_tuple(spi_heap_tuple_data: &SpiHeapTupleData) -> ((Option<A>,), usize) {
-        let opt_a = spi_heap_tuple_data
-            .by_ordinal(1)
-            .expect("Unable to get element 1 of heap tuple data")
-            .value::<A>();
-        ((opt_a,), 1)
-    }
-}
-impl<T, PrevTuple, Head, PrevOptionedTuple, PrevOptionedTupleNested> TupleDatum for T
-where
-    T: Marked + PreviousTuple<TailTuple = PrevTuple, Head = Head>,
-    Head: FromDatum,
-    PrevTuple: TupleDatum<OptionedTuple = PrevOptionedTuple>,
-    PrevOptionedTuple: NestTuple<Nested = PrevOptionedTupleNested>,
-    (PrevOptionedTupleNested, Option<Head>): UnnestTuple,
-{
-    type OptionedTuple = <(PrevOptionedTupleNested, Option<Head>) as UnnestTuple>::Unnested;
-    fn get_tuple(spi_heap_tuple_data: &SpiHeapTupleData) -> (Self::OptionedTuple, usize) {
-        let (prev_optioned_tupled, last_index) =
-            <PrevTuple as TupleDatum>::get_tuple(spi_heap_tuple_data);
-        let new_index = last_index + 1;
-        let prev_optioned_tupled_nested = prev_optioned_tupled.nest();
-        let new_datum = spi_heap_tuple_data
-            .by_ordinal(new_index)
-            .expect(&format!(
-                "Unnable to get element {} of heap tuple data",
-                new_index
-            ))
-            .value::<Head>();
-        let unnested_new = (prev_optioned_tupled_nested, new_datum).unnest();
-        (unnested_new, new_index)
+    /// Get a tuple of options by specifying a tuple of inner types
+    /// If the type cannot be cast then returns None. If there aren't enough entries, then it will
+    /// fail
+    pub fn get_tuple<T: TupleDatum>(&self) -> <T as TupleDatum>::OptionedTuple {
+        let (tuple, _) = <T as TupleDatum>::get_tuple(self);
+        tuple
     }
 }
 


### PR DESCRIPTION
This adds a very generic typed tuple deserialisation to SpiHeapTupleData. This depends on a crate I've created that allows induction of methods on tuples on the length of the tuple called tuple-traits. This is more of a proof of concept, and I'd like to solicit feedback on it. 
I'm a little afraid that this might be inefficient, but optimistic that the compiler should optimise all of the extra stuff out, but I haven't profiled it yet.

It adds a method 
```rust
pub fn get_tuple<(A1, A2, ...., An)>(&self) -> (Option<A1>, ..., Option<An>)
```
to the SpiHeapTupleData struct, that will try to get each type from that position.

I implemented a simple test, which is probably the best way of groking how it works.

I think this would be a cool way to get typed entries from Spi, but definitely need some feedback on this and the new dependency that this adds: [tuple_tricks](https://github.com/jcrist1/tuple_tricks)