### PR TITLE
Obtain extension version from Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-pgx"
 version = "0.2.6"
 dependencies = [
+ "cargo_metadata",
  "clap",
  "colored",
  "env_proxy",
@@ -257,6 +267,28 @@ dependencies = [
  "symbolic",
  "syn",
  "unescape",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.4",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1865,6 +1897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [ "*.png" ]
 
 
 [dependencies]
+cargo_metadata = "0.14.1"
 clap = { version = "2.34.0", features = [ "yaml" ] }
 colored = "2.0.0"
 env_proxy = "0.4.1"

--- a/cargo-pgx/src/templates/control
+++ b/cargo-pgx/src/templates/control
@@ -1,5 +1,5 @@
 comment = '{name}:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/{name}'
 relocatable = false
 superuser = false

--- a/nix/templates/default/pgx_demo.control
+++ b/nix/templates/default/pgx_demo.control
@@ -1,5 +1,5 @@
 comment = 'pgx_demo:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pgx_demo'
 relocatable = false
 superuser = false

--- a/pgx-examples/aggregate/aggregate.control
+++ b/pgx-examples/aggregate/aggregate.control
@@ -1,5 +1,5 @@
 comment = 'aggregate:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/aggregate'
 relocatable = false
 superuser = false

--- a/pgx-examples/arrays/arrays.control
+++ b/pgx-examples/arrays/arrays.control
@@ -1,5 +1,5 @@
 comment = 'arrays:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/arrays'
 relocatable = false
 superuser = false

--- a/pgx-examples/bad_ideas/bad_ideas.control
+++ b/pgx-examples/bad_ideas/bad_ideas.control
@@ -1,5 +1,5 @@
 comment = 'bad_ideas:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/bad_ideas'
 relocatable = false
 superuser = false

--- a/pgx-examples/bgworker/bgworker.control
+++ b/pgx-examples/bgworker/bgworker.control
@@ -1,5 +1,5 @@
 comment = 'bgworker:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/bgworker'
 relocatable = false
 superuser = false

--- a/pgx-examples/bytea/bytea.control
+++ b/pgx-examples/bytea/bytea.control
@@ -1,5 +1,5 @@
 comment = 'bytea:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/bytea'
 relocatable = false
 superuser = false

--- a/pgx-examples/custom_sql/custom_sql.control
+++ b/pgx-examples/custom_sql/custom_sql.control
@@ -1,5 +1,5 @@
 comment = 'custom_sql:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/custom_sql'
 relocatable = false
 superuser = false

--- a/pgx-examples/custom_types/custom_types.control
+++ b/pgx-examples/custom_types/custom_types.control
@@ -1,5 +1,5 @@
 comment = 'custom_types:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/custom_types'
 relocatable = false
 superuser = false

--- a/pgx-examples/errors/errors.control
+++ b/pgx-examples/errors/errors.control
@@ -1,5 +1,5 @@
 comment = 'errors:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/errors'
 relocatable = false
 superuser = false

--- a/pgx-examples/operators/operators.control
+++ b/pgx-examples/operators/operators.control
@@ -1,5 +1,5 @@
 comment = 'operators:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/operators'
 relocatable = false
 superuser = false

--- a/pgx-examples/schemas/schemas.control
+++ b/pgx-examples/schemas/schemas.control
@@ -1,5 +1,5 @@
 comment = 'schemas:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/schemas'
 relocatable = false
 superuser = true    # b/c this extension creates objects in "pg_catalog"

--- a/pgx-examples/shmem/shmem.control
+++ b/pgx-examples/shmem/shmem.control
@@ -1,5 +1,5 @@
 comment = 'shmem:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/shmem'
 relocatable = false
 superuser = false

--- a/pgx-examples/spi/spi.control
+++ b/pgx-examples/spi/spi.control
@@ -1,5 +1,5 @@
 comment = 'spi:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/spi'
 relocatable = false
 superuser = false

--- a/pgx-examples/srf/srf.control
+++ b/pgx-examples/srf/srf.control
@@ -1,5 +1,5 @@
 comment = 'srf:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/srf'
 relocatable = false
 superuser = false

--- a/pgx-examples/strings/strings.control
+++ b/pgx-examples/strings/strings.control
@@ -1,5 +1,5 @@
 comment = 'strings:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/strings'
 relocatable = false
 superuser = false

--- a/pgx-examples/triggers/triggers.control
+++ b/pgx-examples/triggers/triggers.control
@@ -1,5 +1,5 @@
 comment = 'triggers:  Created by pgx'
-default_version = '1.0'
+default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/triggers'
 relocatable = false
 superuser = false


### PR DESCRIPTION
This change allows the version to flow from Cargo.toml into the control
file. To enable this behavior default_version in the control file must
be set to '@CARGO_VERSION@'.

Fixes #344