### PR TITLE
Use correctly spanned fcinfo

### DIFF
--- a/pgx-macros/src/rewriter.rs
+++ b/pgx-macros/src/rewriter.rs
@@ -723,30 +723,7 @@ impl FunctionSignatureRewriter {
 
         let mut stream = proc_macro2::TokenStream::new();
         let mut i = 0usize;
-        let mut fcinfo_ident = None;
-
-        // Get the fcinfo ident, if it exists.
-        // We do this because we need to get the **right** ident, if it exists, so Rustc
-        // doesn't think we're pointing at the fcinfo module path.
-        for arg in &self.func.sig.inputs {
-            match arg {
-                FnArg::Typed(ty) => match ty.pat.deref() {
-                    Pat::Ident(ident) => {
-                        if type_matches(&ty.ty, "pg_sys :: FunctionCallInfo")
-                            || type_matches(&ty.ty, "pgx :: pg_sys :: FunctionCallInfo")
-                        {
-                            if fcinfo_ident.is_some() {
-                                panic!("When using `pg_sys::FunctionCallInfo` as an argument it must be the last argument");
-                            }
-                            fcinfo_ident = Some(ident.ident.clone());
-                        }
-                    },
-                    _ => (),
-                },
-                _ => ()
-            }
-        }
-        let fcinfo_ident = fcinfo_ident.unwrap_or(syn::Ident::new("fcinfo", Span::call_site()));
+        let fcinfo_ident: syn::Ident = syn::parse_quote! { fcinfo };
 
         for arg in &self.func.sig.inputs {
             match arg {

--- a/pgx-tests/src/tests/fcinfo_tests.rs
+++ b/pgx-tests/src/tests/fcinfo_tests.rs
@@ -98,7 +98,24 @@ fn same_name(same_name: &str) -> &str {
 
 // Tests for regression of https://github.com/zombodb/pgx/issues/432
 #[pg_extern]
-fn bar_func(_x: PgBox<pg_sys::IndexAmRoutine>, _fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutine> {
+fn fcinfo_renamed_one_arg(_x: PgBox<pg_sys::IndexAmRoutine>, _fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutine> {
+    todo!()
+}
+
+#[pg_extern]
+fn fcinfo_renamed_no_arg(_fcinfo: pg_sys::FunctionCallInfo) -> i32 {
+    todo!()
+}
+
+#[pg_extern]
+fn fcinfo_not_named_one_arg(_x: PgBox<pg_sys::IndexAmRoutine>, fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutine> {
+    let _fcinfo = fcinfo;
+    todo!()
+}
+
+#[pg_extern]
+fn fcinfo_not_named_no_arg(fcinfo: pg_sys::FunctionCallInfo) -> i32 {
+    let _fcinfo = fcinfo;
     todo!()
 }
 

--- a/pgx-tests/src/tests/fcinfo_tests.rs
+++ b/pgx-tests/src/tests/fcinfo_tests.rs
@@ -96,6 +96,12 @@ fn same_name(same_name: &str) -> &str {
     same_name
 }
 
+// Tests for regression of https://github.com/zombodb/pgx/issues/432
+#[pg_extern]
+fn bar_func(_x: PgBox<pg_sys::IndexAmRoutine>, _fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutine> {
+    todo!()
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {


### PR DESCRIPTION
Fixes #432 .

Turns out I had the wrong idea for the Function rewriter.