### PR TITLE
Add `cargo pgx init --no-restart`

### DIFF
--- a/cargo-pgx/src/cli.yml
+++ b/cargo-pgx/src/cli.yml
@@ -41,6 +41,9 @@ subcommands:
                     takes_value: true
                     required: false
                     help: if installed locally, the path to PG14's 'pg_config' tool, or 'download' to have pgx download/compile/install it
+                - no-restart:
+                    long: no-restart
+                    help: do not stop and initialize the Postgres instance(s) that pgx will point at.
           - start:
               about: start a pgx-managed Postgres instance
               args:
@@ -120,7 +123,7 @@ subcommands:
                 REQUIREMENTS
                     The SQL generation process requires configuring a few settings in the crate. Normally 'cargo pgx schema --force-default'
                     can set these automatically.
-                    
+
                     They are documented in the README.md of cargo-pgx: https://github.com/zombodb/pgx/tree/master/cargo-pgx#Manual-SQL-Generation
               args:
                 - manual:

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -55,7 +55,7 @@ fn do_it() -> std::result::Result<(), std::io::Error> {
 
                 if versions.is_empty() {
                     // no arguments specified, so we'll just install our defaults
-                    init_pgx(&Pgx::default(SUPPORTED_MAJOR_VERSIONS)?)
+                    init_pgx(&Pgx::default(SUPPORTED_MAJOR_VERSIONS)?, true)
                 } else {
                     // user specified arguments, so we'll only install those versions of Postgres
                     let mut default_pgx = None;
@@ -78,7 +78,9 @@ fn do_it() -> std::result::Result<(), std::io::Error> {
                         pgx.push(config);
                     }
 
-                    init_pgx(&pgx)
+                    let initialize_postgres = !init.is_present("no-restart");
+
+                    init_pgx(&pgx, initialize_postgres)
                 }
             }
             ("new", Some(new)) => {


### PR DESCRIPTION
When installing a pgx extension on an already running system, it can be useful to point `cargo pgx` at that system's `pg_config` in order to ensure that the extension is being compiled against the correct version. Right now `cargo pgx init --pgXX` restarts the database, so the only way to do this is by manually writing the `config.toml`. This commit adds a flag to `cargo pgx init` `--no-restart` that suppresses the default behavior, and allows `cargo pgx` to build against an already running system.