### PR TITLE
Disable PGUSER env when checking for existing database

### DIFF
--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -141,7 +141,7 @@ fn does_db_exist(pg_config: &PgConfig, dbname: &str) -> Result<bool, std::io::Er
     let mut command = Command::new(pg_config.psql_path()?);
     command
         .arg("-XqAt")
-        .arg("-U postgres")
+        .env_remove("PGUSER")
         .arg("-h")
         .arg(pg_config.host())
         .arg("-p")

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -141,6 +141,7 @@ fn does_db_exist(pg_config: &PgConfig, dbname: &str) -> Result<bool, std::io::Er
     let mut command = Command::new(pg_config.psql_path()?);
     command
         .arg("-XqAt")
+        .arg("-U postgres")
         .arg("-h")
         .arg(pg_config.host())
         .arg("-p")


### PR DESCRIPTION
Alike for when pgx does CREATE DATABASE, this commit forces disabling of PGUSER when checking for existing database. 

This failed on my test setup, since I had setup PGUSER (for other projects) but that caused `cargo pgx init` to fail.

There is no need to disable PGHOST / PGPASSWORD / PGPORT since that's being set at this point anyway (so they would override the env settings)