### PR TITLE
feat: extend sql generation via to_sql attribute

### DIFF
--- a/pgx-macros/src/operators.rs
+++ b/pgx-macros/src/operators.rs
@@ -1,17 +1,18 @@
 use pgx_utils::{operator_common::*, sql_entity_graph};
+
 use quote::ToTokens;
 use syn::DeriveInput;
 
-pub(crate) fn impl_postgres_eq(ast: DeriveInput) -> proc_macro2::TokenStream {
+pub(crate) fn impl_postgres_eq(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut stream = proc_macro2::TokenStream::new();
 
     stream.extend(eq(&ast.ident));
     stream.extend(ne(&ast.ident));
 
-    stream
+    Ok(stream)
 }
 
-pub(crate) fn impl_postgres_ord(ast: DeriveInput) -> proc_macro2::TokenStream {
+pub(crate) fn impl_postgres_ord(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut stream = proc_macro2::TokenStream::new();
 
     stream.extend(lt(&ast.ident));
@@ -20,19 +21,19 @@ pub(crate) fn impl_postgres_ord(ast: DeriveInput) -> proc_macro2::TokenStream {
     stream.extend(ge(&ast.ident));
     stream.extend(cmp(&ast.ident));
 
-    let sql_graph_entity_item = sql_entity_graph::PostgresOrd::new(ast.ident.clone());
+    let sql_graph_entity_item = sql_entity_graph::PostgresOrd::from_derive_input(ast)?;
     sql_graph_entity_item.to_tokens(&mut stream);
 
-    stream
+    Ok(stream)
 }
 
-pub(crate) fn impl_postgres_hash(ast: DeriveInput) -> proc_macro2::TokenStream {
+pub(crate) fn impl_postgres_hash(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut stream = proc_macro2::TokenStream::new();
 
     stream.extend(hash(&ast.ident));
 
-    let sql_graph_entity_item = sql_entity_graph::PostgresHash::new(ast.ident.clone());
+    let sql_graph_entity_item = sql_entity_graph::PostgresHash::from_derive_input(ast)?;
     sql_graph_entity_item.to_tokens(&mut stream);
 
-    stream
+    Ok(stream)
 }

--- a/pgx-tests/src/tests/schema_tests.rs
+++ b/pgx-tests/src/tests/schema_tests.rs
@@ -4,14 +4,66 @@ use pgx::*;
 
 #[pgx::pg_schema]
 mod test_schema {
+    use pgx::datum::sql_entity_graph::{PgxSql, SqlGraphEntity};
     use pgx::*;
     use serde::{Deserialize, Serialize};
 
     #[pg_extern]
     fn func_in_diff_schema() {}
 
+    #[pg_extern(sql = false)]
+    fn func_elided_from_schema() {}
+
+    #[pg_extern(sql = generate_function)]
+    fn func_generated_with_custom_sql() {}
+
     #[derive(Debug, PostgresType, Serialize, Deserialize)]
     pub struct TestType(pub u64);
+
+    #[derive(Debug, PostgresType, Serialize, Deserialize)]
+    #[pgx(sql = false)]
+    pub struct ElidedType(pub u64);
+
+    #[derive(Debug, PostgresType, Serialize, Deserialize)]
+    #[pgx(sql = generate_type)]
+    pub struct OtherType(pub u64);
+
+    #[derive(Debug, PostgresType, Serialize, Deserialize)]
+    #[pgx(sql = "CREATE TYPE test_schema.ManuallyRenderedType;")]
+    pub struct OverriddenType(pub u64);
+
+    fn generate_function(
+        entity: &SqlGraphEntity,
+        _context: &PgxSql,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        if let SqlGraphEntity::Function(ref func) = entity {
+            Ok(format!("\
+                CREATE OR REPLACE FUNCTION test_schema.\"func_generated_with_custom_name\"() RETURNS void\n\
+                LANGUAGE c /* Rust */\n\
+                AS 'MODULE_PATHNAME', '{unaliased_name}_wrapper';\
+                ",
+                unaliased_name = func.unaliased_name,
+            ))
+        } else {
+            panic!("expected extern function entity, got {:?}", entity);
+        }
+    }
+
+    fn generate_type(
+        entity: &SqlGraphEntity,
+        _context: &PgxSql,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        if let SqlGraphEntity::Type(ref ty) = entity {
+            Ok(format!(
+                "\n\
+                CREATE TYPE test_schema.Custom{name};\
+                ",
+                name = ty.name,
+            ))
+        } else {
+            panic!("expected type entity, got {:?}", entity);
+        }
+    }
 }
 
 #[pg_extern(schema = "test_schema")]
@@ -43,5 +95,65 @@ mod tests {
     #[pg_test]
     fn test_type_in_different_schema() {
         Spi::run("SELECT type_in_diff_schema();");
+    }
+
+    #[pg_test]
+    fn elided_extern_is_elided() {
+        // Validate that a function we know exists, exists
+        let result: bool = Spi::get_one(
+            "SELECT exists(SELECT 1 FROM pg_proc WHERE proname = 'func_in_diff_schema');",
+        )
+        .expect("expected result");
+        assert_eq!(result, true);
+
+        // Validate that the function we expect not to exist, doesn't
+        let result: bool = Spi::get_one(
+            "SELECT exists(SELECT 1 FROM pg_proc WHERE proname = 'func_elided_from_schema');",
+        )
+        .expect("expected result");
+        assert_eq!(result, false);
+    }
+
+    #[pg_test]
+    fn elided_type_is_elided() {
+        // Validate that a type we know exists, exists
+        let result: bool =
+            Spi::get_one("SELECT exists(SELECT 1 FROM pg_type WHERE typname = 'testtype');")
+                .expect("expected result");
+        assert_eq!(result, true);
+
+        // Validate that the type we expect not to exist, doesn't
+        let result: bool =
+            Spi::get_one("SELECT exists(SELECT 1 FROM pg_type WHERE typname = 'elidedtype');")
+                .expect("expected result");
+        assert_eq!(result, false);
+    }
+
+    #[pg_test]
+    fn custom_to_sql_extern() {
+        // Validate that the function we generated has the modifications we expect
+        let result: bool = Spi::get_one("SELECT exists(SELECT 1 FROM pg_proc WHERE proname = 'func_generated_with_custom_name');").expect("expected result");
+        assert_eq!(result, true);
+
+        Spi::run("SELECT test_schema.func_generated_with_custom_name();");
+    }
+
+    #[pg_test]
+    fn custom_to_sql_type() {
+        // Validate that the type we generated has the expected modifications
+        let result: bool =
+            Spi::get_one("SELECT exists(SELECT 1 FROM pg_type WHERE typname = 'customothertype');")
+                .expect("expected result");
+        assert_eq!(result, true);
+    }
+
+    #[pg_test]
+    fn custom_handwritten_to_sql_type() {
+        // Validate that the SQL we provided was used
+        let result: bool = Spi::get_one(
+            "SELECT exists(SELECT 1 FROM pg_type WHERE typname = 'manuallyrenderedtype');",
+        )
+        .expect("expected result");
+        assert_eq!(result, true);
     }
 }

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -311,6 +311,12 @@ pub fn parse_extern_attributes(attr: TokenStream) -> HashSet<ExternArgs> {
                         let name = name[1..name.len() - 1].to_string();
                         args.insert(ExternArgs::Name(name.to_string()))
                     }
+                    // Recognized, but not handled as an extern argument
+                    "sql" => {
+                        let _punc = itr.next().unwrap();
+                        let _value = itr.next().unwrap();
+                        false
+                    }
                     _ => false,
                 };
             }

--- a/pgx-utils/src/sql_entity_graph/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/mod.rs
@@ -2,22 +2,26 @@ mod extension_sql;
 mod pg_aggregate;
 mod pg_extern;
 mod pg_schema;
+mod pgx_attribute;
 mod positioning_ref;
 mod postgres_enum;
 mod postgres_hash;
 mod postgres_ord;
 mod postgres_type;
+mod to_sql;
 
 pub use super::ExternArgs;
 pub use extension_sql::{ExtensionSql, ExtensionSqlFile, SqlDeclared};
 pub use pg_aggregate::PgAggregate;
 pub use pg_extern::{Argument, PgExtern, PgOperator};
 pub use pg_schema::Schema;
+pub use pgx_attribute::{ArgValue, NameValueArg, PgxArg, PgxAttribute};
 pub use positioning_ref::PositioningRef;
 pub use postgres_enum::PostgresEnum;
 pub use postgres_hash::PostgresHash;
 pub use postgres_ord::PostgresOrd;
 pub use postgres_type::PostgresType;
+pub use to_sql::ToSqlConfig;
 
 /// Reexports for the pgx SQL generator binaries.
 #[doc(hidden)]

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -5,19 +5,22 @@ mod returning;
 mod search_path;
 
 pub use argument::Argument;
-use attribute::{Attribute, PgxAttributes};
+use attribute::Attribute;
 pub use operator::PgOperator;
 use operator::{PgxOperatorAttributeWithIdent, PgxOperatorOpName};
-use returning::Returning;
 pub(crate) use returning::NameMacro;
+use returning::Returning;
 use search_path::SearchPathList;
 
 use eyre::WrapErr;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};
 use std::convert::TryFrom;
-use syn::parse::{Parse, ParseStream};
-use syn::Meta;
+use syn::parse::{Parse, ParseStream, Parser};
+use syn::punctuated::Punctuated;
+use syn::{Meta, Token};
+
+use crate::sql_entity_graph::ToSqlConfig;
 
 /// A parsed `#[pg_extern]` item.
 ///
@@ -42,42 +45,35 @@ use syn::Meta;
 /// ```
 #[derive(Debug, Clone)]
 pub struct PgExtern {
-    attrs: Option<PgxAttributes>,
-    attr_tokens: proc_macro2::TokenStream,
+    attrs: Vec<Attribute>,
     func: syn::ItemFn,
+    to_sql_config: ToSqlConfig,
 }
 
 impl PgExtern {
     fn name(&self) -> String {
         self.attrs
-            .as_ref()
-            .and_then(|a| {
-                a.attrs.iter().find_map(|candidate| match candidate {
-                    Attribute::Name(name) => Some(name.value()),
-                    _ => None,
-                })
+            .iter()
+            .find_map(|a| match a {
+                Attribute::Name(name) => Some(name.value()),
+                _ => None,
             })
             .unwrap_or_else(|| self.func.sig.ident.to_string())
     }
 
     fn schema(&self) -> Option<String> {
-        self.attrs.as_ref().and_then(|a| {
-            a.attrs.iter().find_map(|candidate| match candidate {
-                Attribute::Schema(name) => Some(name.value()),
-                _ => None,
-            })
+        self.attrs.iter().find_map(|a| match a {
+            Attribute::Schema(name) => Some(name.value()),
+            _ => None,
         })
     }
 
-    fn extern_attrs(&self) -> Option<&PgxAttributes> {
-        self.attrs.as_ref()
+    pub fn extern_attrs(&self) -> &[Attribute] {
+        self.attrs.as_slice()
     }
 
-    pub fn extern_attr_tokens(&self) -> &proc_macro2::TokenStream {
-        &self.attr_tokens
-    }
-
-    fn overridden(&self) -> Option<String> {
+    fn overridden(&self) -> Option<syn::LitStr> {
+        let mut span = None;
         let mut retval = None;
         let mut in_commented_sql_block = false;
         for attr in &self.func.attrs {
@@ -88,7 +84,8 @@ impl PgExtern {
                         Meta::Path(_) | Meta::List(_) => continue,
                         Meta::NameValue(mnv) => mnv,
                     };
-                    if let syn::Lit::Str(inner) = content.lit {
+                    if let syn::Lit::Str(ref inner) = content.lit {
+                        span.get_or_insert(content.lit.span());
                         if !in_commented_sql_block && inner.value().trim() == "```pgxsql" {
                             in_commented_sql_block = true;
                         } else if in_commented_sql_block && inner.value().trim() == "```" {
@@ -105,7 +102,7 @@ impl PgExtern {
                 }
             }
         }
-        retval
+        retval.map(|s| syn::LitStr::new(s.as_ref(), span.unwrap()))
     }
 
     fn operator(&self) -> Option<PgOperator> {
@@ -191,12 +188,27 @@ impl PgExtern {
     }
 
     pub fn new(attr: TokenStream2, item: TokenStream2) -> Result<Self, syn::Error> {
-        let attrs = syn::parse2::<PgxAttributes>(attr.clone()).ok();
+        let mut attrs = Vec::new();
+        let mut to_sql_config: Option<ToSqlConfig> = None;
+
+        let parser = Punctuated::<Attribute, Token![,]>::parse_terminated;
+        let punctuated_attrs = parser.parse2(attr)?;
+        for pair in punctuated_attrs.into_pairs() {
+            match pair.into_value() {
+                Attribute::Sql(config) => {
+                    to_sql_config.get_or_insert(config);
+                }
+                attr => {
+                    attrs.push(attr);
+                }
+            }
+        }
+
         let func = syn::parse2::<syn::ItemFn>(item)?;
         Ok(Self {
-            attrs: attrs,
-            attr_tokens: attr,
-            func: func,
+            attrs,
+            func,
+            to_sql_config: to_sql_config.unwrap_or_default(),
         })
     }
 }
@@ -207,7 +219,7 @@ impl ToTokens for PgExtern {
         let name = self.name();
         let schema = self.schema();
         let schema_iter = schema.iter();
-        let extern_attrs = self.extern_attrs();
+        let extern_attrs = self.attrs.iter().collect::<Punctuated<_, Token![,]>>();
         let search_path = self.search_path().into_iter();
         let inputs = self.inputs().unwrap();
         let returns = match self.returns() {
@@ -221,7 +233,14 @@ impl ToTokens for PgExtern {
             }
         };
         let operator = self.operator().into_iter();
-        let overridden = self.overridden().into_iter();
+        let to_sql_config = match self.overridden() {
+            None => self.to_sql_config.clone(),
+            Some(content) => {
+                let mut config = self.to_sql_config.clone();
+                config.content = Some(content);
+                config
+            }
+        };
 
         let sql_graph_entity_fn_name =
             syn::Ident::new(&format!("__pgx_internals_fn_{}", ident), Span::call_site());
@@ -237,12 +256,12 @@ impl ToTokens for PgExtern {
                     line: line!(),
                     module_path: core::module_path!(),
                     full_path: concat!(core::module_path!(), "::", stringify!(#ident)),
-                    extern_attrs: #extern_attrs,
+                    extern_attrs: vec![#extern_attrs],
                     search_path: None#( .unwrap_or(Some(vec![#search_path])) )*,
                     fn_args: vec![#(#inputs),*],
                     fn_return: #returns,
                     operator: None#( .unwrap_or(Some(#operator)) )*,
-                    overridden: None#( .unwrap_or(Some(#overridden)) )*,
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Function(submission)
             }
@@ -253,13 +272,27 @@ impl ToTokens for PgExtern {
 
 impl Parse for PgExtern {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        let attrs: Option<PgxAttributes> = input.parse().ok();
-        let func = input.parse()?;
-        let attr_tokens: proc_macro2::TokenStream = attrs.clone().into_token_stream();
+        let mut attrs = Vec::new();
+        let mut to_sql_config: Option<ToSqlConfig> = None;
+
+        let parser = Punctuated::<Attribute, Token![,]>::parse_terminated;
+        let punctuated_attrs = input.call(parser).ok().unwrap_or_default();
+        for pair in punctuated_attrs.into_pairs() {
+            match pair.into_value() {
+                Attribute::Sql(config) => {
+                    to_sql_config.get_or_insert(config);
+                }
+                attr => {
+                    attrs.push(attr);
+                }
+            }
+        }
+
+        let func: syn::ItemFn = input.parse()?;
         Ok(Self {
             attrs,
-            attr_tokens,
             func,
+            to_sql_config: to_sql_config.unwrap_or_default(),
         })
     }
 }

--- a/pgx-utils/src/sql_entity_graph/pgx_attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pgx_attribute.rs
@@ -1,0 +1,80 @@
+use syn::parse::{Parse, ParseStream};
+use syn::{parenthesized, punctuated::Punctuated};
+use syn::{token, Token};
+
+/// This struct is intented to represent the contents of the `#[pgx]` attribute when parsed.
+///
+/// The intended usage is to parse an `Attribute`, then use `attr.parse_args::<PgxAttribute>()?` to
+/// parse the contents of the attribute into this struct.
+///
+/// We use this rather than `Attribute::parse_meta` because it is not supported to parse bare paths
+/// as values of a `NameValueMeta`, and we want to support that to avoid conflating SQL strings with
+/// paths-as-strings. We re-use as much of the standard `parse_meta` structure types as possible though.
+pub struct PgxAttribute {
+    pub args: Vec<PgxArg>,
+}
+
+impl Parse for PgxAttribute {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let parser = Punctuated::<PgxArg, Token![,]>::parse_terminated;
+        let punctuated = input.call(parser)?;
+        let args = punctuated
+            .into_pairs()
+            .map(|p| p.into_value())
+            .collect::<Vec<_>>();
+        Ok(Self { args })
+    }
+}
+
+/// This enum is akin to `syn::Meta`, but supports a custom `NameValue` variant which allows
+/// for bare paths in the value position.
+pub enum PgxArg {
+    Path(syn::Path),
+    List(syn::MetaList),
+    NameValue(NameValueArg),
+}
+
+impl Parse for PgxArg {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let path = input.parse::<syn::Path>()?;
+        if input.peek(token::Paren) {
+            let content;
+            Ok(Self::List(syn::MetaList {
+                path,
+                paren_token: parenthesized!(content in input),
+                nested: content.parse_terminated(syn::NestedMeta::parse)?,
+            }))
+        } else if input.peek(Token![=]) {
+            Ok(Self::NameValue(NameValueArg {
+                path,
+                eq_token: input.parse()?,
+                value: input.parse()?,
+            }))
+        } else {
+            Ok(Self::Path(path))
+        }
+    }
+}
+
+/// This struct is akin to `syn::NameValueMeta`, but allows for more than just `syn::Lit` as a value.
+pub struct NameValueArg {
+    pub path: syn::Path,
+    pub eq_token: syn::token::Eq,
+    pub value: ArgValue,
+}
+
+/// This is the type of a value that can be used in the value position of a `name = value` attribute argument.
+pub enum ArgValue {
+    Path(syn::Path),
+    Lit(syn::Lit),
+}
+
+impl Parse for ArgValue {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        if input.peek(syn::Lit) {
+            return Ok(Self::Lit(input.parse()?));
+        }
+
+        Ok(Self::Path(input.parse()?))
+    }
+}

--- a/pgx-utils/src/sql_entity_graph/postgres_enum.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum.rs
@@ -6,6 +6,8 @@ use syn::{
 };
 use syn::{punctuated::Punctuated, Ident, Token};
 
+use super::ToSqlConfig;
+
 /// A parsed `#[derive(PostgresEnum)]` item.
 ///
 /// It should be used with [`syn::parse::Parse`] functions.
@@ -33,6 +35,7 @@ pub struct PostgresEnum {
     name: Ident,
     generics: Generics,
     variants: Punctuated<syn::Variant, Token![,]>,
+    to_sql_config: ToSqlConfig,
 }
 
 impl PostgresEnum {
@@ -40,15 +43,19 @@ impl PostgresEnum {
         name: Ident,
         generics: Generics,
         variants: Punctuated<syn::Variant, Token![,]>,
+        to_sql_config: ToSqlConfig,
     ) -> Self {
         Self {
             name,
             generics,
             variants,
+            to_sql_config,
         }
     }
 
     pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
+        let to_sql_config =
+            ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
         let data_enum = match derive_input.data {
             syn::Data::Enum(data_enum) => data_enum,
             syn::Data::Union(_) | syn::Data::Struct(_) => {
@@ -59,6 +66,7 @@ impl PostgresEnum {
             derive_input.ident,
             derive_input.generics,
             data_enum.variants,
+            to_sql_config,
         ))
     }
 }
@@ -66,7 +74,14 @@ impl PostgresEnum {
 impl Parse for PostgresEnum {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let parsed: ItemEnum = input.parse()?;
-        Ok(Self::new(parsed.ident, parsed.generics, parsed.variants))
+        let to_sql_config =
+            ToSqlConfig::from_attributes(parsed.attrs.as_slice())?.unwrap_or_default();
+        Ok(Self::new(
+            parsed.ident,
+            parsed.generics,
+            parsed.variants,
+            to_sql_config,
+        ))
     }
 }
 
@@ -83,6 +98,8 @@ impl ToTokens for PostgresEnum {
         let variants = self.variants.iter();
         let sql_graph_entity_fn_name =
             syn::Ident::new(&format!("__pgx_internals_enum_{}", name), Span::call_site());
+
+        let to_sql_config = &self.to_sql_config;
 
         let inv = quote! {
             #[no_mangle]
@@ -101,6 +118,7 @@ impl ToTokens for PostgresEnum {
                     full_path: core::any::type_name::<#name #ty_generics>(),
                     mappings,
                     variants: vec![ #(  stringify!(#variants)  ),* ],
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Enum(submission)
             }

--- a/pgx-utils/src/sql_entity_graph/postgres_hash.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash.rs
@@ -2,8 +2,10 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
     parse::{Parse, ParseStream},
-    DeriveInput, Ident, ItemEnum, ItemStruct,
+    DeriveInput, Ident,
 };
+
+use super::ToSqlConfig;
 
 /// A parsed `#[derive(PostgresHash)]` item.
 ///
@@ -51,27 +53,36 @@ use syn::{
 #[derive(Debug, Clone)]
 pub struct PostgresHash {
     pub name: Ident,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl PostgresHash {
-    pub fn new(name: Ident) -> Self {
-        Self { name }
+    pub fn new(name: Ident, to_sql_config: ToSqlConfig) -> Self {
+        Self {
+            name,
+            to_sql_config,
+        }
     }
 
     pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
-        Ok(Self::new(derive_input.ident))
+        let to_sql_config =
+            ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
+        Ok(Self::new(derive_input.ident, to_sql_config))
     }
 }
 
 impl Parse for PostgresHash {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        let parsed_enum: Result<ItemEnum, syn::Error> = input.parse();
-        let parsed_struct: Result<ItemStruct, syn::Error> = input.parse();
-        let ident = parsed_enum
-            .map(|x| x.ident)
-            .or_else(|_| parsed_struct.map(|x| x.ident))
-            .map_err(|_| syn::Error::new(input.span(), "expected enum or struct"))?;
-        Ok(Self::new(ident))
+        use syn::Item;
+
+        let parsed = input.parse()?;
+        let (ident, attrs) = match &parsed {
+            Item::Enum(item) => (item.ident.clone(), item.attrs.as_slice()),
+            Item::Struct(item) => (item.ident.clone(), item.attrs.as_slice()),
+            _ => return Err(syn::Error::new(input.span(), "expected enum or struct")),
+        };
+        let to_sql_config = ToSqlConfig::from_attributes(attrs)?.unwrap_or_default();
+        Ok(Self::new(ident, to_sql_config))
     }
 }
 
@@ -82,6 +93,7 @@ impl ToTokens for PostgresHash {
             &format!("__pgx_internals_hash_{}", self.name),
             Span::call_site(),
         );
+        let to_sql_config = &self.to_sql_config;
         let inv = quote! {
             #[no_mangle]
             pub extern "C" fn  #sql_graph_entity_fn_name() -> pgx::datum::sql_entity_graph::SqlGraphEntity {
@@ -93,6 +105,7 @@ impl ToTokens for PostgresHash {
                     full_path: core::any::type_name::<#name>(),
                     module_path: module_path!(),
                     id: TypeId::of::<#name>(),
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Hash(submission)
             }

--- a/pgx-utils/src/sql_entity_graph/postgres_ord.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord.rs
@@ -2,8 +2,10 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
     parse::{Parse, ParseStream},
-    DeriveInput, Ident, ItemEnum, ItemStruct,
+    DeriveInput, Ident,
 };
+
+use super::ToSqlConfig;
 
 /// A parsed `#[derive(PostgresOrd)]` item.
 ///
@@ -51,27 +53,36 @@ use syn::{
 #[derive(Debug, Clone)]
 pub struct PostgresOrd {
     pub name: Ident,
+    pub to_sql_config: ToSqlConfig,
 }
 
 impl PostgresOrd {
-    pub fn new(name: Ident) -> Self {
-        Self { name }
+    pub fn new(name: Ident, to_sql_config: ToSqlConfig) -> Self {
+        Self {
+            name,
+            to_sql_config,
+        }
     }
 
     pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
-        Ok(Self::new(derive_input.ident))
+        let to_sql_config =
+            ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
+        Ok(Self::new(derive_input.ident, to_sql_config))
     }
 }
 
 impl Parse for PostgresOrd {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        let parsed_enum: Result<ItemEnum, syn::Error> = input.parse();
-        let parsed_struct: Result<ItemStruct, syn::Error> = input.parse();
-        let ident = parsed_enum
-            .map(|x| x.ident)
-            .or_else(|_| parsed_struct.map(|x| x.ident))
-            .map_err(|_| syn::Error::new(input.span(), "expected enum or struct"))?;
-        Ok(Self::new(ident))
+        use syn::Item;
+
+        let parsed = input.parse()?;
+        let (ident, attrs) = match &parsed {
+            Item::Enum(item) => (item.ident.clone(), item.attrs.as_slice()),
+            Item::Struct(item) => (item.ident.clone(), item.attrs.as_slice()),
+            _ => return Err(syn::Error::new(input.span(), "expected enum or struct")),
+        };
+        let to_sql_config = ToSqlConfig::from_attributes(attrs)?.unwrap_or_default();
+        Ok(Self::new(ident, to_sql_config))
     }
 }
 
@@ -82,6 +93,7 @@ impl ToTokens for PostgresOrd {
             &format!("__pgx_internals_ord_{}", self.name),
             Span::call_site(),
         );
+        let to_sql_config = &self.to_sql_config;
         let inv = quote! {
             #[no_mangle]
             pub extern "C" fn  #sql_graph_entity_fn_name() -> pgx::datum::sql_entity_graph::SqlGraphEntity {
@@ -93,6 +105,7 @@ impl ToTokens for PostgresOrd {
                     full_path: core::any::type_name::<#name>(),
                     module_path: module_path!(),
                     id: TypeId::of::<#name>(),
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Ord(submission)
             }

--- a/pgx-utils/src/sql_entity_graph/postgres_type.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type.rs
@@ -9,6 +9,8 @@ use syn::{
     DeriveInput, Generics, ItemStruct,
 };
 
+use super::ToSqlConfig;
+
 /// A parsed `#[derive(PostgresType)]` item.
 ///
 /// It should be used with [`syn::parse::Parse`] functions.
@@ -37,15 +39,23 @@ pub struct PostgresType {
     generics: Generics,
     in_fn: Ident,
     out_fn: Ident,
+    to_sql_config: ToSqlConfig,
 }
 
 impl PostgresType {
-    pub fn new(name: Ident, generics: Generics, in_fn: Ident, out_fn: Ident) -> Self {
+    pub fn new(
+        name: Ident,
+        generics: Generics,
+        in_fn: Ident,
+        out_fn: Ident,
+        to_sql_config: ToSqlConfig,
+    ) -> Self {
         Self {
             generics,
             name,
             in_fn,
             out_fn,
+            to_sql_config,
         }
     }
 
@@ -59,6 +69,8 @@ impl PostgresType {
                 ))
             }
         };
+        let to_sql_config =
+            ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
         let funcname_in = Ident::new(
             &format!("{}_in", derive_input.ident).to_lowercase(),
             derive_input.ident.span(),
@@ -72,6 +84,7 @@ impl PostgresType {
             derive_input.generics,
             funcname_in,
             funcname_out,
+            to_sql_config,
         ))
     }
 
@@ -93,6 +106,8 @@ impl PostgresType {
 impl Parse for PostgresType {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let parsed: ItemStruct = input.parse()?;
+        let to_sql_config =
+            ToSqlConfig::from_attributes(parsed.attrs.as_slice())?.unwrap_or_default();
         let funcname_in = Ident::new(
             &format!("{}_in", parsed.ident).to_lowercase(),
             parsed.ident.span(),
@@ -106,6 +121,7 @@ impl Parse for PostgresType {
             parsed.generics,
             funcname_in,
             funcname_out,
+            to_sql_config,
         ))
     }
 }
@@ -126,6 +142,8 @@ impl ToTokens for PostgresType {
             &format!("__pgx_internals_type_{}", self.name),
             Span::call_site(),
         );
+
+        let to_sql_config = &self.to_sql_config;
 
         let inv = quote! {
             #[no_mangle]
@@ -167,7 +185,8 @@ impl ToTokens for PostgresType {
                         let mut path_items: Vec<_> = out_fn.split("::").collect();
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
-                    }
+                    },
+                    to_sql_config: #to_sql_config,
                 };
                 pgx::datum::sql_entity_graph::SqlGraphEntity::Type(submission)
             }

--- a/pgx/src/datum/sql_entity_graph/aggregate.rs
+++ b/pgx/src/datum/sql_entity_graph/aggregate.rs
@@ -1,6 +1,6 @@
 use crate::{
     aggregate::{FinalizeModify, ParallelOption},
-    datum::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier, ToSql},
+    datum::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfigEntity},
 };
 use core::{any::TypeId, cmp::Ordering};
 use eyre::eyre as eyre_err;
@@ -127,6 +127,7 @@ pub struct PgAggregateEntity {
     ///
     /// Corresponds to `hypothetical` in [`crate::aggregate::Aggregate`].
     pub hypothetical: bool,
+    pub to_sql_config: ToSqlConfigEntity,
 }
 
 impl Ord for PgAggregateEntity {
@@ -278,21 +279,29 @@ impl ToSql for PgAggregateEntity {
                 })?;
             optional_attributes.push((
                 format!("\tMSTYPE = {}", sql),
-                format!("/* {}::MovingState = {} */", self.full_path, value.full_path),
+                format!(
+                    "/* {}::MovingState = {} */",
+                    self.full_path, value.full_path
+                ),
             ));
         }
 
         let mut optional_attributes_string = String::new();
         for (index, (optional_attribute, comment)) in optional_attributes.iter().enumerate() {
-            let optional_attribute_string = format!("{optional_attribute}{maybe_comma} {comment}{maybe_newline}",
+            let optional_attribute_string = format!(
+                "{optional_attribute}{maybe_comma} {comment}{maybe_newline}",
                 optional_attribute = optional_attribute,
-                maybe_comma = if index == optional_attributes.len() -1 {
+                maybe_comma = if index == optional_attributes.len() - 1 {
                     ""
-                } else { "," },
+                } else {
+                    ","
+                },
                 comment = comment,
-                maybe_newline = if index == optional_attributes.len() -1 {
+                maybe_newline = if index == optional_attributes.len() - 1 {
                     ""
-                } else { "\n" }
+                } else {
+                    "\n"
+                }
             );
             optional_attributes_string += &optional_attribute_string;
         }

--- a/pgx/src/datum/sql_entity_graph/mod.rs
+++ b/pgx/src/datum/sql_entity_graph/mod.rs
@@ -64,6 +64,111 @@ pub trait ToSql {
     fn to_sql(&self, context: &PgxSql) -> eyre::Result<String>;
 }
 
+/// The signature of a function that can transform a SqlGraphEntity to a SQL string
+///
+/// This is used to provide a facility for overriding the default SQL generator behavior using
+/// the `#[to_sql(path::to::function)]` attribute in circumstances where the default behavior is
+/// not desirable.
+///
+/// Implementations can invoke `ToSql::to_sql(entity, context)` on the unwrapped SqlGraphEntity
+/// type should they wish to delegate to the default behavior for any reason.
+pub type ToSqlFn =
+    fn(
+        &SqlGraphEntity,
+        &PgxSql,
+    ) -> std::result::Result<String, Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+/// Represents configuration options for tuning the SQL generator.
+///
+/// When an item that can be rendered to SQL has these options at hand, they should be
+/// respected. If an item does not have them, then it is not expected that the SQL generation
+/// for those items can be modified.
+///
+/// The default configuration has `enabled` set to `true`, and `callback` to `None`, which indicates
+/// that the default SQL generation behavior will be used. These are intended to be mutually exclusive
+/// options, so `callback` should only be set if generation is enabled.
+///
+/// When `enabled` is false, no SQL is generated for the item being configured.
+///
+/// When `callback` has a value, the corresponding `ToSql` implementation should invoke the
+/// callback instead of performing their default behavior.
+#[derive(Default, Clone)]
+pub struct ToSqlConfigEntity {
+    pub enabled: bool,
+    pub callback: Option<ToSqlFn>,
+    pub content: Option<&'static str>,
+}
+impl ToSqlConfigEntity {
+    /// Given a SqlGraphEntity, this function converts it to SQL based on the current configuration.
+    ///
+    /// If the config overrides the default behavior (i.e. using the `ToSql` trait), then `Some(eyre::Result)`
+    /// is returned. If the config does not override the default behavior, then `None` is returned. This can
+    /// be used to dispatch SQL generation in a single line, e.g.:
+    ///
+    /// ```rust,ignore
+    /// config.to_sql(entity, context).unwrap_or_else(|| entity.to_sql(context))?
+    /// ```
+    pub fn to_sql(
+        &self,
+        entity: &SqlGraphEntity,
+        context: &PgxSql,
+    ) -> Option<eyre::Result<String>> {
+        use eyre::{eyre, WrapErr};
+
+        if !self.enabled {
+            return Some(Ok(String::default()));
+        }
+
+        if let Some(content) = self.content {
+            return Some(Ok("\n".to_owned() + content));
+        }
+
+        if let Some(callback) = self.callback {
+            return Some(
+                callback(entity, context)
+                    .map_err(|e| eyre!(e))
+                    .wrap_err("Failed to run specified `#[pgx(sql = path)] function`"),
+            );
+        }
+
+        None
+    }
+}
+impl std::cmp::PartialEq for ToSqlConfigEntity {
+    fn eq(&self, other: &Self) -> bool {
+        if self.enabled != other.enabled {
+            return false;
+        }
+        match (self.callback, other.callback) {
+            (None, None) => match (self.content, other.content) {
+                (None, None) => true,
+                (Some(a), Some(b)) => a == b,
+                _ => false,
+            },
+            (Some(a), Some(b)) => std::ptr::eq(std::ptr::addr_of!(a), std::ptr::addr_of!(b)),
+            _ => false,
+        }
+    }
+}
+impl std::cmp::Eq for ToSqlConfigEntity {}
+impl std::hash::Hash for ToSqlConfigEntity {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.enabled.hash(state);
+        self.callback.map(|cb| std::ptr::addr_of!(cb)).hash(state);
+        self.content.hash(state);
+    }
+}
+impl std::fmt::Debug for ToSqlConfigEntity {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let callback = self.callback.map(|cb| std::ptr::addr_of!(cb));
+        f.debug_struct("ToSqlConfigEntity")
+            .field("enabled", &self.enabled)
+            .field("callback", &format_args!("{:?}", &callback))
+            .field("content", &self.content)
+            .finish()
+    }
+}
+
 /// A mapping from a Rust type to a SQL type, with a `TypeId`.
 ///
 /// ```rust

--- a/pgx/src/datum/sql_entity_graph/postgres_enum.rs
+++ b/pgx/src/datum/sql_entity_graph/postgres_enum.rs
@@ -3,7 +3,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfigEntity};
 
 /// The output of a [`PostgresEnum`](crate::datum::sql_entity_graph::PostgresEnum) from `quote::ToTokens::to_tokens`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,6 +15,7 @@ pub struct PostgresEnumEntity {
     pub module_path: &'static str,
     pub mappings: std::collections::HashSet<super::RustSqlMapping>,
     pub variants: Vec<&'static str>,
+    pub to_sql_config: ToSqlConfigEntity,
 }
 
 impl Hash for PostgresEnumEntity {

--- a/pgx/src/datum/sql_entity_graph/postgres_hash.rs
+++ b/pgx/src/datum/sql_entity_graph/postgres_hash.rs
@@ -1,4 +1,4 @@
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfigEntity};
 use std::cmp::Ordering;
 
 /// The output of a [`PostgresHash`](crate::datum::sql_entity_graph::PostgresHash) from `quote::ToTokens::to_tokens`.
@@ -10,6 +10,7 @@ pub struct PostgresHashEntity {
     pub full_path: &'static str,
     pub module_path: &'static str,
     pub id: core::any::TypeId,
+    pub to_sql_config: ToSqlConfigEntity,
 }
 
 impl PostgresHashEntity {

--- a/pgx/src/datum/sql_entity_graph/postgres_ord.rs
+++ b/pgx/src/datum/sql_entity_graph/postgres_ord.rs
@@ -1,4 +1,4 @@
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfigEntity};
 use std::cmp::Ordering;
 
 /// The output of a [`PostgresOrd`](crate::datum::sql_entity_graph::PostgresOrd) from `quote::ToTokens::to_tokens`.
@@ -10,6 +10,7 @@ pub struct PostgresOrdEntity {
     pub full_path: &'static str,
     pub module_path: &'static str,
     pub id: core::any::TypeId,
+    pub to_sql_config: ToSqlConfigEntity,
 }
 
 impl PostgresOrdEntity {

--- a/pgx/src/datum/sql_entity_graph/postgres_type.rs
+++ b/pgx/src/datum/sql_entity_graph/postgres_type.rs
@@ -5,7 +5,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfigEntity};
 
 /// The output of a [`PostgresType`](crate::datum::sql_entity_graph::PostgresType) from `quote::ToTokens::to_tokens`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,6 +20,7 @@ pub struct PostgresTypeEntity {
     pub in_fn_module_path: String,
     pub out_fn: &'static str,
     pub out_fn_module_path: String,
+    pub to_sql_config: ToSqlConfigEntity,
 }
 
 impl Hash for PostgresTypeEntity {


### PR DESCRIPTION
/cc @Hoverbear @JamesGuthrie 

This PR was spawned from some needs we have over at Timescale in our Promscale extension. I looked into #377 as an option, but found that due to expectations the `ToSql` trait has about the entity graph, trying to manipulate entities at that stage is delicate at best. For example, you can't conditionally elide certain entities from SQL generation by removing them from the graph, because things like types are expected to exist in the graph during lowering. To make it work, you'd essentially need to reconstruct the graph within the hook to join the incoming and outgoing neighbors of those entities so that the dependency ordering is preserved without those entities being present in the output. It feels like that is exposing too much of the pgx internals implicitly, in a way that can break non-obviously and will always be fragile to internal changes.

So as an alternative, this PR introduces an approach that I think you'll like, and is less invasive while still providing quite a bit of flexibility around how entities get lowered to SQL. It works great for our needs, and others that are in a similar boat, so I'm hoping it is something you all are open to merging!

---

This commit introduces a new `#[to_sql]` attribute that allows for
customizing the behavior of SQL generation on certain entities in two
different ways:

1. `#[to_sql(false)]` disables generation of the decorated item's SQL
2. `#[to_sql(path::to::function)]` delegates responsibility for
   generating SQL to the named function

In the latter case, the function has almost the same signature as the
`to_sql` function of the built-in `ToSql` trait, except the function
receives a reference to a `SqlGraphEntity` in place of `&self`. This
allows for extending any of the `SqlGraphEntity` variants using a single
function, as trying to use specific typed functions for each entity type
was deemed overly complex. This also works well with the way `ToSql` is
invoked today, which starts by calling the implementation on a value of
type `SqlGraphEntity`, so we can perform all the checks in a single
place.

As an aside, these custom callbacks can still delegate to the built-in
`ToSql` trait if desired. For example, if you wish to write the
generated SQL for specific entities to a different file. One thing that might make
this even more powerful is if the lowering is by value (and also receives a mutable
reference to the `PgxSql` context), as this would allow custom functions to
modify certain attributes of the entities during lowering (as a simple exercise,
consider how one would modify the naming scheme used by the generator without
breaking dependents of the lowered entity - currently that isn't possible without taking
over almost all of the lowering yourself). Not super important I don't think, but something
to mull over.

The motivation for this is that in some edge cases, it is desirable to
elide or modify the SQL being generated. In our case specifically, we
need to chop up the generated SQL so that we can split out non-idempotent
operations separately from idempotent operations in order to properly
manage extension upgrades. Rather than lose the facilities pgx provides,
the `#[to_sql]` attribute allows us to make ad-hoc adjustments to what,
when and where things get generated without needing any upstream support
for those details.