### PR TITLE
Prepare 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "pgx-utils",
  "proc-macro-crate",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-parent"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cargo-pgx",
  "pgx",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "colored",
  "eyre",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap 3.1.0",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-parent"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -52,8 +52,8 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-cargo-pgx = { path = "cargo-pgx", version = "0.3.2" }
-pgx = { path = "pgx", version = "0.3.2", default-features = false }
-pgx-macros = { path = "pgx-macros", version = "0.3.2" }
-pgx-pg-sys = { path = "pgx-pg-sys", version = "0.3.2", default-features = false }
-pgx-tests = { path = "pgx-tests", version = "0.3.2", default-features = false }
+cargo-pgx = { path = "cargo-pgx", version = "0.3.3" }
+pgx = { path = "pgx", version = "0.3.3", default-features = false }
+pgx-macros = { path = "pgx-macros", version = "0.3.3" }
+pgx-pg-sys = { path = "pgx-pg-sys", version = "0.3.3", default-features = false }
+pgx-tests = { path = "pgx-tests", version = "0.3.3", default-features = false }

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -22,7 +22,7 @@ semver = "1.0.5"
 colored = "2.0.0"
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils", version = "0.3.2" }
+pgx-utils = { path = "../pgx-utils", version = "0.3.3" }
 proc-macro2 = { version = "1.0.36", features = [ "span-locations" ] }
 quote = "1.0.15"
 rayon = "1.5.1"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.3.2"
-pgx-macros = "0.3.2"
+pgx = "0.3.3"
+pgx-macros = "0.3.3"
 
 [dev-dependencies]
-pgx-tests = "0.3.2"
+pgx-tests = "0.3.3"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,13 +16,13 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.3.2"
-pgx-macros = "0.3.2"
-pgx-utils = "0.3.2"
+pgx = "0.3.3"
+pgx-macros = "0.3.3"
+pgx-utils = "0.3.3"
 
 
 [dev-dependencies]
-pgx-tests = "0.3.2"
+pgx-tests = "0.3.3"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -18,7 +18,7 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "0.3.2" }
+pgx-utils = { path = "../pgx-utils", version = "0.3.3" }
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
 syn = { version = "1.0.86", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -29,14 +29,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.5"
 once_cell = "1.9.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.3.2" }
+pgx-macros = { path = "../pgx-macros/", version = "0.3.3" }
 
 [build-dependencies]
 bindgen = "0.59.2"
 build-deps = "0.1.4"
 colored = "2.0.0"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils/", version = "0.3.2" }
+pgx-utils = { path = "../pgx-utils/", version = "0.3.3" }
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
 rayon = "1.5.1"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -30,9 +30,9 @@ no-default-features = true
 colored = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2.117"
-pgx = { path = "../pgx", default-features = false, version= "0.3.2" }
-pgx-macros = { path = "../pgx-macros", version= "0.3.2" }
-pgx-utils = { path = "../pgx-utils", version= "0.3.2" }
+pgx = { path = "../pgx", default-features = false, version= "0.3.3" }
+pgx-macros = { path = "../pgx-macros", version= "0.3.3" }
+pgx-utils = { path = "../pgx-utils", version= "0.3.3" }
 postgres = "0.19.2"
 regex = "1.5.4"
 serde = "1.0.136"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -34,9 +34,9 @@ cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.14"
 seahash = "4.1.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.3.2" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.3.2" }
-pgx-utils = { path = "../pgx-utils/", version = "0.3.2" }
+pgx-macros = { path = "../pgx-macros/", version = "0.3.3" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.3.3" }
+pgx-utils = { path = "../pgx-utils/", version = "0.3.3" }
 serde = { version = "1.0.136", features = [ "derive" ] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.78"


### PR DESCRIPTION
Release 0.3.3, a bugfix release.

Release notes:

---

# v0.3.3

## Upgrading

Please make sure to run `cargo install cargo-pgx` and update all the `pgx` extension `Cargo.toml`'s `pgx*` versions to `0.3.3`.

## What's Changed

* We resolved the use of a deprecated item in Clap. (https://github.com/zombodb/pgx/pull/444)
* **Fix:** The `@FUNCTION_NAME@` string fragments inside `#[pg_extern(sql = "...@FUNCTION_NAME@...")]` (from #410) would not get replaced by the generated wrapper name, as they used to in `pgxsql` doc comments. (https://github.com/zombodb/pgx/pull/443)
