### PR TITLE
Relax memctx closures from Fn to FnOnce

### DIFF
--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -257,7 +257,7 @@ impl PgMemoryContexts {
     /// ```
     pub fn switch_to<
         R,
-        F: Fn(&mut PgMemoryContexts) -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
+        F: FnOnce(&mut PgMemoryContexts) -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
     >(
         &mut self,
         f: F,
@@ -371,7 +371,7 @@ impl PgMemoryContexts {
     /// helper function
     fn exec_in_context<
         R,
-        F: Fn(&mut PgMemoryContexts) -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
+        F: FnOnce(&mut PgMemoryContexts) -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
     >(
         context: pg_sys::MemoryContext,
         f: F,


### PR DESCRIPTION
While working on #230 I was trying to use `pgx::memcxt::PgMemoryContexts::exec_in_context` and `pgx::memcxt::PgMemoryContexts::switch_to` and realized they used `Fn` over `FnOnce`.

This means that closures using it:

```rust
let internal = String::default();
PgMemoryContexts::TopTransactionContext.switch_to(|context| {
    let path = Path::from(internal); // <-- `internal` must be moved here by value, not ref.
});
```

Would get errors like: "cannot move out of `internal`, a captured variable in an `Fn` closure`"

This should not break anything for users, as it's a general relaxation.

* `FnOnce`: https://doc.rust-lang.org/std/ops/trait.FnOnce.html
* `Fn`: https://doc.rust-lang.org/std/ops/trait.Fn.html

Notably:

> Since both Fn and FnMut are subtraits of FnOnce, any instance of Fn or FnMut can be used where a FnOnce is expected.