### PR TITLE
Correctly transform control file version number in sql entity graph

### DIFF
--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -326,10 +326,9 @@ pub(crate) fn get_version() -> eyre::Result<String> {
     match get_property("default_version")? {
         Some(v) => {
             if v == "@CARGO_VERSION@" {
-                let metadata = MetadataCommand::new()
-                    .exec()
-                    .wrap_err("failed to parse Cargo.toml")?;
-                Ok(metadata.root_package().unwrap().version.to_string())
+                let metadata = MetadataCommand::new().exec()?;
+                let root_package = metadata.root_package().ok_or(eyre!("no root package found"))?;
+                Ok(root_package.version.to_string())
             } else {
                 Ok(v)
             }

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -338,14 +338,17 @@ macro_rules! pg_sql_graph_magic {
         > {
             use pgx::datum::sql_entity_graph::reexports::eyre::WrapErr;
             use std::convert::TryFrom;
+            let package_version = env!("CARGO_PKG_VERSION");
             let context = include_str!(concat!(
                 env!("CARGO_MANIFEST_DIR"),
                 "/",
                 env!("CARGO_CRATE_NAME"),
                 ".control"
-            ));
-            let control_file = pgx::datum::sql_entity_graph::ControlFile::try_from(context)
-                .wrap_err_with(|| "Could not parse control file, is it valid?")?;
+            ))
+            .replace("@CARGO_VERSION@", package_version);
+            let control_file =
+                pgx::datum::sql_entity_graph::ControlFile::try_from(context.as_str())
+                    .wrap_err_with(|| "Could not parse control file, is it valid?")?;
             Ok(control_file)
         }
     };


### PR DESCRIPTION
Commit f00c335a7 added the ability to use '@CARGO_VERSION@' as a
placeholder for 'default_version' in the extension's .control file.

That change missed the fact that the contents of the .control file are
loaded into the root node of the sql entity graph. This means that when
using the placeholder, the default_version in the sql entity graph's
control file is '@CARGO_VERSION@'.

This change replaces the placeholder with the package version when
executing the compiled sql-generator.