### PR TITLE
Allow pgx-pg-sys docs to build on docs.rs

### DIFF
--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -24,6 +24,7 @@ no-default-features = true
 targets = ["x86_64-unknown-linux-gnu"]
 # Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.6.5"


### PR DESCRIPTION
This should work according to my tests running docs.rs locally. 

Docs: https://docs.rs/about/metadata