### PR TITLE
Remove old .so before copying new one into place

### DIFF
--- a/cargo-pgx/src/commands/install.rs
+++ b/cargo-pgx/src/commands/install.rs
@@ -45,6 +45,18 @@ pub(crate) fn install_extension(
         let mut dest = base_directory.clone();
         dest.push(&pkgdir);
         dest.push(format!("{}.so", extname));
+
+        if cfg!(target_os = "macos") {
+            // Remove the existing .so if present. This is a workaround for an
+            // issue highlighted by the following apple documentation:
+            // https://developer.apple.com/documentation/security/updating_mac_software
+            if dest.exists() {
+                handle_result!(
+                std::fs::remove_file(&dest),
+                format!("unable to remove existing file {}", dest.display())
+            )
+            }
+        }
         copy_file(&shlibpath, &dest, "shared library", false);
     }
 


### PR DESCRIPTION
This is a workaround for an issue on new M1 Macs, as outlined in [1].

The basic rundown is: Apple has recently added mandatory signing of
binaries and libraries, with associated automatic signing of
locally-compiled artifacts.

The signature verification uses a static in-kernel inode-based signature
cache. Once cached, the signature associated with an inode is not
updated.

This means that by "copying over" the shared library, the kernel
compares the outdated signature (from its static cache) to the new
shared library contents.

This workaround removes the existing .so, ensuring that a new inode is
used for the newly-compiled extension .so.

Fixes #328

[1]: https://developer.apple.com/documentation/security/updating_mac_software