### PR TITLE
Fix schema generation on alpine

### DIFF
--- a/cargo-pgx/src/templates/cargo_config
+++ b/cargo-pgx/src/templates/cargo_config
@@ -6,6 +6,12 @@ linker = ".cargo/pgx-linker-script.sh"
 [target.aarch64-unknown-linux-gnu]
 linker = ".cargo/pgx-linker-script.sh"
 
+[target.x86_64-unknown-linux-musl]
+linker = ".cargo/pgx-linker-script.sh"
+
+[target.aarch64-unknown-linux-musl]
+linker = ".cargo/pgx-linker-script.sh"
+
 [target.x86_64-apple-darwin]
 linker = ".cargo/pgx-linker-script.sh"
 


### PR DESCRIPTION
Alpine uses musl libc, which is identified as a different compilation
target by the Rust compiler. This target was not configured to use pgx's
magical linker script, so the symbols which the schema generator expects
to be present were not present.

Fixes #340