### PR TITLE
Respect sandbox boundaries in pgx-examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,7 +2631,6 @@ name = "triggers"
 version = "0.0.0"
 dependencies = [
  "pgx",
- "pgx-macros",
  "pgx-tests",
 ]
 

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 serde = "1.0.136"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/arrays/Cargo.toml
+++ b/pgx-examples/arrays/Cargo.toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 serde = "1.0.136"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/bad_ideas/Cargo.toml
+++ b/pgx-examples/bad_ideas/Cargo.toml
@@ -16,12 +16,12 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 rand = "0.8.5"
 rttp_client = "0.1.0"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/bgworker/Cargo.toml
+++ b/pgx-examples/bgworker/Cargo.toml
@@ -16,12 +16,12 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 rand = "0.8.5"
 rttp_client = "0.1.0"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/bytea/Cargo.toml
+++ b/pgx-examples/bytea/Cargo.toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 libflate = "1.1.2"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/custom_sql/Cargo.toml
+++ b/pgx-examples/custom_sql/Cargo.toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 serde = "1.0.136"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/custom_types/Cargo.toml
+++ b/pgx-examples/custom_types/Cargo.toml
@@ -16,12 +16,12 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 maplit = "1.0.2"
 serde = "1.0.136"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/errors/Cargo.toml
+++ b/pgx-examples/errors/Cargo.toml
@@ -16,10 +16,10 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/nostd/Cargo.toml
+++ b/pgx-examples/nostd/Cargo.toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 serde = "1.0.136"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/operators/Cargo.toml
+++ b/pgx-examples/operators/Cargo.toml
@@ -16,12 +16,12 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 maplit = "1.0.2"
 serde = "1.0.136"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/schemas/Cargo.toml
+++ b/pgx-examples/schemas/Cargo.toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 serde = "1.0.136"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/shmem/Cargo.toml
+++ b/pgx-examples/shmem/Cargo.toml
@@ -17,11 +17,11 @@ pg_test = []
 
 [dependencies]
 heapless = "0.7.10"
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 serde = { version = "1.0.136", features = [ "derive" ] }
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/spi/Cargo.toml
+++ b/pgx-examples/spi/Cargo.toml
@@ -16,10 +16,10 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/srf/Cargo.toml
+++ b/pgx-examples/srf/Cargo.toml
@@ -16,11 +16,11 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx", default-features = false }
 rand = "0.8.5"
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/strings/Cargo.toml
+++ b/pgx-examples/strings/Cargo.toml
@@ -16,10 +16,10 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
+pgx = { path = "../../pgx/", default-features = false }
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]

--- a/pgx-examples/triggers/Cargo.toml
+++ b/pgx-examples/triggers/Cargo.toml
@@ -16,11 +16,10 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = { path = "../../../pgx/pgx/", default-features = false }
-pgx-macros = { path = "../../../pgx/pgx-macros" }
+pgx = { path = "../../pgx/", default-features = false }
 
 [dev-dependencies]
-pgx-tests = { path = "../../../pgx/pgx-tests" }
+pgx-tests = { path = "../../pgx-tests" }
 
 # uncomment these if compiling outside of 'pgx'
 #[profile.dev]


### PR DESCRIPTION
After #461 I was testing https://github.com/zombodb/plrust and noticed this:

```
cargo-pgx-deps> [naersk] cargo_build_output_json (created): /build/tmp.3AkWFzqdBS
cargo-pgx-deps> [naersk] crate_sources: /nix/store/0fdvbq0jrl852dwpwldjfkcd6wzbk8d7-crates-io
cargo-pgx-deps> [naersk] RUSTFLAGS:
cargo-pgx-deps> [naersk] CARGO_BUILD_RUSTFLAGS:
cargo-pgx-deps> [naersk] CARGO_BUILD_RUSTFLAGS (updated): --remap-path-prefix /nix/store/0fdvbq0jrl852dwpwldjfkcd6wzbk8d7-crates-io=/sources
cargo-pgx-deps> building
cargo-pgx-deps> cargo build $cargo_release -j "$NIX_BUILD_CORES" --message-format=$cargo_message_format --package cargo-pgx
cargo-pgx-deps> error: failed to load manifest for workspace member `/build/dummy-src/pgx-examples/aggregate`
cargo-pgx-deps> Caused by:
cargo-pgx-deps>   failed to load manifest for dependency `pgx`
cargo-pgx-deps> Caused by:
cargo-pgx-deps>   failed to read `/build/pgx/pgx/Cargo.toml`
cargo-pgx-deps> Caused by:
cargo-pgx-deps>   No such file or directory (os error 2)
cargo-pgx-deps> [naersk] cargo returned with exit code 101, exiting
note: keeping build directory '/tmp/nix-build-cargo-pgx-deps-0.4.0-beta.0.drv-0'
error: builder for '/nix/store/q1qzc47d0kqxzc376aichykyc1xypy0i-cargo-pgx-deps-0.4.0-beta.0.drv' failed with exit code 101
error: 1 dependencies of derivation '/nix/store/l3v60hd25b3cjqsivg5ybn00cpwnjfcg-cargo-pgx-0.4.0-beta.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/klkjkp9cz216s7n9vl9ifscdkz7324jm-plrust-pg11-0.0.0.drv' failed to build
```

This was due to the `pgx-examples` stepping outside the sandbox (then back in):

https://github.com/zombodb/pgx/blob/9f2164fe248d59edd7782b27f9ad6afc28b7c418/pgx-examples/custom_types/Cargo.toml#L19