### PR TITLE
Flush to tar `stdio`

### DIFF
--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -238,6 +238,7 @@ fn untar(bytes: &[u8], pgxdir: &PathBuf, pg_config: &PgConfig) -> eyre::Result<P
 
     let stdin = child.stdin.as_mut().expect("failed to get `tar`'s stdin");
     stdin.write_all(bytes)?;
+    stdin.flush()?;
     let output = child.wait_with_output()?;
 
     if output.status.success() {


### PR DESCRIPTION
While running `cargo pgx init` users may experience errors while passing the downloaded to `tar` via `stdio`, this is because we don't currently flush.