### PR TITLE
Validate cargo-pgx and pgx crates are compatible using semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ version = "0.2.6"
 dependencies = [
  "cargo_metadata",
  "clap 3.0.10",
+ "clap-cargo",
  "color-eyre",
  "colored",
  "env_proxy",
@@ -266,6 +267,7 @@ dependencies = [
  "rayon",
  "regex",
  "rttp_client",
+ "semver 1.0.4",
  "symbolic",
  "syn",
  "tracing",
@@ -358,6 +360,17 @@ dependencies = [
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap-cargo"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551b6aa534ced210e29bc4ea2016bc11c74770f0a2b94b29dfc1a92ab6fc28d4"
+dependencies = [
+ "cargo_metadata",
+ "clap 3.0.10",
+ "doc-comment",
 ]
 
 [[package]]
@@ -568,6 +581,12 @@ name = "dmsort"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4699f5cb7678f099b747ffdc1e6ce6cdc42579e29d28315aa715b9fd10324fc"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -17,6 +17,8 @@ exclude = [ "*.png" ]
 [dependencies]
 cargo_metadata = "0.14.1"
 clap = { version = "3.0.10", features = [ "env", "suggestions", "cargo", "derive" ] }
+clap-cargo = { version = "0.8", features = [ "cargo_metadata" ] }
+semver = "1"
 colored = "2.0.0"
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -26,9 +26,8 @@ pub(crate) struct Install {
     /// The `pg_config` path (default is first in $PATH)
     #[clap(long, short = 'c')]
     pg_config: Option<String>,
-    /// Additional cargo features to activate (default is '--no-default-features')
-    #[clap(long, short)]
-    features: Option<Vec<String>>,
+    #[clap(flatten)]
+    features: clap_cargo::Features,
     #[clap(from_global, parse(from_occurrences))]
     verbose: usize,
 }
@@ -36,7 +35,6 @@ pub(crate) struct Install {
 impl CommandExecute for Install {
     #[tracing::instrument(level = "error", skip(self))]
     fn execute(self) -> eyre::Result<()> {
-        let features = self.features.unwrap_or(vec![]);
         let pg_config =
             match std::env::var("PGX_TEST_MODE_VERSION") {
                 // for test mode, we want the pg_config specified in PGX_TEST_MODE_VERSION
@@ -54,7 +52,7 @@ impl CommandExecute for Install {
                 },
             };
 
-        install_extension(&pg_config, self.release, self.no_schema, None, &features)
+        install_extension(&pg_config, self.release, self.no_schema, None, &self.features)
     }
 }
 
@@ -68,7 +66,7 @@ pub(crate) fn install_extension(
     is_release: bool,
     no_schema: bool,
     base_directory: Option<PathBuf>,
-    additional_features: &Vec<impl AsRef<str>>,
+    features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
     let base_directory = base_directory.unwrap_or("/".into());
     tracing::Span::current().record(
@@ -86,7 +84,7 @@ pub(crate) fn install_extension(
         ));
     }
 
-    build_extension(major_version, is_release, &*additional_features)?;
+    build_extension(major_version, is_release, &features)?;
 
     println!();
     println!("installing extension");
@@ -123,7 +121,7 @@ pub(crate) fn install_extension(
         copy_sql_files(
             pg_config,
             is_release,
-            additional_features,
+            features,
             &extdir,
             &base_directory,
         )?;
@@ -173,31 +171,38 @@ fn copy_file(src: &PathBuf, dest: &PathBuf, msg: &str, do_filter: bool) -> eyre:
 pub(crate) fn build_extension(
     major_version: u16,
     is_release: bool,
-    additional_features: &Vec<impl AsRef<str>>,
+    features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
-    let additional_features = additional_features
-        .iter()
-        .map(AsRef::as_ref)
-        .collect::<Vec<_>>();
-    let mut features =
+    let pgx_build_features =
         std::env::var("PGX_BUILD_FEATURES").unwrap_or(format!("pg{}", major_version));
     let flags = std::env::var("PGX_BUILD_FLAGS").unwrap_or_default();
-    if !additional_features.is_empty() {
+    
+    let features_arg = if !features.features.is_empty() {
         use std::fmt::Write;
-        let mut additional_features = additional_features.join(" ");
-        let _ = write!(&mut additional_features, " {}", features);
-        features = additional_features
-    }
+        let mut additional_features = features.features.join(" ");
+        let _ = write!(&mut additional_features, " {}", pgx_build_features);
+        additional_features
+    } else { pgx_build_features };
+
     let mut command = Command::new("cargo");
     command.arg("build");
     if is_release {
         command.arg("--release");
     }
 
-    if !features.trim().is_empty() {
+    if !features_arg.trim().is_empty() {
         command.arg("--features");
-        command.arg(&features);
+        command.arg(&features_arg);
+        // While this is not 'correct' `cargo` does not let us negate features.
         command.arg("--no-default-features");
+    }
+
+    if features.no_default_features && features_arg.trim().is_empty() {
+        command.arg("--no-default-features");
+    }
+
+    if features.all_features {
+        command.arg("--all-features");
     }
 
     for arg in flags.split_ascii_whitespace() {
@@ -208,7 +213,7 @@ pub(crate) fn build_extension(
     let command_str = format!("{:?}", command);
     println!(
         "building extension with features `{}`\n{}",
-        features, command_str
+        features_arg, command_str
     );
     let status = command
         .status()
@@ -234,7 +239,7 @@ fn get_target_sql_file(extdir: &PathBuf, base_directory: &PathBuf) -> eyre::Resu
 fn copy_sql_files(
     pg_config: &PgConfig,
     is_release: bool,
-    additional_features: &Vec<impl AsRef<str>>,
+    features: &clap_cargo::Features,
     extdir: &PathBuf,
     base_directory: &PathBuf,
 ) -> eyre::Result<()> {
@@ -244,7 +249,7 @@ fn copy_sql_files(
     crate::command::schema::generate_schema(
         pg_config,
         is_release,
-        additional_features,
+        features,
         &dest,
         Option::<String>::None,
         None,

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -19,9 +19,8 @@ pub(crate) struct Package {
     /// The `pg_config` path (default is first in $PATH)
     #[clap(long, short = 'c', parse(from_os_str))]
     pg_config: Option<PathBuf>,
-    /// Additional cargo features to activate (default is '--no-default-features')
-    #[clap(long)]
-    features: Vec<String>,
+    #[clap(flatten)]
+    features: clap_cargo::Features,
     #[clap(from_global, parse(from_occurrences))]
     verbose: usize,
 }
@@ -44,7 +43,7 @@ impl CommandExecute for Package {
 pub(crate) fn package_extension(
     pg_config: &PgConfig,
     is_debug: bool,
-    additional_features: &Vec<impl AsRef<str>>,
+    features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
     let base_path = build_base_path(pg_config, is_debug)?;
 
@@ -60,7 +59,7 @@ pub(crate) fn package_extension(
         !is_debug,
         false,
         Some(base_path),
-        additional_features,
+        features,
     )
 }
 

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -54,13 +54,7 @@ pub(crate) fn package_extension(
     if !base_path.exists() {
         std::fs::create_dir_all(&base_path)?;
     }
-    install_extension(
-        pg_config,
-        !is_debug,
-        false,
-        Some(base_path),
-        features,
-    )
+    install_extension(pg_config, !is_debug, false, Some(base_path), features)
 }
 
 fn build_base_path(pg_config: &PgConfig, is_debug: bool) -> eyre::Result<PathBuf> {

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -29,9 +29,8 @@ pub(crate) struct Run {
     /// Don't regenerate the schema
     #[clap(long, short)]
     no_schema: bool,
-    /// Additional cargo features to activate (default is '--no-default-features')
-    #[clap(long)]
-    features: Vec<String>,
+    #[clap(flatten)]
+    features: clap_cargo::Features,
     #[clap(from_global, parse(from_occurrences))]
     verbose: usize,
 }
@@ -64,13 +63,13 @@ pub(crate) fn run_psql(
     dbname: &str,
     is_release: bool,
     no_schema: bool,
-    additional_features: &Vec<impl AsRef<str>>,
+    features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
     // stop postgres
     stop_postgres(pg_config)?;
 
     // install the extension
-    install_extension(pg_config, is_release, no_schema, None, additional_features)?;
+    install_extension(pg_config, is_release, no_schema, None, features)?;
 
     // restart postgres
     start_postgres(pg_config)?;

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -45,9 +45,8 @@ pub(crate) struct Schema {
     /// The `pg_config` path (default is first in $PATH)
     #[clap(long, short = 'c', parse(from_os_str))]
     pg_config: Option<PathBuf>,
-    /// Additional cargo features to activate (default is `--no-default-features`)
-    #[clap(long)]
-    features: Vec<String>,
+    #[clap(flatten)]
+    features: clap_cargo::Features,
     /// A path to output a produced SQL file (default is `sql/$EXTNAME-$VERSION.sql`)
     #[clap(long, short, parse(from_os_str))]
     out: Option<PathBuf>,
@@ -103,8 +102,6 @@ impl CommandExecute for Schema {
                 },
             };
 
-        let _span = tracing::info_span!("version", pg_version = %pg_config.version()?).entered();
-
         generate_schema(
             &pg_config,
             self.release,
@@ -128,7 +125,7 @@ impl CommandExecute for Schema {
 pub(crate) fn generate_schema(
     pg_config: &PgConfig,
     is_release: bool,
-    additional_features: &Vec<impl AsRef<str>>,
+    features: &clap_cargo::Features,
     path: impl AsRef<std::path::Path>,
     dot: Option<impl AsRef<std::path::Path>>,
     log_level: Option<String>,
@@ -136,10 +133,8 @@ pub(crate) fn generate_schema(
     manual: bool,
     skip_build: bool,
 ) -> eyre::Result<()> {
-    let additional_features = additional_features
-        .iter()
-        .map(AsRef::as_ref)
-        .collect::<Vec<_>>();
+    crate::validate::validate(&features)?;
+
     let (control_file, _extname) = find_control_file()?;
     let major_version = pg_config.major_version()?;
 
@@ -197,15 +192,18 @@ pub(crate) fn generate_schema(
         ))
     }
 
-    let mut features =
+    let pgx_build_features =
         std::env::var("PGX_BUILD_FEATURES").unwrap_or(format!("pg{}", major_version));
-    let flags = std::env::var("PGX_BUILD_FLAGS").unwrap_or_default();
-    if !additional_features.is_empty() {
+    let features_arg = if !features.features.is_empty() {
         use std::fmt::Write;
-        let mut additional_features = additional_features.join(" ");
-        let _ = write!(&mut additional_features, " {}", features);
-        features = additional_features
-    }
+        let mut additional_features = features.features.join(" ");
+        let _ = write!(&mut additional_features, " {}", pgx_build_features);
+        additional_features
+    } else {
+        pgx_build_features
+    };
+    
+    let flags = std::env::var("PGX_BUILD_FLAGS").unwrap_or_default();
 
     if !skip_build {
         // First, build the SQL generator so we can get a look at the symbol table
@@ -219,11 +217,21 @@ pub(crate) fn generate_schema(
             command.env("RUST_LOG", log_level);
         }
 
-        if !features.trim().is_empty() {
+        if !features_arg.trim().is_empty() {
             command.arg("--features");
-            command.arg(&features);
+            command.arg(&features_arg);
+            // While this is not 'correct' `cargo` does not let us negate features.
             command.arg("--no-default-features");
         }
+
+        if features.no_default_features && features_arg.trim().is_empty() {
+            command.arg("--no-default-features");
+        }
+
+        if features.all_features {
+            command.arg("--all-features");
+        }
+
 
         for arg in flags.split_ascii_whitespace() {
             command.arg(arg);
@@ -234,7 +242,7 @@ pub(crate) fn generate_schema(
         println!(
             "{} SQL generator with features `{}`\n{}",
             "    Building".bold().green(),
-            features,
+            features_arg,
             command_str
         );
         let status = command

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -4,9 +4,7 @@ use crate::{
 };
 use colored::Colorize;
 use eyre::{eyre, WrapErr};
-use pgx_utils::{
-    pg_config::{PgConfig, Pgx},
-};
+use pgx_utils::pg_config::{PgConfig, Pgx};
 use std::{
     collections::HashSet,
     fs::File,
@@ -189,7 +187,7 @@ pub(crate) fn generate_schema(
         return Err(eyre!(
             "{}:  The `relocatable` property MUST be `false`.  Please update your .control file.",
             control_file.display()
-        ))
+        ));
     }
 
     let pgx_build_features =
@@ -202,7 +200,7 @@ pub(crate) fn generate_schema(
     } else {
         pgx_build_features
     };
-    
+
     let flags = std::env::var("PGX_BUILD_FLAGS").unwrap_or_default();
 
     if !skip_build {
@@ -231,7 +229,6 @@ pub(crate) fn generate_schema(
         if features.all_features {
             command.arg("--all-features");
         }
-
 
         for arg in flags.split_ascii_whitespace() {
             command.arg(arg);

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -118,7 +118,8 @@ impl CommandExecute for Schema {
     pg_version = %pg_config.version()?,
     release = is_release,
     path,
-    dot
+    dot,
+    features = ?features.features,
 ))]
 pub(crate) fn generate_schema(
     pg_config: &PgConfig,

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -2,10 +2,12 @@
 // governed by the MIT license that can be found in the LICENSE file.
 
 mod command;
+mod validate;
 
 use clap::Parser;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
 const SUPPORTED_MAJOR_VERSIONS: &[u16] = &[10, 11, 12, 13, 14];
 
 trait CommandExecute {

--- a/cargo-pgx/src/validate.rs
+++ b/cargo-pgx/src/validate.rs
@@ -10,10 +10,12 @@ pub fn validate(features: &clap_cargo::Features) -> eyre::Result<()> {
     let cargo_pgx_version = env!("CARGO_PKG_VERSION");
     let cargo_pgx_version_req = VersionReq::parse(&format!("^{}", cargo_pgx_version))?;
 
-    let pgx_packages = metadata.packages.iter().filter(|package| 
-        package.name == "pgx" || package.name == "pgx-utils" ||
-        package.name == "pgx-macros" || package.name == "pgx-tests"
-    );
+    let pgx_packages = metadata.packages.iter().filter(|package| {
+        package.name == "pgx"
+            || package.name == "pgx-utils"
+            || package.name == "pgx-macros"
+            || package.name == "pgx-tests"
+    });
 
     for package in pgx_packages {
         let package_semver = metadata_version_to_semver(package.version.clone());
@@ -42,8 +44,8 @@ fn metadata_version_to_semver(metadata_version: cargo_metadata::Version) -> semv
     Version {
         major: metadata_version.major,
         minor: metadata_version.minor,
-        patch:  metadata_version.patch,
-        pre:  metadata_version.pre,
+        patch: metadata_version.patch,
+        pre: metadata_version.pre,
         build: metadata_version.build,
     }
 }

--- a/cargo-pgx/src/validate.rs
+++ b/cargo-pgx/src/validate.rs
@@ -1,0 +1,49 @@
+use cargo_metadata::MetadataCommand;
+use semver::{Version, VersionReq};
+
+#[tracing::instrument(level = "error", skip(features))]
+pub fn validate(features: &clap_cargo::Features) -> eyre::Result<()> {
+    let mut metadata_command = MetadataCommand::new();
+    features.forward_metadata(&mut metadata_command);
+    let metadata = metadata_command.exec()?;
+
+    let cargo_pgx_version = env!("CARGO_PKG_VERSION");
+    let cargo_pgx_version_req = VersionReq::parse(&format!("^{}", cargo_pgx_version))?;
+
+    let pgx_packages = metadata.packages.iter().filter(|package| 
+        package.name == "pgx" || package.name == "pgx-utils" ||
+        package.name == "pgx-macros" || package.name == "pgx-tests"
+    );
+
+    for package in pgx_packages {
+        let package_semver = metadata_version_to_semver(package.version.clone());
+        if !cargo_pgx_version_req.matches(&package_semver) {
+            // This will not always be a hard error. We just warn.
+            tracing::warn!(
+                "`{}-{}` may not be compatible with `cargo-pgx-{}`, you may need to upgrade.",
+                package.name,
+                package.version,
+                cargo_pgx_version,
+            );
+        } else {
+            tracing::trace!(
+                "`{}-{}` is compatible with `cargo-pgx-{}`.",
+                package.name,
+                package.version,
+                cargo_pgx_version,
+            )
+        }
+    }
+
+    Ok(())
+}
+
+fn metadata_version_to_semver(metadata_version: cargo_metadata::Version) -> semver::Version {
+    Version {
+        major: metadata_version.major,
+        minor: metadata_version.minor,
+        patch:  metadata_version.patch,
+        pre:  metadata_version.pre,
+        build: metadata_version.build,
+    }
+}

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -7,8 +7,8 @@ use lazy_static::*;
 use std::sync::{Arc, Mutex};
 
 use colored::*;
-use pgx::*;
 use eyre::{eyre, WrapErr};
+use pgx::*;
 use pgx_utils::pg_config::{PgConfig, Pgx};
 use pgx_utils::{createdb, get_named_capture, get_target_dir};
 use postgres::error::DbError;
@@ -135,7 +135,9 @@ pub fn run_test(
     } else if let Some(expected_error_message) = expected_error {
         // we expected an ERROR, but didn't get one
         return Err(eyre!("Expected error: {}", expected_error_message));
-    } else { Ok(()) }
+    } else {
+        Ok(())
+    }
 }
 
 fn format_loglines(session_id: &str, loglines: &LogLines) -> String {
@@ -155,7 +157,9 @@ fn format_loglines(session_id: &str, loglines: &LogLines) -> String {
     result
 }
 
-fn initialize_test_framework(postgresql_conf: Vec<&'static str>) -> eyre::Result<(LogLines, String)> {
+fn initialize_test_framework(
+    postgresql_conf: Vec<&'static str>,
+) -> eyre::Result<(LogLines, String)> {
     let mut state = TEST_MUTEX.lock().unwrap_or_else(|_| {
         // if we can't get the lock, that means it was poisoned,
         // so we just abruptly exit, which cuts down on test failure spam

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -457,7 +457,7 @@ macro_rules! pg_binary_magic {
                 .init();
             color_eyre::install()?;
 
-            // Prior to 0.2.7 the `cargo-pgx pgx schema` command would pass symbols in comma-separated.
+            // After 0.2.6 the `cargo-pgx pgx schema` command would pass symbols in comma-separated.
             // This catches that, warns, and handles it.
             let sql_generator_cli = if sql_generator_cli.symbols.len() == 1 && sql_generator_cli.symbols[0].contains(",") {
                 tracing::warn!("`pgx` 0.2.7 changed how schema arguments are passed to the `sql-generator`. You are using a post-0.2.7 `pgx` with a 0.2.6 (or earlier) `cargo-pgx`. Please update `cargo-pgx`.");


### PR DESCRIPTION
This PR cleans up some of our feature handling for `cargo-pgx` to use the same API that `cargo` itself uses (with `--no-default-features` etc) and uses that new API to validate that the `pgx` crates appearing in the metadata are indeed semver compatible with `cargo-pgx`. It warns if they are not.

This is a safety step for when we make breaking changes in the future. It is not itself a breaking change.

![image](https://user-images.githubusercontent.com/130903/150235866-12041f33-e0fd-4142-8d93-37cc7fb65906.png)
