### PR TITLE
Fix a problem with fns returning tuples with Attributes

### DIFF
--- a/pgx-tests/src/tests/pg_extern_args_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_args_tests.rs
@@ -1,6 +1,16 @@
 // Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
 // governed by the MIT license that can be found in the LICENSE file.
 
+use pgx::*;
+
+#[pg_extern(immutable)]
+fn returns_tuple_with_attributes() -> (
+    name!(arg, String),
+    name!(arg2, String),
+) {
+   ("hi".to_string(), "bye".to_string())
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -219,7 +219,9 @@ impl ToTokens for PgExtern {
         let name = self.name();
         let schema = self.schema();
         let schema_iter = schema.iter();
-        let extern_attrs = self.attrs.iter().collect::<Punctuated<_, Token![,]>>();
+        let extern_attrs = self.attrs.iter()
+            .map(|attr| attr.to_sql_entity_graph_tokens())
+            .collect::<Punctuated<_, Token![,]>>();
         let search_path = self.search_path().into_iter();
         let inputs = self.inputs().unwrap();
         let returns = match self.returns() {


### PR DESCRIPTION
In #410 we introduced some new `sql` attribute and functionality related to SQL generation.

As part of this we removed the `extern_attr_tokens` from `pgx-utils::sql_entity_graph::PgExtern`.

Changing from:

```rust
let attrs = entity_submission.unwrap().extern_attr_tokens();
```

to:

https://github.com/zombodb/pgx/blob/f653be4acd519827642d59533f06bd309befa608/pgx-macros/src/rewriter.rs#L228-L232

This caused `pgx_utils::sql_entity_graph::pg_extern::Attribute::to_tokens` to be invoked. Since it did not return what it had parsed, later when it got re-parsed for `ToSqlConfig` it was revealing entity graph tokens. This functionality has been fixed and these entity graph tokens now come from `to_sql_entity_graph_tokens`.