### PR TITLE
Improve Aggregate performance

### DIFF
--- a/pgx/src/aggregate.rs
+++ b/pgx/src/aggregate.rs
@@ -410,6 +410,7 @@ where
         fcinfo: FunctionCallInfo,
     ) -> Self::Finalize;
 
+    #[inline(always)]
     unsafe fn memory_context(fcinfo: FunctionCallInfo) -> Option<MemoryContext> {
         if fcinfo.is_null() {
             return Some(CurrentMemoryContext);
@@ -424,6 +425,7 @@ where
         }
     }
 
+    #[inline(always)]
     fn in_memory_context<
         R,
         F: FnOnce(&mut PgMemoryContexts) -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,


### PR DESCRIPTION
Thanks to a report from @jamessewell we dug into some aggregate performance issues.

This hints that memory context swap calls like these should always be inline, and should improve performance in many cases.


Using an example of

```rust
pub struct RustMaxInternal;

#[pg_aggregate]
impl Aggregate for RustMaxInternal {
    type Args = i32;
    type State = Internal;
    type Finalize = i32;
    #[inline(always)]
    fn state(
        mut current: Self::State,
        value: Self::Args,
        _fcinfo: pg_sys::FunctionCallInfo,
    ) -> Self::State {
        let inner = unsafe { current.get_or_insert_default::<i32>() };

        if *inner < value {
            *inner = value;
        };
        current
    }
    #[inline(always)]
    fn combine(
        mut first: Self::State,
        mut second: Self::State,
        _fcinfo: pg_sys::FunctionCallInfo,
    ) -> Self::State {
        let first_inner = unsafe { first.get_or_insert_default::<i32>() };
        let second_inner = unsafe { second.get_or_insert_default::<i32>() };


        if *first_inner < *second_inner {
            *first_inner = *second_inner;
        };
        first
    }
    #[inline(always)]
    fn finalize(
        mut current: Self::State,
        _direct_arg: Self::OrderedSetArgs,
        _fcinfo: pg_sys::FunctionCallInfo,
    ) -> Self::Finalize {
        let inner = unsafe { current.get_or_insert_default::<i32>() };
        *inner
    }
}
```

Before:

```bash
$ cargo pgx run pg14 -p pgx-tests --features pg_test --release
    Stopping Postgres v14
building extension with features `pg_test pg14`
"cargo" "build" "--package" "pgx-tests" "--release" "--features" "pg_test pg14" "--no-default-features" "--message-format=json-render-diagnostics"
   Compiling pgx-tests v0.4.0 (/home/ana/git/zombodb/pgx/pgx-tests)
    Finished release [optimized] target(s) in 11.81s

installing extension
     Copying control file to /home/ana/.pgx/14.2/pgx-install/share/postgresql/extension/pgx_tests.control
     Copying shared library to /home/ana/.pgx/14.2/pgx-install/lib/postgresql/pgx_tests.so
 Discovering SQL entities
  Discovered 332 SQL entities: 32 schemas (2 unique), 282 functions, 11 types, 1 enums, 2 sqls, 0 ords, 0 hashes, 4 aggregates
     Writing SQL entities to /home/ana/.pgx/14.2/pgx-install/share/postgresql/extension/pgx_tests--1.0.sql
    Finished installing pgx_tests
    Starting Postgres v14 on port 28814
    Re-using existing database pgx_tests
psql (14.2)
Type "help" for help.

pgx_tests=# DROP EXTENSION pgx_tests; CREATE EXTENSION pgx_tests;
DROP EXTENSION
CREATE EXTENSION
pgx_tests=# \timing
Timing is on.
pgx_tests=# SELECT RustMaxInternal(value) FROM generate_series(0, 400000) as value;
 rustmaxinternal 
-----------------
          400000
(1 row)

Time: 131.944 ms
pgx_tests=# 
```

After:

```bash
pgx_tests=# SELECT RustMaxInternal(value) FROM generate_series(0, 400000) as value;
 rustmaxinternal 
-----------------
          400000
(1 row)

Time: 128.002 ms
```

A single run isn't really meaningful, but we think this hinting may yield some perf improvements where the optimizer does actually need hinting. Further, it does make sense to inline these calls, since they always happen, have small bodies, and it's performance sensitive bits of the code.