### PR TITLE
Add appendinfo.h and regenerate bindings

### DIFF
--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -51,6 +51,7 @@
 #include "nodes/supportnodes.h"
 #include "nodes/tidbitmap.h"
 #include "nodes/value.h"
+#include "optimizer/appendinfo.h"
 #include "optimizer/clauses.h"
 #include "optimizer/cost.h"
 #include "optimizer/optimizer.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -51,6 +51,7 @@
 #include "nodes/supportnodes.h"
 #include "nodes/tidbitmap.h"
 #include "nodes/value.h"
+#include "optimizer/appendinfo.h"
 #include "optimizer/clauses.h"
 #include "optimizer/cost.h"
 #include "optimizer/optimizer.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -51,6 +51,7 @@
 #include "nodes/supportnodes.h"
 #include "nodes/tidbitmap.h"
 #include "nodes/value.h"
+#include "optimizer/appendinfo.h"
 #include "optimizer/clauses.h"
 #include "optimizer/cost.h"
 #include "optimizer/optimizer.h"

--- a/pgx-pg-sys/src/pg10.rs
+++ b/pgx-pg-sys/src/pg10.rs
@@ -323,15 +323,15 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 26usize] = b"pgsql-bugs@postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 10.19\0";
+pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 10.20\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1usize] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 6usize] = b"10.19\0";
+pub const PACKAGE_VERSION: &[u8; 6usize] = b"10.20\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"10\0";
-pub const PG_VERSION: &[u8; 6usize] = b"10.19\0";
-pub const PG_VERSION_NUM: u32 = 100019;
-pub const PG_VERSION_STR : & [u8 ; 97usize] = b"PostgreSQL 10.19 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 6usize] = b"10.20\0";
+pub const PG_VERSION_NUM: u32 = 100020;
+pub const PG_VERSION_STR : & [u8 ; 102usize] = b"PostgreSQL 10.20 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_LONG: u32 = 8;
 pub const SIZEOF_OFF_T: u32 = 8;
@@ -383,10 +383,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -398,26 +394,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -444,6 +442,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -460,18 +471,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -499,6 +498,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -978,9 +978,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1039,7 +1036,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1075,7 +1071,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1174,13 +1169,12 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 10.19\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 10.20\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1470,7 +1464,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1835,6 +1832,7 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -1846,34 +1844,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -1885,7 +1882,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -2844,7 +2841,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3023,15 +3019,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3043,6 +3035,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3205,10 +3201,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3486,6 +3478,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3494,14 +3494,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3528,6 +3528,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -3854,13 +3862,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4211,15 +4212,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4239,10 +4240,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5409,7 +5407,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5649,10 +5646,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -12845,6 +12840,7 @@ pub struct IndexOnlyScan {
     pub indexorderby: *mut List,
     pub indextlist: *mut List,
     pub indexorderdir: ScanDirection,
+    pub recheckqual: *mut List,
 }
 impl Default for IndexOnlyScan {
     fn default() -> Self {
@@ -15105,7 +15101,7 @@ impl Default for IndexScanState {
 #[derive(Debug, Copy, Clone)]
 pub struct IndexOnlyScanState {
     pub ss: ScanState,
-    pub indexqual: *mut ExprState,
+    pub recheckqual: *mut ExprState,
     pub ioss_ScanKeys: ScanKey,
     pub ioss_NumScanKeys: ::std::os::raw::c_int,
     pub ioss_OrderByKeys: ScanKey,
@@ -23637,8 +23633,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -23879,6 +23873,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -39514,6 +39516,48 @@ extern "C" {
 extern "C" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufFile {
+    _unused: [u8; 0],
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileClose(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileWrite(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize)
+        -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeek(
+        file: *mut BufFile,
+        fileno: ::std::os::raw::c_int,
+        offset: off_t,
+        whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileTell(file: *mut BufFile, fileno: *mut ::std::os::raw::c_int, offset: *mut off_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeekBlock(
+        file: *mut BufFile,
+        blknum: ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
 pub type pg_on_exit_callback =
     ::std::option::Option<unsafe extern "C" fn(code: ::std::os::raw::c_int, arg: Datum)>;
 pub type shmem_startup_hook_type = ::std::option::Option<unsafe extern "C" fn()>;
@@ -51915,6 +51959,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn xidComparator(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn xidLogicalComparator(
         arg1: *const ::std::os::raw::c_void,
         arg2: *const ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -319,15 +319,15 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 26usize] = b"pgsql-bugs@postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 11.14\0";
+pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 11.15\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1usize] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 6usize] = b"11.14\0";
+pub const PACKAGE_VERSION: &[u8; 6usize] = b"11.15\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"11\0";
-pub const PG_VERSION: &[u8; 6usize] = b"11.14\0";
-pub const PG_VERSION_NUM: u32 = 110014;
-pub const PG_VERSION_STR : & [u8 ; 97usize] = b"PostgreSQL 11.14 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 6usize] = b"11.15\0";
+pub const PG_VERSION_NUM: u32 = 110015;
+pub const PG_VERSION_STR : & [u8 ; 102usize] = b"PostgreSQL 11.15 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -380,10 +380,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -395,26 +391,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -441,6 +439,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -457,18 +468,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -496,6 +495,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -977,9 +977,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1038,7 +1035,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1074,7 +1070,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1173,7 +1168,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 11.14\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 11.15\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
@@ -1204,7 +1199,6 @@ pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1505,7 +1499,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1754,6 +1751,7 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -1765,34 +1763,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -1804,7 +1801,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -3006,7 +3003,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3185,15 +3181,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3205,6 +3197,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3367,10 +3363,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3648,6 +3640,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3656,14 +3656,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3690,6 +3690,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -4016,13 +4024,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4373,15 +4374,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4401,10 +4402,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5579,7 +5577,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5819,10 +5816,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -14737,6 +14732,7 @@ pub struct IndexOnlyScan {
     pub indexorderby: *mut List,
     pub indextlist: *mut List,
     pub indexorderdir: ScanDirection,
+    pub recheckqual: *mut List,
 }
 impl Default for IndexOnlyScan {
     fn default() -> Self {
@@ -17916,7 +17912,7 @@ impl Default for IndexScanState {
 #[derive(Debug, Copy, Clone)]
 pub struct IndexOnlyScanState {
     pub ss: ScanState,
-    pub indexqual: *mut ExprState,
+    pub recheckqual: *mut ExprState,
     pub ioss_ScanKeys: ScanKey,
     pub ioss_NumScanKeys: ::std::os::raw::c_int,
     pub ioss_OrderByKeys: ScanKey,
@@ -25320,8 +25316,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -25562,6 +25556,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -42865,6 +42867,78 @@ extern "C" {
 extern "C" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufFile {
+    _unused: [u8; 0],
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileClose(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileWrite(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize)
+        -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeek(
+        file: *mut BufFile,
+        fileno: ::std::os::raw::c_int,
+        offset: off_t,
+        whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileTell(file: *mut BufFile, fileno: *mut ::std::os::raw::c_int, offset: *mut off_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeekBlock(
+        file: *mut BufFile,
+        blknum: ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSize(file: *mut BufFile) -> int64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileAppend(target: *mut BufFile, source: *mut BufFile) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateShared(
+        fileset: *mut SharedFileSet,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileExportShared(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileOpenShared(
+        fileset: *mut SharedFileSet,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileDeleteShared(fileset: *mut SharedFileSet, name: *const ::std::os::raw::c_char);
+}
 pub type pg_on_exit_callback =
     ::std::option::Option<unsafe extern "C" fn(code: ::std::os::raw::c_int, arg: Datum)>;
 pub type shmem_startup_hook_type = ::std::option::Option<unsafe extern "C" fn()>;
@@ -55354,6 +55428,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn xidComparator(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn xidLogicalComparator(
         arg1: *const ::std::os::raw::c_void,
         arg2: *const ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -41233,6 +41233,58 @@ impl Default for SupportRequestIndexCondition {
         }
     }
 }
+#[pg_guard]
+extern "C" {
+    pub fn make_append_rel_info(
+        parentrel: Relation,
+        childrel: Relation,
+        parentRTindex: Index,
+        childRTindex: Index,
+    ) -> *mut AppendRelInfo;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_appendrel_attrs(
+        root: *mut PlannerInfo,
+        node: *mut Node,
+        nappinfos: ::std::os::raw::c_int,
+        appinfos: *mut *mut AppendRelInfo,
+    ) -> *mut Node;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_appendrel_attrs_multilevel(
+        root: *mut PlannerInfo,
+        node: *mut Node,
+        child_relids: Relids,
+        top_parent_relids: Relids,
+    ) -> *mut Node;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_child_relids(
+        relids: Relids,
+        nappinfos: ::std::os::raw::c_int,
+        appinfos: *mut *mut AppendRelInfo,
+    ) -> Relids;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_child_relids_multilevel(
+        root: *mut PlannerInfo,
+        relids: Relids,
+        child_relids: Relids,
+        top_parent_relids: Relids,
+    ) -> Relids;
+}
+#[pg_guard]
+extern "C" {
+    pub fn find_appinfos_by_relids(
+        root: *mut PlannerInfo,
+        relids: Relids,
+        nappinfos: *mut ::std::os::raw::c_int,
+    ) -> *mut *mut AppendRelInfo;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct WindowFuncLists {

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -325,15 +325,15 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 12.9\0";
+pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 12.10\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1usize] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 5usize] = b"12.9\0";
+pub const PACKAGE_VERSION: &[u8; 6usize] = b"12.10\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"12\0";
-pub const PG_VERSION: &[u8; 5usize] = b"12.9\0";
-pub const PG_VERSION_NUM: u32 = 120009;
-pub const PG_VERSION_STR : & [u8 ; 96usize] = b"PostgreSQL 12.9 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 6usize] = b"12.10\0";
+pub const PG_VERSION_NUM: u32 = 120010;
+pub const PG_VERSION_STR : & [u8 ; 102usize] = b"PostgreSQL 12.10 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -386,10 +386,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -401,26 +397,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -447,6 +445,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -463,18 +474,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -502,6 +501,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -983,9 +983,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1044,7 +1041,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1080,7 +1076,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1179,7 +1174,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 12.9\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 12.10\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1212,7 +1207,6 @@ pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1375,7 +1369,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1791,6 +1788,7 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -1802,34 +1800,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -1841,7 +1838,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -3060,7 +3057,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3239,15 +3235,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3259,6 +3251,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3421,10 +3417,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3702,6 +3694,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3710,14 +3710,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3744,6 +3744,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -4070,13 +4078,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4427,15 +4428,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4455,10 +4456,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5633,7 +5631,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5873,10 +5870,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -14230,6 +14225,7 @@ pub struct IndexOnlyScan {
     pub indexorderby: *mut List,
     pub indextlist: *mut List,
     pub indexorderdir: ScanDirection,
+    pub recheckqual: *mut List,
 }
 impl Default for IndexOnlyScan {
     fn default() -> Self {
@@ -17900,7 +17896,7 @@ impl Default for IndexScanState {
 #[derive(Debug, Copy, Clone)]
 pub struct IndexOnlyScanState {
     pub ss: ScanState,
-    pub indexqual: *mut ExprState,
+    pub recheckqual: *mut ExprState,
     pub ioss_ScanKeys: *mut ScanKeyData,
     pub ioss_NumScanKeys: ::std::os::raw::c_int,
     pub ioss_OrderByKeys: *mut ScanKeyData,
@@ -23833,8 +23829,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -24075,6 +24069,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -45051,6 +45053,78 @@ extern "C" {
 extern "C" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufFile {
+    _unused: [u8; 0],
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileClose(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileWrite(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize)
+        -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeek(
+        file: *mut BufFile,
+        fileno: ::std::os::raw::c_int,
+        offset: off_t,
+        whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileTell(file: *mut BufFile, fileno: *mut ::std::os::raw::c_int, offset: *mut off_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeekBlock(
+        file: *mut BufFile,
+        blknum: ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSize(file: *mut BufFile) -> int64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileAppend(target: *mut BufFile, source: *mut BufFile) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateShared(
+        fileset: *mut SharedFileSet,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileExportShared(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileOpenShared(
+        fileset: *mut SharedFileSet,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileDeleteShared(fileset: *mut SharedFileSet, name: *const ::std::os::raw::c_char);
+}
 pub type pg_on_exit_callback =
     ::std::option::Option<unsafe extern "C" fn(code: ::std::os::raw::c_int, arg: Datum)>;
 pub type shmem_startup_hook_type = ::std::option::Option<unsafe extern "C" fn()>;
@@ -56901,6 +56975,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn xidComparator(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn xidLogicalComparator(
         arg1: *const ::std::os::raw::c_void,
         arg2: *const ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -178,7 +178,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 102usize] = b" '--prefix=/home/ana/.pgx/13.5/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 104usize] = b" '--prefix=/home/einar/.pgx/13.6/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -317,18 +317,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 13.5\0";
+pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 13.6\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28usize] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5usize] = b"13.5\0";
+pub const PACKAGE_VERSION: &[u8; 5usize] = b"13.6\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"13\0";
 pub const PG_MAJORVERSION_NUM: u32 = 13;
-pub const PG_MINORVERSION_NUM: u32 = 5;
+pub const PG_MINORVERSION_NUM: u32 = 6;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5usize] = b"13.5\0";
-pub const PG_VERSION_NUM: u32 = 130005;
-pub const PG_VERSION_STR : & [u8 ; 96usize] = b"PostgreSQL 13.5 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 5usize] = b"13.6\0";
+pub const PG_VERSION_NUM: u32 = 130006;
+pub const PG_VERSION_STR : & [u8 ; 101usize] = b"PostgreSQL 13.6 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -380,10 +380,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -395,26 +391,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -441,6 +439,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -457,18 +468,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -496,6 +495,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -977,9 +977,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1038,7 +1035,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1074,7 +1070,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1173,7 +1168,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 13.5\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 13.6\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1206,7 +1201,6 @@ pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1354,7 +1348,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -2017,6 +2014,7 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -2028,34 +2026,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -2067,7 +2064,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -2208,6 +2205,7 @@ pub const PROC_VACUUM_FOR_WRAPAROUND: u32 = 8;
 pub const PROC_IN_LOGICAL_DECODING: u32 = 16;
 pub const PROC_RESERVED: u32 = 32;
 pub const PROC_VACUUM_STATE_MASK: u32 = 14;
+pub const PROC_COPYABLE_FLAGS: u32 = 2;
 pub const FP_LOCK_SLOTS_PER_BACKEND: u32 = 16;
 pub const INVALID_PGPROCNO: u32 = 2147483647;
 pub const NUM_AUXILIARY_PROCS: u32 = 4;
@@ -3059,7 +3057,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3238,15 +3235,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3258,6 +3251,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3420,10 +3417,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3701,6 +3694,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3709,14 +3710,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3743,6 +3744,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -4069,13 +4078,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4426,15 +4428,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4454,10 +4456,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5632,7 +5631,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5872,10 +5870,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -14458,6 +14454,7 @@ pub struct IndexOnlyScan {
     pub indexorderby: *mut List,
     pub indextlist: *mut List,
     pub indexorderdir: ScanDirection,
+    pub recheckqual: *mut List,
 }
 impl Default for IndexOnlyScan {
     fn default() -> Self {
@@ -18225,7 +18222,7 @@ impl Default for IndexScanState {
 #[derive(Debug, Copy, Clone)]
 pub struct IndexOnlyScanState {
     pub ss: ScanState,
-    pub indexqual: *mut ExprState,
+    pub recheckqual: *mut ExprState,
     pub ioss_ScanKeys: *mut ScanKeyData,
     pub ioss_NumScanKeys: ::std::os::raw::c_int,
     pub ioss_OrderByKeys: *mut ScanKeyData,
@@ -24573,8 +24570,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -24815,6 +24810,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -46056,6 +46059,78 @@ extern "C" {
 extern "C" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufFile {
+    _unused: [u8; 0],
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileClose(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileWrite(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize)
+        -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeek(
+        file: *mut BufFile,
+        fileno: ::std::os::raw::c_int,
+        offset: off_t,
+        whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileTell(file: *mut BufFile, fileno: *mut ::std::os::raw::c_int, offset: *mut off_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeekBlock(
+        file: *mut BufFile,
+        blknum: ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSize(file: *mut BufFile) -> int64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileAppend(target: *mut BufFile, source: *mut BufFile) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateShared(
+        fileset: *mut SharedFileSet,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileExportShared(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileOpenShared(
+        fileset: *mut SharedFileSet,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileDeleteShared(fileset: *mut SharedFileSet, name: *const ::std::os::raw::c_char);
+}
 pub type pg_on_exit_callback =
     ::std::option::Option<unsafe extern "C" fn(code: ::std::os::raw::c_int, arg: Datum)>;
 pub type shmem_startup_hook_type = ::std::option::Option<unsafe extern "C" fn()>;
@@ -58234,6 +58309,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn xidComparator(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn xidLogicalComparator(
         arg1: *const ::std::os::raw::c_void,
         arg2: *const ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -42142,6 +42142,58 @@ impl Default for SupportRequestIndexCondition {
         }
     }
 }
+#[pg_guard]
+extern "C" {
+    pub fn make_append_rel_info(
+        parentrel: Relation,
+        childrel: Relation,
+        parentRTindex: Index,
+        childRTindex: Index,
+    ) -> *mut AppendRelInfo;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_appendrel_attrs(
+        root: *mut PlannerInfo,
+        node: *mut Node,
+        nappinfos: ::std::os::raw::c_int,
+        appinfos: *mut *mut AppendRelInfo,
+    ) -> *mut Node;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_appendrel_attrs_multilevel(
+        root: *mut PlannerInfo,
+        node: *mut Node,
+        child_relids: Relids,
+        top_parent_relids: Relids,
+    ) -> *mut Node;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_child_relids(
+        relids: Relids,
+        nappinfos: ::std::os::raw::c_int,
+        appinfos: *mut *mut AppendRelInfo,
+    ) -> Relids;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_child_relids_multilevel(
+        root: *mut PlannerInfo,
+        relids: Relids,
+        child_relids: Relids,
+        top_parent_relids: Relids,
+    ) -> Relids;
+}
+#[pg_guard]
+extern "C" {
+    pub fn find_appinfos_by_relids(
+        root: *mut PlannerInfo,
+        relids: Relids,
+        nappinfos: *mut ::std::os::raw::c_int,
+    ) -> *mut *mut AppendRelInfo;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct WindowFuncLists {

--- a/pgx-pg-sys/src/pg14.rs
+++ b/pgx-pg-sys/src/pg14.rs
@@ -178,7 +178,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 102usize] = b" '--prefix=/home/ana/.pgx/14.1/pgx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 104usize] = b" '--prefix=/home/einar/.pgx/14.2/pgx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28814;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28814\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -324,18 +324,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 14.1\0";
+pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 14.2\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28usize] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5usize] = b"14.1\0";
+pub const PACKAGE_VERSION: &[u8; 5usize] = b"14.2\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"14\0";
 pub const PG_MAJORVERSION_NUM: u32 = 14;
-pub const PG_MINORVERSION_NUM: u32 = 1;
+pub const PG_MINORVERSION_NUM: u32 = 2;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5usize] = b"14.1\0";
-pub const PG_VERSION_NUM: u32 = 140001;
-pub const PG_VERSION_STR : & [u8 ; 96usize] = b"PostgreSQL 14.1 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 5usize] = b"14.2\0";
+pub const PG_VERSION_NUM: u32 = 140002;
+pub const PG_VERSION_STR : & [u8 ; 101usize] = b"PostgreSQL 14.2 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -386,10 +386,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -401,26 +397,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -447,6 +445,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -463,18 +474,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -502,6 +501,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -981,9 +981,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1042,7 +1039,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1078,7 +1074,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1177,7 +1172,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 14.1\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 14.2\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1210,7 +1205,6 @@ pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1366,7 +1360,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -2053,6 +2050,7 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -2064,34 +2062,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -2103,7 +2100,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -2757,6 +2754,7 @@ pub const PROC_IN_SAFE_IC: u32 = 4;
 pub const PROC_VACUUM_FOR_WRAPAROUND: u32 = 8;
 pub const PROC_IN_LOGICAL_DECODING: u32 = 16;
 pub const PROC_VACUUM_STATE_MASK: u32 = 14;
+pub const PROC_COPYABLE_FLAGS: u32 = 6;
 pub const FP_LOCK_SLOTS_PER_BACKEND: u32 = 16;
 pub const INVALID_PGPROCNO: u32 = 2147483647;
 pub const NUM_AUXILIARY_PROCS: u32 = 5;
@@ -3126,7 +3124,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3305,15 +3302,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3325,6 +3318,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3487,10 +3484,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3768,6 +3761,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3776,14 +3777,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3810,6 +3811,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -4136,13 +4145,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4493,15 +4495,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4521,10 +4523,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5695,7 +5694,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5935,10 +5933,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -14730,6 +14726,7 @@ pub struct IndexOnlyScan {
     pub indexorderby: *mut List,
     pub indextlist: *mut List,
     pub indexorderdir: ScanDirection,
+    pub recheckqual: *mut List,
 }
 impl Default for IndexOnlyScan {
     fn default() -> Self {
@@ -15063,7 +15060,9 @@ pub struct Memoize {
     pub collations: *mut Oid,
     pub param_exprs: *mut List,
     pub singlerow: bool,
+    pub binary_mode: bool,
     pub est_entries: uint32,
+    pub keyparamids: *mut Bitmapset,
 }
 impl Default for Memoize {
     fn default() -> Self {
@@ -18622,7 +18621,7 @@ impl Default for IndexScanState {
 #[derive(Debug, Copy, Clone)]
 pub struct IndexOnlyScanState {
     pub ss: ScanState,
-    pub indexqual: *mut ExprState,
+    pub recheckqual: *mut ExprState,
     pub ioss_ScanKeys: *mut ScanKeyData,
     pub ioss_NumScanKeys: ::std::os::raw::c_int,
     pub ioss_OrderByKeys: *mut ScanKeyData,
@@ -19126,8 +19125,10 @@ pub struct MemoizeState {
     pub last_tuple: *mut MemoizeTuple,
     pub entry: *mut MemoizeEntry,
     pub singlerow: bool,
+    pub binary_mode: bool,
     pub stats: MemoizeInstrumentation,
     pub shared_info: *mut SharedMemoizeInfo,
+    pub keyparamids: *mut Bitmapset,
 }
 impl Default for MemoizeState {
     fn default() -> Self {
@@ -25218,8 +25219,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -25460,6 +25459,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -40404,6 +40411,7 @@ pub struct MemoizePath {
     pub hash_operators: *mut List,
     pub param_exprs: *mut List,
     pub singlerow: bool,
+    pub binary_mode: bool,
     pub calls: f64,
     pub est_entries: uint32,
 }
@@ -43076,6 +43084,102 @@ impl Default for SupportRequestIndexCondition {
         }
     }
 }
+#[pg_guard]
+extern "C" {
+    pub fn make_append_rel_info(
+        parentrel: Relation,
+        childrel: Relation,
+        parentRTindex: Index,
+        childRTindex: Index,
+    ) -> *mut AppendRelInfo;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_appendrel_attrs(
+        root: *mut PlannerInfo,
+        node: *mut Node,
+        nappinfos: ::std::os::raw::c_int,
+        appinfos: *mut *mut AppendRelInfo,
+    ) -> *mut Node;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_appendrel_attrs_multilevel(
+        root: *mut PlannerInfo,
+        node: *mut Node,
+        child_relids: Relids,
+        top_parent_relids: Relids,
+    ) -> *mut Node;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_child_relids(
+        relids: Relids,
+        nappinfos: ::std::os::raw::c_int,
+        appinfos: *mut *mut AppendRelInfo,
+    ) -> Relids;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_child_relids_multilevel(
+        root: *mut PlannerInfo,
+        relids: Relids,
+        child_relids: Relids,
+        top_parent_relids: Relids,
+    ) -> Relids;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_inherited_attnums(attnums: *mut List, context: *mut AppendRelInfo) -> *mut List;
+}
+#[pg_guard]
+extern "C" {
+    pub fn adjust_inherited_attnums_multilevel(
+        root: *mut PlannerInfo,
+        attnums: *mut List,
+        child_relid: Index,
+        top_parent_relid: Index,
+    ) -> *mut List;
+}
+#[pg_guard]
+extern "C" {
+    pub fn get_translated_update_targetlist(
+        root: *mut PlannerInfo,
+        relid: Index,
+        processed_tlist: *mut *mut List,
+        update_colnos: *mut *mut List,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn find_appinfos_by_relids(
+        root: *mut PlannerInfo,
+        relids: Relids,
+        nappinfos: *mut ::std::os::raw::c_int,
+    ) -> *mut *mut AppendRelInfo;
+}
+#[pg_guard]
+extern "C" {
+    pub fn add_row_identity_var(
+        root: *mut PlannerInfo,
+        rowid_var: *mut Var,
+        rtindex: Index,
+        rowid_name: *const ::std::os::raw::c_char,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn add_row_identity_columns(
+        root: *mut PlannerInfo,
+        rtindex: Index,
+        target_rte: *mut RangeTblEntry,
+        target_relation: Relation,
+    );
+}
+#[pg_guard]
+extern "C" {
+    pub fn distribute_row_identity_vars(root: *mut PlannerInfo);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct WindowFuncLists {
@@ -43170,6 +43274,10 @@ extern "C" {
         root: *mut PlannerInfo,
         rte: *mut RangeTblEntry,
     ) -> *mut Query;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pull_paramids(expr: *mut Expr) -> *mut Bitmapset;
 }
 pub const ConstraintExclusionType_CONSTRAINT_EXCLUSION_OFF: ConstraintExclusionType = 0;
 pub const ConstraintExclusionType_CONSTRAINT_EXCLUSION_ON: ConstraintExclusionType = 1;
@@ -44159,6 +44267,7 @@ extern "C" {
         param_exprs: *mut List,
         hash_operators: *mut List,
         singlerow: bool,
+        binary_mode: bool,
         calls: f64,
     ) -> *mut MemoizePath;
 }
@@ -47283,6 +47392,82 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufFile {
+    _unused: [u8; 0],
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileClose(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize) -> usize;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileWrite(file: *mut BufFile, ptr: *mut ::std::os::raw::c_void, size: usize);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeek(
+        file: *mut BufFile,
+        fileno: ::std::os::raw::c_int,
+        offset: off_t,
+        whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileTell(file: *mut BufFile, fileno: *mut ::std::os::raw::c_int, offset: *mut off_t);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSeekBlock(
+        file: *mut BufFile,
+        blknum: ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileSize(file: *mut BufFile) -> int64;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileAppend(target: *mut BufFile, source: *mut BufFile) -> ::std::os::raw::c_long;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileCreateShared(
+        fileset: *mut SharedFileSet,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileExportShared(file: *mut BufFile);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileOpenShared(
+        fileset: *mut SharedFileSet,
+        name: *const ::std::os::raw::c_char,
+        mode: ::std::os::raw::c_int,
+    ) -> *mut BufFile;
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileDeleteShared(fileset: *mut SharedFileSet, name: *const ::std::os::raw::c_char);
+}
+#[pg_guard]
+extern "C" {
+    pub fn BufFileTruncateShared(file: *mut BufFile, fileno: ::std::os::raw::c_int, offset: off_t);
 }
 pub type pg_on_exit_callback =
     ::std::option::Option<unsafe extern "C" fn(code: ::std::os::raw::c_int, arg: Datum)>;
@@ -60079,6 +60264,13 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn xidComparator(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub fn xidLogicalComparator(
         arg1: *const ::std::os::raw::c_void,
         arg2: *const ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;


### PR DESCRIPTION
Seems to have upgraded bindings to 12.10 from 12.9, among other things.

appendinfo.h contains a couple of methods used for foreign data wrappers. In particular `add_row_identity_var` is referenced from the official postgres documentation, and is nice to have here.

The file exists for pg12 and pg13 as well, but it's just the `add_row_identity_var` method first added in pg14 which seem generally useful here. I think only that method is needed for external applications in practice.