### PR TITLE
Allow `extension_sql!` to work on expressions

### DIFF
--- a/pgx-tests/src/tests/extension_sql_tests.rs
+++ b/pgx-tests/src/tests/extension_sql_tests.rs
@@ -1,0 +1,33 @@
+// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
+// governed by the MIT license that can be found in the LICENSE file.
+
+use pgx::*;
+
+extension_sql!(
+    "CREATE TABLE extension_sql_table();\n",
+    name = "extension_sql_table"
+);
+
+extension_sql!(
+    format!("CREATE TABLE extension_sql_{}();\n", "dynamic"),
+    name = "extension_sql_dynamic"
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+
+    use pgx::*;
+
+    #[pg_test]
+    fn test_extension_sql_literal() {
+        Spi::run("SELECT FROM extension_sql_table");
+    }
+
+    #[pg_test]
+    fn test_extension_sql_expression() {
+        Spi::run("SELECT FROM extension_sql_dynamic");
+    }
+}

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod datetime_tests;
 mod default_arg_value_tests;
 mod derive_pgtype_lifetimes;
 mod enum_type_tests;
+mod extension_sql_tests;
 mod fcinfo_tests;
 mod guc_tests;
 mod hooks_tests;

--- a/pgx-utils/src/sql_entity_graph/extension_sql.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql.rs
@@ -3,7 +3,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    LitStr, Token,
+    Expr, LitStr, Token,
 };
 
 use crate::sql_entity_graph::PositioningRef;
@@ -134,7 +134,7 @@ impl ToTokens for ExtensionSqlFile {
 /// ```
 #[derive(Debug, Clone)]
 pub struct ExtensionSql {
-    pub sql: LitStr,
+    pub sql: Expr,
     pub name: LitStr,
     pub attrs: Punctuated<ExtensionSqlAttribute, Token![,]>,
 }
@@ -195,7 +195,7 @@ impl ToTokens for ExtensionSql {
             #[no_mangle]
             pub extern "C" fn  #sql_graph_entity_fn_name() -> pgx::datum::sql_entity_graph::SqlGraphEntity {
                 let submission = pgx::datum::sql_entity_graph::ExtensionSqlEntity {
-                    sql: #sql,
+                    sql: String::from(#sql),
                     module_path: module_path!(),
                     full_path: concat!(file!(), ':', line!()),
                     file: file!(),

--- a/pgx/src/datum/sql_entity_graph/extension_sql.rs
+++ b/pgx/src/datum/sql_entity_graph/extension_sql.rs
@@ -8,7 +8,7 @@ use pgx_utils::sql_entity_graph::SqlDeclared;
 pub struct ExtensionSqlEntity {
     pub module_path: &'static str,
     pub full_path: &'static str,
-    pub sql: &'static str,
+    pub sql: String,
     pub file: &'static str,
     pub line: u32,
     pub name: &'static str,


### PR DESCRIPTION
This commit makes `extension_sql!` work on arbitrary string-returning expressions, not just string literals. The goal for this is to improve rust-sql interop, eventually enabling things such as
```rust
extension_sql! (
    format!(
        "CREATE TABLE example_table(name {}, id {})",
        String::SQL_TYPE,
        i64::SQL_TYPE,
    )
    name = "create_table_demo"
);
```