### PR TITLE
Expand pgx::Internal API

### DIFF
--- a/pgx-tests/src/tests/internal_tests.rs
+++ b/pgx-tests/src/tests/internal_tests.rs
@@ -1,0 +1,56 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    use pgx::*;
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+
+    #[pg_test]
+    fn insert() {
+        let mut val = Internal::default();
+        assert_eq!(val.initialized(), false);
+
+        let inner = unsafe { val.insert::<i32>(5) };
+        
+        assert_eq!(*inner, 5);
+        assert_eq!(val.initialized(), true);
+        
+        let inner = unsafe { val.insert::<i32>(6) };
+        
+        assert_eq!(*inner, 6);
+        assert_eq!(val.initialized(), true);
+    }
+
+    #[pg_test]
+    fn get_or_insert_default() {
+        let mut val = Internal::default();
+        assert_eq!(val.initialized(), false);
+
+        let inner = unsafe { val.get_or_insert_default::<i32>() };
+        
+        assert_eq!(*inner, 0);
+        assert_eq!(val.initialized(), true);
+    }
+
+    #[pg_test]
+    fn get_or_insert() {
+        let mut val = Internal::default();
+        assert_eq!(val.initialized(), false);
+
+        let inner = unsafe { val.get_or_insert::<i32>(5) };
+        
+        assert_eq!(*inner, 5);
+        assert_eq!(val.initialized(), true);
+    }
+
+    #[pg_test]
+    fn get_or_insert_with() {
+        let mut val = Internal::default();
+        assert_eq!(val.initialized(), false);
+
+        let inner = unsafe { val.get_or_insert_with(|| 5) };
+        
+        assert_eq!(*inner, 5);
+        assert_eq!(val.initialized(), true);
+    }
+}

--- a/pgx-tests/src/tests/internal_tests.rs
+++ b/pgx-tests/src/tests/internal_tests.rs
@@ -1,9 +1,9 @@
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {
-    use pgx::*;
     #[allow(unused_imports)]
     use crate as pgx_tests;
+    use pgx::*;
 
     #[pg_test]
     fn insert() {
@@ -11,12 +11,12 @@ mod tests {
         assert_eq!(val.initialized(), false);
 
         let inner = unsafe { val.insert::<i32>(5) };
-        
+
         assert_eq!(*inner, 5);
         assert_eq!(val.initialized(), true);
-        
+
         let inner = unsafe { val.insert::<i32>(6) };
-        
+
         assert_eq!(*inner, 6);
         assert_eq!(val.initialized(), true);
     }
@@ -27,7 +27,7 @@ mod tests {
         assert_eq!(val.initialized(), false);
 
         let inner = unsafe { val.get_or_insert_default::<i32>() };
-        
+
         assert_eq!(*inner, 0);
         assert_eq!(val.initialized(), true);
     }
@@ -38,7 +38,7 @@ mod tests {
         assert_eq!(val.initialized(), false);
 
         let inner = unsafe { val.get_or_insert::<i32>(5) };
-        
+
         assert_eq!(*inner, 5);
         assert_eq!(val.initialized(), true);
     }
@@ -49,7 +49,7 @@ mod tests {
         assert_eq!(val.initialized(), false);
 
         let inner = unsafe { val.get_or_insert_with(|| 5) };
-        
+
         assert_eq!(*inner, 5);
         assert_eq!(val.initialized(), true);
     }

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod fcinfo_tests;
 mod guc_tests;
 mod hooks_tests;
 mod inet_tests;
+mod internal_tests;
 mod json_tests;
 mod lifetime_tests;
 mod log_tests;

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -21,6 +21,7 @@ use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 ///
 /// We make no guarantees about what the internal [pg_sys::Datum] actually points to in memory, so
 /// it is your responsibility to ensure that what you're casting it to is really what it is.
+#[derive(Default)]
 pub struct Internal(Option<pg_sys::Datum>);
 
 impl Internal {
@@ -34,7 +35,13 @@ impl Internal {
         ))
     }
 
-    /// Return a reference to the memory pointed to by this [Internal], as `Some(&T)`, unless the
+    /// Returns if the internal value is initialized. If false, this is a null pointer.
+    #[inline]
+    pub fn initialized(&self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Return a reference to the memory pointed to by this [`Internal`], as `Some(&T)`, unless the
     /// backing datum is null, then `None`.
     ///
     /// ## Safety
@@ -43,10 +50,27 @@ impl Internal {
     /// your responsibility.
     #[inline]
     pub unsafe fn get<T>(&self) -> Option<&T> {
-        self.0.map(|datum| (datum as *const T).as_ref()).flatten()
+        self.0.and_then(|datum| (datum as *const T).as_ref())
     }
 
-    /// Return a reference to the memory pointed to by this [Internal], as `Some(&mut T)`, unless the
+    /// Initializes the internal with `value`, then returns a mutable reference to it.
+    ///
+    /// If the Internal is already initialized with a value, the old value is dropped.
+    ///
+    /// See also [`Internal::get_or_insert`], which doesn’t update the value if already initialized.
+    ///
+    /// ## Safety
+    ///
+    /// We cannot guarantee that the contained datum points to memory that is really `T`.  This is
+    /// your responsibility.
+    #[inline]
+    pub unsafe fn insert<T>(&mut self, value: T) -> &mut T {
+        let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(value) as pg_sys::Datum;
+        let ptr = self.0.insert(datum);
+        &mut *(*ptr as *mut T)
+    }
+
+    /// Return a reference to the memory pointed to by this [`Internal`], as `Some(&mut T)`, unless the
     /// backing datum is null, then `None`.
     ///
     /// ## Safety
@@ -55,7 +79,59 @@ impl Internal {
     /// your responsibility.
     #[inline]
     pub unsafe fn get_mut<T>(&self) -> Option<&mut T> {
-        self.0.map(|datum| (datum as *mut T).as_mut()).flatten()
+        self.0.and_then(|datum| (datum as *mut T).as_mut())
+    }
+
+    /// Initializes the internal with `value` if it is not initialized, then returns a mutable reference to
+    /// the contained value.
+    ///
+    /// See also [`Internal::insert`], which updates the value even if the option already contains Some.
+    /// 
+    /// ## Safety
+    ///
+    /// We cannot guarantee that the contained datum points to memory that is really `T`.  This is
+    /// your responsibility.
+    pub unsafe fn get_or_insert<T>(&mut self, value: T) -> &mut T  {
+        let ptr = self.0.get_or_insert({
+            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(value) as pg_sys::Datum;
+            datum
+        });
+        &mut *(*ptr as *mut T)
+    }
+
+    /// Initializes the internal with a default if it is not initialized, then returns a mutable reference
+    /// to the contained value.
+    ///
+    /// See also [`Internal::insert`], which updates the value even if the option already contains Some.
+    /// 
+    /// ## Safety
+    ///
+    /// We cannot guarantee that the contained datum points to memory that is really `T`.  This is
+    /// your responsibility.
+    pub unsafe fn get_or_insert_default<T>(&mut self) -> &mut T where T: Default {
+        let ptr = self.0.get_or_insert({
+            let default = T::default();
+            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(default) as pg_sys::Datum;
+            datum
+        });
+        &mut *(*ptr as *mut T)
+    }
+
+    /// Inserts a value computed from `f` into the internal if it is `None`, then returns a mutable reference
+    /// to the contained value.
+    /// 
+    /// ## Safety
+    ///
+    /// We cannot guarantee that the contained datum points to memory that is really `T`.  This is
+    /// your responsibility.
+    pub unsafe fn get_or_insert_with<F, T>(&mut self, f: F) -> &mut T
+    where F: FnOnce() -> T {
+        let ptr = self.0.get_or_insert_with(|| {
+            let result = f();
+            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(result) as pg_sys::Datum;
+            datum
+        });
+        &mut *(*ptr as *mut T)
     }
 
     /// Returns the contained `Option<pg_sys::Datum>`

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -65,7 +65,8 @@ impl Internal {
     /// your responsibility.
     #[inline]
     pub unsafe fn insert<T>(&mut self, value: T) -> &mut T {
-        let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(value) as pg_sys::Datum;
+        let datum =
+            PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(value) as pg_sys::Datum;
         let ptr = self.0.insert(datum);
         &mut *(*ptr as *mut T)
     }
@@ -86,14 +87,15 @@ impl Internal {
     /// the contained value.
     ///
     /// See also [`Internal::insert`], which updates the value even if the option already contains Some.
-    /// 
+    ///
     /// ## Safety
     ///
     /// We cannot guarantee that the contained datum points to memory that is really `T`.  This is
     /// your responsibility.
-    pub unsafe fn get_or_insert<T>(&mut self, value: T) -> &mut T  {
+    pub unsafe fn get_or_insert<T>(&mut self, value: T) -> &mut T {
         let ptr = self.0.get_or_insert({
-            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(value) as pg_sys::Datum;
+            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(value)
+                as pg_sys::Datum;
             datum
         });
         &mut *(*ptr as *mut T)
@@ -103,15 +105,19 @@ impl Internal {
     /// to the contained value.
     ///
     /// See also [`Internal::insert`], which updates the value even if the option already contains Some.
-    /// 
+    ///
     /// ## Safety
     ///
     /// We cannot guarantee that the contained datum points to memory that is really `T`.  This is
     /// your responsibility.
-    pub unsafe fn get_or_insert_default<T>(&mut self) -> &mut T where T: Default {
+    pub unsafe fn get_or_insert_default<T>(&mut self) -> &mut T
+    where
+        T: Default,
+    {
         let ptr = self.0.get_or_insert({
             let default = T::default();
-            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(default) as pg_sys::Datum;
+            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(default)
+                as pg_sys::Datum;
             datum
         });
         &mut *(*ptr as *mut T)
@@ -119,16 +125,19 @@ impl Internal {
 
     /// Inserts a value computed from `f` into the internal if it is `None`, then returns a mutable reference
     /// to the contained value.
-    /// 
+    ///
     /// ## Safety
     ///
     /// We cannot guarantee that the contained datum points to memory that is really `T`.  This is
     /// your responsibility.
     pub unsafe fn get_or_insert_with<F, T>(&mut self, f: F) -> &mut T
-    where F: FnOnce() -> T {
+    where
+        F: FnOnce() -> T,
+    {
         let ptr = self.0.get_or_insert_with(|| {
             let result = f();
-            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(result) as pg_sys::Datum;
+            let datum = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(result)
+                as pg_sys::Datum;
             datum
         });
         &mut *(*ptr as *mut T)

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -35,7 +35,7 @@ impl Internal {
         ))
     }
 
-    /// Returns if the internal value is initialized. If false, this is a null pointer.
+    /// Returns true if the internal value is initialized. If false, this is a null pointer.
     #[inline]
     pub fn initialized(&self) -> bool {
         self.0.is_some()


### PR DESCRIPTION
Expand the `pgx::Internal` API to include some familiar faces from `Option` and improve usability. Check out the tests to see how they work!