### PR TITLE
Fix some issues around `STRICT` handling

### DIFF
--- a/pgx-utils/src/sql_entity_graph/pg_extern/argument.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/argument.rs
@@ -265,6 +265,7 @@ impl ToTokens for Argument {
                     match ident_string.as_str() {
                         "Option" => found_optional = true,
                         "VariadicArray" => found_variadic = true,
+                        "Internal" => found_optional = true,
                         _ => (),
                     }
                 }

--- a/pgx/src/datum/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx/src/datum/sql_entity_graph/pg_extern/mod.rs
@@ -80,8 +80,9 @@ impl ToSql for PgExternEntity {
     fn to_sql(&self, context: &super::PgxSql) -> eyre::Result<String> {
         let self_index = context.externs[self];
         let mut extern_attrs = self.extern_attrs.clone();
-        let mut strict_upgrade = true;
-        if !extern_attrs.iter().any(|i| i == &ExternArgs::Strict) {
+        // if we already have a STRICT marker we do not need to add it
+        let mut strict_upgrade = !extern_attrs.iter().any(|i| i == &ExternArgs::Strict);
+        if strict_upgrade {
             for arg in &self.fn_args {
                 if arg.is_optional {
                     strict_upgrade = false;


### PR DESCRIPTION
1. If we have a `#[pg_extern(strict)]` marker, don't add an additional `STRICT` because none of the arguments are optional.
2. `Internal` handles `NULL`s internally, and thus should be considered an optional type for adding `STRICT`. Many functions that take `internal` are required to be non-strict anyway.

Fixes https://github.com/zombodb/pgx/issues/282