### PR TITLE
Fix `@FUNCTION_NAME@` not being handled in sql attributes

### DIFF
--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -21,7 +21,7 @@ mod log_tests;
 mod memcxt_tests;
 mod name_tests;
 mod numeric_tests;
-mod pg_extern_args_tests;
+mod pg_extern_tests;
 mod pg_try_tests;
 mod pgbox_tests;
 mod postgres_type_tests;

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -30,4 +30,25 @@ mod tests {
         .expect("failed to get SPI result");
         assert!(result)
     }
+
+    
+    // Ensures `@FUNCTION_NAME@` is handled.
+    #[pg_extern(sql = r#"
+        CREATE OR REPLACE FUNCTION tests."test_overriden_sql_with_fn_name"() RETURNS void
+        STRICT
+        LANGUAGE c /* Rust */
+        AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
+    "#)]
+    fn overriden_sql_with_fn_name() -> bool {
+        true
+    }
+
+    #[pg_test]
+    fn test_overriden_sql_with_fn_name() {
+        let result = Spi::get_one::<bool>(
+            "SELECT tests.overriden_sql_with_fn_name()",
+        )
+        .expect("failed to get SPI result");
+        assert!(result)
+    }
 }

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -34,7 +34,7 @@ mod tests {
     
     // Ensures `@FUNCTION_NAME@` is handled.
     #[pg_extern(sql = r#"
-        CREATE OR REPLACE FUNCTION tests."test_overridden_sql_with_fn_name"() RETURNS void
+        CREATE OR REPLACE FUNCTION tests."overridden_sql_with_fn_name"() RETURNS void
         STRICT
         LANGUAGE c /* Rust */
         AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
@@ -46,7 +46,7 @@ mod tests {
     #[pg_test]
     fn test_overridden_sql_with_fn_name() {
         let result = Spi::get_one::<bool>(
-            "SELECT tests.overridden_sql_with_fn_name()",
+            r#"SELECT tests."overridden_sql_with_fn_name"()"#,
         )
         .expect("failed to get SPI result");
         assert!(result)

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -34,19 +34,19 @@ mod tests {
     
     // Ensures `@FUNCTION_NAME@` is handled.
     #[pg_extern(sql = r#"
-        CREATE OR REPLACE FUNCTION tests."test_overriden_sql_with_fn_name"() RETURNS void
+        CREATE OR REPLACE FUNCTION tests."test_overridden_sql_with_fn_name"() RETURNS void
         STRICT
         LANGUAGE c /* Rust */
         AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
     "#)]
-    fn overriden_sql_with_fn_name() -> bool {
+    fn overridden_sql_with_fn_name() -> bool {
         true
     }
 
     #[pg_test]
-    fn test_overriden_sql_with_fn_name() {
+    fn test_overridden_sql_with_fn_name() {
         let result = Spi::get_one::<bool>(
-            "SELECT tests.overriden_sql_with_fn_name()",
+            "SELECT tests.overridden_sql_with_fn_name()",
         )
         .expect("failed to get SPI result");
         assert!(result)

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -205,6 +205,18 @@ impl PgExtern {
         }
 
         let func = syn::parse2::<syn::ItemFn>(item)?;
+        
+        if let Some(ref mut to_sql_config) = to_sql_config {
+            if let Some(ref mut content) = to_sql_config.content {
+                let value = content.value();
+                let updated_value = value.replace(
+                    "@FUNCTION_NAME@",
+                    &*(func.sig.ident.to_string() + "_wrapper"),
+                ) + "\n";
+                *content = syn::LitStr::new(&updated_value, Span::call_site());
+            }
+        }
+
         Ok(Self {
             attrs,
             func,


### PR DESCRIPTION
In #410 we didn't handle `@FUNCTION_NAME@` appropriately, this replicates the functionality in the old `pgxsql` feature.