### PR TITLE
Use '--' instead of '-' when emitting sql with `cargo pgx schema`

### DIFF
--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -577,7 +577,7 @@ OPTIONS:
             Do not activate the `default` feature
 
     -o, --out <OUT>
-            A path to output a produced SQL file (default is `sql/$EXTNAME-$VERSION.sql`)
+            A path to output a produced SQL file (default is `sql/$EXTNAME--$VERSION.sql`)
 
     -r, --release
             Compile for release mode (default is debug)

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -45,7 +45,7 @@ pub(crate) struct Schema {
     pg_config: Option<PathBuf>,
     #[clap(flatten)]
     features: clap_cargo::Features,
-    /// A path to output a produced SQL file (default is `sql/$EXTNAME-$VERSION.sql`)
+    /// A path to output a produced SQL file (default is `sql/$EXTNAME--$VERSION.sql`)
     #[clap(long, short, parse(from_os_str))]
     out: Option<PathBuf>,
     /// A path to output a produced GraphViz DOT file
@@ -66,7 +66,7 @@ impl CommandExecute for Schema {
         let out = match self.out {
             Some(out) => out,
             None => format!(
-                "sql/{}-{}.sql",
+                "sql/{}--{}.sql",
                 extname,
                 crate::command::install::get_version()?,
             )

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -407,7 +407,7 @@ macro_rules! pg_binary_magic {
                 about,
             )]
             struct SqlGenerator {
-                /// A path to output a produced SQL file (default is `sql/$EXTNAME-$VERSION.sql`)
+                /// A path to output a produced SQL file (default is `sql/$EXTNAME--$VERSION.sql`)
                 #[clap(
                     long,
                     short,


### PR DESCRIPTION
Postgres expects SQL schema files be named in the following form:

`<extension>--<version>.sql`

In general, pgx produces sql files following this naming scheme. For
some reason, `cargo pgx schema` does not. Instead, it produces a file
in the form of:

`<extension>-<version>.sql`

This change fixes that.