### PR TITLE
Release 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -531,11 +531,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -565,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -1034,9 +1035,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "libloading"
@@ -1400,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1428,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "pgx-utils",
  "proc-macro-crate",
@@ -1441,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-parent"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cargo-pgx",
  "pgx",
@@ -1452,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1472,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "colored",
  "eyre",
@@ -1491,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap 3.0.14",
  "color-eyre",
@@ -1587,7 +1588,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.4",
+ "rand 0.8.5",
  "sha2",
  "stringprep",
 ]
@@ -1617,9 +1618,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "9dada8c9981fcf32929c3c0f0cd796a9284aca335565227ed88c83babb1d43dc"
 dependencies = [
  "thiserror",
  "toml",
@@ -1683,19 +1684,18 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1743,15 +1743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2059,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-parent"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -52,8 +52,8 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-cargo-pgx = { path = "cargo-pgx", version = "0.3.1" }
-pgx = { path = "pgx", version = "0.3.1", default-features = false }
-pgx-macros = { path = "pgx-macros", version = "0.3.1" }
-pgx-pg-sys = { path = "pgx-pg-sys", version = "0.3.1", default-features = false }
-pgx-tests = { path = "pgx-tests", version = "0.3.1", default-features = false }
+cargo-pgx = { path = "cargo-pgx", version = "0.3.2" }
+pgx = { path = "pgx", version = "0.3.2", default-features = false }
+pgx-macros = { path = "pgx-macros", version = "0.3.2" }
+pgx-pg-sys = { path = "pgx-pg-sys", version = "0.3.2", default-features = false }
+pgx-tests = { path = "pgx-tests", version = "0.3.2", default-features = false }

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -22,7 +22,7 @@ semver = "1.0.5"
 colored = "2.0.0"
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils", version = "0.3.1" }
+pgx-utils = { path = "../pgx-utils", version = "0.3.2" }
 proc-macro2 = { version = "1.0.36", features = [ "span-locations" ] }
 quote = "1.0.15"
 rayon = "1.5.1"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.3.1"
-pgx-macros = "0.3.1"
+pgx = "0.3.2"
+pgx-macros = "0.3.2"
 
 [dev-dependencies]
-pgx-tests = "0.3.1"
+pgx-tests = "0.3.2"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,13 +16,13 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.3.1"
-pgx-macros = "0.3.1"
-pgx-utils = "0.3.1"
+pgx = "0.3.2"
+pgx-macros = "0.3.2"
+pgx-utils = "0.3.2"
 
 
 [dev-dependencies]
-pgx-tests = "0.3.1"
+pgx-tests = "0.3.2"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -18,7 +18,7 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "0.3.1" }
+pgx-utils = { path = "../pgx-utils", version = "0.3.2" }
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
 syn = { version = "1.0.86", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -29,14 +29,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.5"
 once_cell = "1.9.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.3.1" }
+pgx-macros = { path = "../pgx-macros/", version = "0.3.2" }
 
 [build-dependencies]
 bindgen = "0.59.2"
 build-deps = "0.1.4"
 colored = "2.0.0"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils/", version = "0.3.1" }
+pgx-utils = { path = "../pgx-utils/", version = "0.3.2" }
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
 rayon = "1.5.1"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -30,9 +30,9 @@ no-default-features = true
 colored = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2.117"
-pgx = { path = "../pgx", default-features = false, version= "0.3.1" }
-pgx-macros = { path = "../pgx-macros", version= "0.3.1" }
-pgx-utils = { path = "../pgx-utils", version= "0.3.1" }
+pgx = { path = "../pgx", default-features = false, version= "0.3.2" }
+pgx-macros = { path = "../pgx-macros", version= "0.3.2" }
+pgx-utils = { path = "../pgx-utils", version= "0.3.2" }
 postgres = "0.19.2"
 regex = "1.5.4"
 serde = "1.0.136"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -34,9 +34,9 @@ cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.14"
 seahash = "4.1.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.3.1" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.3.1" }
-pgx-utils = { path = "../pgx-utils/", version = "0.3.1" }
+pgx-macros = { path = "../pgx-macros/", version = "0.3.2" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.3.2" }
+pgx-utils = { path = "../pgx-utils/", version = "0.3.2" }
 serde = { version = "1.0.136", features = [ "derive" ] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.78"


### PR DESCRIPTION
Release 0.3.2, a bugfix release.

Release notes:

---

# v0.3.2

## Upgrading

Please make sure to run `cargo install cargo-pgx` and update all the `pgx` extension `Cargo.toml`'s `pgx*` versions to `0.3.2`.

## What's Changed

* **Fix:** Resolved an issue in `#[pg_extern(..)]` functions with attributes that also returned tuples. A change in #410 caused incorrect macro expansion. (#440)
